### PR TITLE
chore: update repository references from sprizend-rh/in-cluster-check…

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -82,5 +82,5 @@ See [@.claude/rules/github-mcp.md](rules/github-mcp.md) for detailed GitHub MCP 
 
 ## Additional Resources
 
-- **Project Wiki**: https://github.com/sprizend-rh/in-cluster-checks/wiki - Detailed knowledge sharing about rules and documentation
+- **Project Wiki**: https://github.com/RedHatInsights/incluster-checks/wiki - Detailed knowledge sharing about rules and documentation
 - **Contributing Guide**: See [CONTRIBUTING.md](../CONTRIBUTING.md) for development setup and contribution guidelines

--- a/.claude/rules/github-mcp.md
+++ b/.claude/rules/github-mcp.md
@@ -45,7 +45,7 @@ This project uses the GitHub MCP (Model Context Protocol) plugin for GitHub oper
 
 ## Repository Information
 
-- **Main repository**: `sprizend-rh/in-cluster-checks`
+- **Main repository**: `RedHatInsights/incluster-checks`
 
 When using GitHub MCP tools, determine the owner/repo dynamically from git remotes:
 ```bash
@@ -55,15 +55,15 @@ git remote get-url origin
 git remote get-url upstream
 ```
 
-For this project's upstream: `owner: "sprizend-rh"`, `repo: "in-cluster-checks"`
+For this project's upstream: `owner: "RedHatInsights"`, `repo: "incluster-checks"`
 
 ## Common Usage Patterns
 
 ### List open PRs in upstream
 ```
 mcp__plugin_github_github__list_pull_requests(
-  owner: "sprizend-rh",
-  repo: "in-cluster-checks",
+  owner: "RedHatInsights",
+  repo: "incluster-checks",
   state: "open"
 )
 ```
@@ -71,8 +71,8 @@ mcp__plugin_github_github__list_pull_requests(
 ### Get PR details
 ```
 mcp__plugin_github_github__pull_request_read(
-  owner: "sprizend-rh",
-  repo: "in-cluster-checks",
+  owner: "RedHatInsights",
+  repo: "incluster-checks",
   pull_number: 50
 )
 ```
@@ -80,15 +80,15 @@ mcp__plugin_github_github__pull_request_read(
 ### Search for PRs by author
 ```
 mcp__plugin_github_github__search_pull_requests(
-  query: "is:pr author:USERNAME repo:sprizend-rh/in-cluster-checks"
+  query: "is:pr author:USERNAME repo:RedHatInsights/incluster-checks"
 )
 ```
 
 ### Create a pull request
 ```
 mcp__plugin_github_github__create_pull_request(
-  owner: "sprizend-rh",
-  repo: "in-cluster-checks",
+  owner: "RedHatInsights",
+  repo: "incluster-checks",
   title: "feat: add new validation rule",
   body: "Description of changes...",
   head: "YOUR-FORK:feature-branch",

--- a/.claude/rules/in-cluster-check.md
+++ b/.claude/rules/in-cluster-check.md
@@ -66,7 +66,7 @@ All rules use the `Status` enum (`utils/enums.py`):
 **Documentation:**
 - **REQUIRED**: Every new rule MUST have a corresponding wiki page in the GitHub wiki
 - When implementing a new rule:
-  1. Add wiki link to the rule's `links` field pointing to where the page will be: `links = ["https://github.com/sprizend-rh/in-cluster-checks/wiki/{Domain}-‐-{Rule-Title}"]`
+  1. Add wiki link to the rule's `links` field pointing to where the page will be: `links = ["https://github.com/RedHatInsights/incluster-checks/wiki/{Domain}-‐-{Rule-Title}"]`
   2. Create wiki page content in markdown format for the user to copy-paste into GitHub wiki
 - Wiki page naming: Use the rule's `title` field with spaces replaced by dashes (e.g., "Check kubelet CA certificate expiry" → `Security-‐-Check-kubelet-CA-certificate-expiry`)
 - **Note**: Use `‐` (not `-`) in wiki URLs due to GitHub wiki URL encoding
@@ -74,7 +74,7 @@ All rules use the `Status` enum (`utils/enums.py`):
 **Creating Wiki Page Content:**
 - GitHub wikis are NOT accessible via the GitHub MCP (REST API returns 404)
 - **Workflow**: 
-  1. Use WebFetch to read existing wiki pages as templates: `WebFetch(url="https://github.com/sprizend-rh/in-cluster-checks/wiki/Security-‐-TLS-certificate-expiry")`
+  1. Use WebFetch to read existing wiki pages as templates: `WebFetch(url="https://github.com/RedHatInsights/incluster-checks/wiki/Security-‐-TLS-certificate-expiry")`
   2. Create the new wiki page content in **markdown format** following the standard structure
   3. Present the markdown content in a code block for easy copy-paste by the user
 
@@ -89,7 +89,7 @@ All wiki pages should follow this standard structure (in markdown format):
   - **Resources**: Links to official documentation, KCS articles, troubleshooting guides
 
 **Wiki Page Examples:**
-- See existing templates: [Security - TLS certificate expiry](https://github.com/sprizend-rh/in-cluster-checks/wiki/Security-‐-TLS-certificate-expiry), [Security - Node certificate expiry](https://github.com/sprizend-rh/in-cluster-checks/wiki/Security-‐-Node-certificate-expiry)
+- See existing templates: [Security - TLS certificate expiry](https://github.com/RedHatInsights/incluster-checks/wiki/Security-‐-TLS-certificate-expiry), [Security - Node certificate expiry](https://github.com/RedHatInsights/incluster-checks/wiki/Security-‐-Node-certificate-expiry)
 
 ## Existing Domains
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,22 +148,22 @@ class YourNewRule(Rule):
 
 The `links` field should contain references to documentation about the rule:
 
-1. **Create a Wiki page** for the new rule at https://github.com/sprizend-rh/in-cluster-checks/wiki
-   - Use the [wiki template](https://github.com/sprizend-rh/in-cluster-checks/wiki) to create the page
+1. **Create a Wiki page** for the new rule at https://github.com/RedHatInsights/incluster-checks/wiki
+   - Use the [wiki template](https://github.com/RedHatInsights/incluster-checks/wiki) to create the page
    - Document what the rule checks, why it's important, and troubleshooting steps
    - Include example output or scenarios
 
 2. **Add the Wiki URL** to the `links` field:
    ```python
    links = [
-       "https://github.com/sprizend-rh/in-cluster-checks/wiki/YourNewRule",
+       "https://github.com/RedHatInsights/incluster-checks/wiki/YourNewRule",
    ]
    ```
 
 3. **Additional documentation URLs** can also be included (Knowledge Base articles, OpenShift docs, bug reports, etc.):
    ```python
    links = [
-       "https://github.com/sprizend-rh/in-cluster-checks/wiki/YourNewRule",
+       "https://github.com/RedHatInsights/incluster-checks/wiki/YourNewRule",
        "https://access.redhat.com/solutions/12345",
    ]
    ```
@@ -518,17 +518,17 @@ We recommend developing and testing directly on a machine with OpenShift cluster
    # You should see: "Hi USERNAME! You've successfully authenticated..."
    ```
 
-2. **Fork the repository** on GitHub: https://github.com/sprizend-rh/in-cluster-checks
+2. **Fork the repository** on GitHub: https://github.com/RedHatInsights/incluster-checks
 
 3. **Clone your fork**:
    ```bash
-   git clone https://github.com/YOUR-USERNAME/in-cluster-checks.git
-   cd in-cluster-checks
+   git clone https://github.com/YOUR-USERNAME/incluster-checks.git
+   cd incluster-checks
    ```
 
 4. **Add upstream remote**:
    ```bash
-   git remote add upstream https://github.com/sprizend-rh/in-cluster-checks.git
+   git remote add upstream https://github.com/RedHatInsights/incluster-checks.git
    ```
 
 ### Install Dependencies
@@ -613,7 +613,7 @@ If all tests pass and pre-commit runs successfully, your development environment
     3. Click "Create pull request"
 
     **Option 2: Via GitHub**
-    1. Go to the [repository on GitHub](https://github.com/sprizend-rh/in-cluster-checks)
+    1. Go to the [repository on GitHub](https://github.com/RedHatInsights/incluster-checks)
     2. Click "New Pull Request"
     3. Select your fork and branch
     4. Fill out the PR template
@@ -646,9 +646,9 @@ Before submitting your PR, ensure:
 
 ## Questions?
 
-- **Bug reports or feature requests**: [Open an issue](https://github.com/sprizend-rh/in-cluster-checks/issues/new) on GitHub
-- **General questions**: [Open an issue](https://github.com/sprizend-rh/in-cluster-checks/issues/new) with your question
-- **Documentation and rule information**: Check the [project wiki](https://github.com/sprizend-rh/in-cluster-checks/wiki) for detailed knowledge sharing about rules
+- **Bug reports or feature requests**: [Open an issue](https://github.com/RedHatInsights/incluster-checks/issues/new) on GitHub
+- **General questions**: [Open an issue](https://github.com/RedHatInsights/incluster-checks/issues/new) with your question
+- **Documentation and rule information**: Check the [project wiki](https://github.com/RedHatInsights/incluster-checks/wiki) for detailed knowledge sharing about rules
 - **Private matters**: Contact maintainers directly via GitHub
 
 ## License

--- a/OPENSOURCE_PLAN.md
+++ b/OPENSOURCE_PLAN.md
@@ -207,7 +207,7 @@ The project will be considered production-ready when:
 
 ## Repository Information
 
-- **GitHub**: https://github.com/sprizend-rh/in-cluster-checks
+- **GitHub**: https://github.com/RedHatInsights/incluster-checks
 - **Package Name**: `in-cluster-checks`
 - **CLI Command**: `in-cluster-checks`
 - **Python Module**: `in_cluster_checks`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # In-Cluster Checks
 
-[![CI](https://github.com/sprizend-rh/in-cluster-checks/workflows/CI/badge.svg)](https://github.com/sprizend-rh/in-cluster-checks/actions)
+[![CI](https://github.com/RedHatInsights/incluster-checks/workflows/CI/badge.svg)](https://github.com/RedHatInsights/incluster-checks/actions)
 [![License: 3-Clause BSD](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/license/bsd-3-clause)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-blue.svg)](https://www.python.org/downloads/)
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,8 +16,8 @@ This repository uses **GitHub Trusted Publishing** to automatically publish to P
 
    Add a new publisher with these settings:
    - **PyPI Project Name**: `in-cluster-checks`
-   - **Owner**: `sprizend-rh`
-   - **Repository name**: `in-cluster-checks`
+   - **Owner**: `RedHatInsights`
+   - **Repository name**: `incluster-checks`
    - **Workflow name**: `publish.yml`
    - **Environment name**: `pypi` (for production) or `testpypi` (for test)
 
@@ -51,7 +51,7 @@ This repository uses **GitHub Trusted Publishing** to automatically publish to P
    ```
 
 4. **Create a GitHub Release**:
-   - Go to: https://github.com/sprizend-rh/in-cluster-checks/releases/new
+   - Go to: https://github.com/RedHatInsights/incluster-checks/releases/new
    - Choose the tag you just created (`v0.2.0`)
    - Title: `v0.2.0` or `Release 0.2.0`
    - Description: Add release notes (what's new, what changed)
@@ -59,7 +59,7 @@ This repository uses **GitHub Trusted Publishing** to automatically publish to P
 
 5. **Automatic publishing**:
    - GitHub Actions will automatically build and publish to both TestPyPI and PyPI
-   - Monitor the workflow: https://github.com/sprizend-rh/in-cluster-checks/actions
+   - Monitor the workflow: https://github.com/RedHatInsights/incluster-checks/actions
    - Your package will be available at: https://pypi.org/project/in-cluster-checks/
 
 ## Manual Publishing (Fallback)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,9 +40,9 @@ dev = [
 in-cluster-checks = "in_cluster_checks.cli:main"
 
 [project.urls]
-Homepage = "https://github.com/sprizend-rh/in-cluster-checks"
-Repository = "https://github.com/sprizend-rh/in-cluster-checks"
-Issues = "https://github.com/sprizend-rh/in-cluster-checks/issues"
+Homepage = "https://github.com/RedHatInsights/incluster-checks"
+Repository = "https://github.com/RedHatInsights/incluster-checks"
+Issues = "https://github.com/RedHatInsights/incluster-checks/issues"
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/in_cluster_checks/rules/k8s/k8s_validations.py
+++ b/src/in_cluster_checks/rules/k8s/k8s_validations.py
@@ -397,7 +397,7 @@ class AllDeploymentsAvailable(OrchestratorRule):
     objective_hosts = [Objectives.ORCHESTRATOR]
     unique_name = "all_deployments_available"
     title = "Verify all deployments are available"
-    links = ["https://github.com/sprizend-rh/in-cluster-checks/wiki/K8s-%E2%80%90-Verify-deployments-availability"]
+    links = ["https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-deployments-availability"]
 
     def run_rule(self):
         """Check if all deployments have Available condition set to True."""
@@ -449,7 +449,7 @@ class CheckDeploymentsReplicaStatus(OrchestratorRule):
     objective_hosts = [Objectives.ORCHESTRATOR]
     unique_name = "check_deployments_replica_status"
     title = "Verify deployment replica counts"
-    links = ["https://github.com/sprizend-rh/in-cluster-checks/wiki/K8s-%E2%80%90-Check-deployment-replicas-status"]
+    links = ["https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Check-deployment-replicas-status"]
 
     def run_rule(self):
         """Check if all deployments have desired number of replicas ready."""
@@ -507,7 +507,7 @@ class AllStatefulsetsReady(OrchestratorRule):
     objective_hosts = [Objectives.ORCHESTRATOR]
     unique_name = "all_statefulsets_ready"
     title = "Verify all statefulsets are ready"
-    links = ["https://github.com/sprizend-rh/in-cluster-checks/wiki/K8s-%E2%80%90-Verify-statefulsets-readiness"]
+    links = ["https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-statefulsets-readiness"]
 
     def run_rule(self):
         """Check if all statefulsets have ready replicas matching desired replicas."""
@@ -632,7 +632,7 @@ class ValidateAllPoliciesCompliant(OrchestratorRule):
     objective_hosts = [Objectives.ORCHESTRATOR]
     unique_name = "validate_all_policies_compliant"
     title = "Verify all policies are in compliant state"
-    links = ["https://github.com/sprizend-rh/in-cluster-checks/wiki/K8s-Verify-policies-compliance"]
+    links = ["https://github.com/RedHatInsights/incluster-checks/wiki/K8s-Verify-policies-compliance"]
 
     def run_rule(self):
         """Check if all OCM policies are in Compliant state"""
@@ -685,7 +685,7 @@ class VerifyInternalRegistry(OrchestratorRule):
     objective_hosts = [Objectives.ORCHESTRATOR]
     unique_name = "verify_internal_registry"
     title = "Verify internal image registry is configured and available"
-    links = ["https://github.com/sprizend-rh/in-cluster-checks/wiki/K8s-%E2%80%90-Verify-internal-image-registry"]
+    links = ["https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-internal-image-registry"]
 
     def is_prerequisite_fulfilled(self) -> PrerequisiteResult:
         """

--- a/src/in_cluster_checks/rules/linux/linux_validations.py
+++ b/src/in_cluster_checks/rules/linux/linux_validations.py
@@ -234,7 +234,7 @@ class SelinuxMode(Rule):
     unique_name = "selinux_mode"
     title = "SELinux enforcing mode"
     links = [
-        "https://github.com/sprizend-rh/in-cluster-checks/wiki/Linux-%E2%80%90-SELinux-enforcing-mode",
+        "https://github.com/RedHatInsights/incluster-checks/wiki/Linux-%E2%80%90-SELinux-enforcing-mode",
         (
             "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/"
             "using_selinux/getting-started-with-selinux_using-selinux"
@@ -263,7 +263,7 @@ class AuditdBacklogLimit(Rule):
     unique_name = "auditd_backlog_limit"
     title = "Check auditd backlog limit usage"
     links = [
-        "https://github.com/sprizend-rh/in-cluster-checks/wiki/Linux-%E2%80%90-Check-auditd-backlog-limit-usage",
+        "https://github.com/RedHatInsights/incluster-checks/wiki/Linux-%E2%80%90-Check-auditd-backlog-limit-usage",
     ]
 
     BACKLOG = "backlog"

--- a/src/in_cluster_checks/rules/network/node_connectivity_validations.py
+++ b/src/in_cluster_checks/rules/network/node_connectivity_validations.py
@@ -201,7 +201,7 @@ class BondDnsServersComparison(OrchestratorRule):
     unique_name = "bond_dns_servers_comparison"
     title = "Compare bond DNS servers across hosts"
     links = [
-        "https://github.com/sprizend-rh/in-cluster-checks/wiki/Network-%E2%80%90-Bond-DNS-Servers-Comparison",
+        "https://github.com/RedHatInsights/incluster-checks/wiki/Network-%E2%80%90-Bond-DNS-Servers-Comparison",
     ]
 
     def run_rule(self):

--- a/src/in_cluster_checks/rules/network/ovnk8s_validations.py
+++ b/src/in_cluster_checks/rules/network/ovnk8s_validations.py
@@ -255,7 +255,7 @@ class OvnRoutingHealthCheck(OvnDetectingNodeRuleBase):
     unique_name = "ovn_routing_health_check"
     title = "Verify OVN-learned routes are present"
     links = [
-        "https://github.com/sprizend-rh/in-cluster-checks/wiki/Network-%E2%80%90-OVN-Routing-Health-Check",
+        "https://github.com/RedHatInsights/incluster-checks/wiki/Network-%E2%80%90-OVN-Routing-Health-Check",
     ]
 
     def _run_ovn_rule(self) -> RuleResult:

--- a/src/in_cluster_checks/rules/network/ovs_validations.py
+++ b/src/in_cluster_checks/rules/network/ovs_validations.py
@@ -36,7 +36,7 @@ class VlanOvsAttachmentCheck(OvnDetectingNodeRuleBase):
     unique_name = "vlan_ovs_attachment_check"
     title = "Verify OVS-configured VLAN interfaces are attached to OVS bridge"
     links = [
-        "https://github.com/sprizend-rh/in-cluster-checks/wiki/Network-%E2%80%90-VLAN-OVS-Attachment-Check",
+        "https://github.com/RedHatInsights/incluster-checks/wiki/Network-%E2%80%90-VLAN-OVS-Attachment-Check",
     ]
 
     def is_prerequisite_fulfilled(self) -> PrerequisiteResult:
@@ -227,7 +227,7 @@ class OvsInterfaceAndPortFound(OvnDetectingNodeRuleBase):
     unique_name = "ovs_interface_and_port_managed_by_network_manager"
     title = "Verify that ovs interface and port are managed by network manager"
     links = [
-        "https://github.com/sprizend-rh/in-cluster-checks/wiki/Network-%E2%80%90-OVS-Interface-And-Port-Found",
+        "https://github.com/RedHatInsights/incluster-checks/wiki/Network-%E2%80%90-OVS-Interface-And-Port-Found",
     ]
 
     def _run_ovn_rule(self):
@@ -279,7 +279,7 @@ class OvsPhysicalPortHealthCheck(OvnDetectingNodeRuleBase):
     unique_name = "ovs_physical_port_health_check"
     title = "Verify OVS physical port is UP and has no IP"
     links = [
-        "https://github.com/sprizend-rh/in-cluster-checks/wiki/Network-%E2%80%90-OVS-Physical-Port-Health-Check",
+        "https://github.com/RedHatInsights/incluster-checks/wiki/Network-%E2%80%90-OVS-Physical-Port-Health-Check",
     ]
 
     def _run_ovn_rule(self) -> RuleResult:
@@ -395,7 +395,7 @@ class OvsBridgeInterfaceHealthCheck(OvnDetectingNodeRuleBase):
     unique_name = "ovs_bridge_interface_health_check"
     title = "Verify OVS bridge is UP with OVN link-local IP"
     links = [
-        "https://github.com/sprizend-rh/in-cluster-checks/wiki/Network-%E2%80%90-OVS-Bridge-Interface-Health-Check",
+        "https://github.com/RedHatInsights/incluster-checks/wiki/Network-%E2%80%90-OVS-Bridge-Interface-Health-Check",
     ]
 
     def _run_ovn_rule(self) -> RuleResult:
@@ -649,7 +649,7 @@ class OvsProfileActivationCheck(OvnDetectingNodeRuleBase):
     unique_name = "ovs_profile_activation_check"
     title = "Verify OVS NetworkManager profiles are activated"
     links = [
-        "https://github.com/sprizend-rh/in-cluster-checks/wiki/Network-%E2%80%90-OVS-Profile-Activation-Check",
+        "https://github.com/RedHatInsights/incluster-checks/wiki/Network-%E2%80%90-OVS-Profile-Activation-Check",
     ]
 
     def _run_ovn_rule(self) -> RuleResult:

--- a/src/in_cluster_checks/rules/security/ca_certificate_expiry.py
+++ b/src/in_cluster_checks/rules/security/ca_certificate_expiry.py
@@ -38,7 +38,8 @@ class KubeletCaExpiryCheck(OrchestratorRule):
     unique_name = "kubelet_ca_expiry_check"
     title = "Check kubelet CA certificate expiry"
     links = [
-        "https://github.com/sprizend-rh/in-cluster-checks/wiki/Security-%E2%80%90-Check-kubelet-CA-certificate-expiry",
+        "https://github.com/RedHatInsights/incluster-checks/wiki/"
+        "Security-%E2%80%90-Check-kubelet-CA-certificate-expiry",
     ]
 
     # Alert threshold: 30 days (CA rotation should have happened at ~73 days, ~292 days after creation)

--- a/src/in_cluster_checks/rules/security/node_certificate_expiry.py
+++ b/src/in_cluster_checks/rules/security/node_certificate_expiry.py
@@ -25,7 +25,7 @@ class NodeCertificateExpiry(Rule):
     unique_name = "node_certificate_expiry"
     title = "Verify node certificates are not expiring soon"
     links = [
-        "https://github.com/sprizend-rh/in-cluster-checks/wiki/Security-%E2%80%90-Node-certificate-expiry",
+        "https://github.com/RedHatInsights/incluster-checks/wiki/Security-%E2%80%90-Node-certificate-expiry",
     ]
 
     # Days before expiry to start warning

--- a/src/in_cluster_checks/rules/security/tls_certificate_expiry.py
+++ b/src/in_cluster_checks/rules/security/tls_certificate_expiry.py
@@ -20,7 +20,7 @@ class TlsCertificateExpiry(OrchestratorRule):
     unique_name = "all_tls_certs_are_valid"
     title = "Check if all TLS certificates don't expire in 14 days"
     links = [
-        "https://github.com/sprizend-rh/in-cluster-checks/wiki/Security-%E2%80%90-TLS-certificate-expiry",
+        "https://github.com/RedHatInsights/incluster-checks/wiki/Security-%E2%80%90-TLS-certificate-expiry",
     ]
 
     WARNING_DAYS = 14


### PR DESCRIPTION
…s to RedHatInsights/incluster-checks

Update all GitHub URLs, wiki links, owner/repo references, and documentation to reflect the repository move to RedHatInsights/incluster-checks.