### PR TITLE
feat(PDRIVE-582): implement NodesAreReady validation rule

### DIFF
--- a/src/in_cluster_checks/domains/k8s_domain.py
+++ b/src/in_cluster_checks/domains/k8s_domain.py
@@ -13,6 +13,7 @@ from in_cluster_checks.rules.k8s.k8s_validations import (
     AllPodsReadyAndRunning,
     AllStatefulsetsReady,
     CheckDeploymentsReplicaStatus,
+    NodesAreReady,
     NodesCpuAndMemoryStatus,
     OpenshiftOperatorStatus,
     ValidateAllDaemonsetsScheduled,
@@ -42,6 +43,7 @@ class K8sValidationDomain(RuleDomain):
         """
         return [
             AllPodsReadyAndRunning,
+            NodesAreReady,
             NodesCpuAndMemoryStatus,
             ValidateNamespaceStatus,
             ValidateAllDaemonsetsScheduled,

--- a/src/in_cluster_checks/rules/k8s/k8s_validations.py
+++ b/src/in_cluster_checks/rules/k8s/k8s_validations.py
@@ -654,3 +654,69 @@ class VerifyInternalRegistry(OrchestratorRule):
             return RuleResult.failed(message)
 
         return RuleResult.passed()
+
+
+class NodesAreReady(OrchestratorRule):
+    """Verify all cluster nodes are in Ready state with no warning conditions."""
+
+    objective_hosts = [Objectives.ORCHESTRATOR]
+    unique_name = "all_nodes_are_ready"
+    title = "Verify all nodes are ready"
+    links = ["https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-nodes-are-ready"]
+
+    WARNING_CONDITIONS = ["DiskPressure", "MemoryPressure", "PIDPressure", "NetworkUnavailable"]
+
+    def run_rule(self):
+        """Check if all nodes are in Ready state with no warning conditions."""
+        node_objects = self.oc_api.get_all_nodes(timeout=45)
+
+        if not node_objects:
+            return RuleResult.failed("Did not get nodes list from 'oc get nodes'")
+
+        ready_list = []
+        not_ready_list = []
+        warned_list = []
+
+        for node in node_objects:
+            node_data = node.as_dict()
+            node_name = node_data["metadata"]["name"]
+            status_dict = node_data.get("status", {})
+            conditions = status_dict.get("conditions", [])
+
+            ready_condition = None
+            warning_conditions = []
+
+            for condition in conditions:
+                condition_type = condition.get("type")
+                condition_status = condition.get("status")
+
+                if condition_type == "Ready":
+                    ready_condition = condition
+                elif condition_type in self.WARNING_CONDITIONS and condition_status == "True":
+                    warning_conditions.append(condition_type)
+
+            if not ready_condition:
+                not_ready_list.append(node_name)
+            elif ready_condition.get("status") != "True":
+                not_ready_list.append(node_name)
+            elif warning_conditions:
+                warned_list.append(f"{node_name} - Ready,{','.join(warning_conditions)}")
+            else:
+                ready_list.append(node_name)
+
+        if not_ready_list or warned_list:
+            error_messages = []
+
+            if not_ready_list:
+                error_messages.append(
+                    "The following nodes are not ready:\n  " + "\n  ".join(not_ready_list)
+                )
+
+            if warned_list:
+                error_messages.append(
+                    "The following nodes are ready but having some issues:\n  " + "\n  ".join(warned_list)
+                )
+
+            return RuleResult.failed("\n\n".join(error_messages))
+
+        return RuleResult.passed()

--- a/tests/rules/k8s/test_k8s_validations.py
+++ b/tests/rules/k8s/test_k8s_validations.py
@@ -14,6 +14,7 @@ from in_cluster_checks.rules.k8s.k8s_validations import (
     AllPodsReadyAndRunning,
     AllStatefulsetsReady,
     CheckDeploymentsReplicaStatus,
+    NodesAreReady,
     NodesCpuAndMemoryStatus,
     OpenshiftOperatorStatus,
     ValidateAllDaemonsetsScheduled,
@@ -39,6 +40,122 @@ def create_mock_pod(namespace, name, phase, ready_containers, total_containers):
         },
     }
     return mock_pod
+
+
+def create_mock_node(name, ready_status="True", warning_conditions=None):
+    """Create a mock node object.
+
+    Args:
+        name: Node name
+        ready_status: Ready condition status ("True", "False", "Unknown")
+        warning_conditions: List of warning condition types to set to True
+                          (e.g., ["DiskPressure", "MemoryPressure"])
+    """
+    mock_node = Mock()
+    conditions = [
+        {
+            "type": "Ready",
+            "status": ready_status,
+            "reason": "KubeletReady" if ready_status == "True" else "KubeletNotReady",
+            "message": "kubelet is posting ready status" if ready_status == "True" else "kubelet is not ready",
+        }
+    ]
+
+    if warning_conditions:
+        for condition_type in warning_conditions:
+            conditions.append(
+                {
+                    "type": condition_type,
+                    "status": "True",
+                    "reason": f"{condition_type}Detected",
+                    "message": f"Node has {condition_type} condition",
+                }
+            )
+
+    mock_node.as_dict.return_value = {
+        "metadata": {"name": name},
+        "status": {"conditions": conditions},
+    }
+    return mock_node
+
+
+class TestNodesAreReady(RuleTestBase):
+    """Test NodesAreReady rule."""
+
+    tested_type = NodesAreReady
+
+    scenario_passed = [
+        RuleScenarioParams(
+            "all nodes are ready with no warnings",
+            tested_object_mock_dict={
+                "oc_api.get_all_nodes": Mock(
+                    return_value=[
+                        create_mock_node("master-1", ready_status="True"),
+                        create_mock_node("master-2", ready_status="True"),
+                        create_mock_node("worker-1", ready_status="True"),
+                    ]
+                )
+            },
+        ),
+    ]
+
+    scenario_failed = [
+        RuleScenarioParams(
+            "node not ready",
+            tested_object_mock_dict={
+                "oc_api.get_all_nodes": Mock(
+                    return_value=[
+                        create_mock_node("master-1", ready_status="True"),
+                        create_mock_node("worker-1", ready_status="False"),
+                    ]
+                )
+            },
+            failed_msg="The following nodes are not ready:\n"
+            "  worker-1",
+        ),
+        RuleScenarioParams(
+            "node ready with DiskPressure warning",
+            tested_object_mock_dict={
+                "oc_api.get_all_nodes": Mock(
+                    return_value=[
+                        create_mock_node("master-1", ready_status="True"),
+                        create_mock_node("worker-1", ready_status="True", warning_conditions=["DiskPressure"]),
+                    ]
+                )
+            },
+            failed_msg="The following nodes are ready but having some issues:\n"
+            "  worker-1 - Ready,DiskPressure",
+        ),
+        RuleScenarioParams(
+            "mixed node states - not ready and warnings",
+            tested_object_mock_dict={
+                "oc_api.get_all_nodes": Mock(
+                    return_value=[
+                        create_mock_node("master-1", ready_status="True"),
+                        create_mock_node("worker-1", ready_status="False"),
+                        create_mock_node("worker-2", ready_status="True", warning_conditions=["DiskPressure"]),
+                    ]
+                )
+            },
+            failed_msg="The following nodes are not ready:\n"
+            "  worker-1\n\n"
+            "The following nodes are ready but having some issues:\n"
+            "  worker-2 - Ready,DiskPressure",
+        ),
+        RuleScenarioParams(
+            "no nodes found in cluster",
+            tested_object_mock_dict={"oc_api.get_all_nodes": Mock(return_value=[])},
+            failed_msg="Did not get nodes list from 'oc get nodes'",
+        ),
+    ]
+
+    @pytest.mark.parametrize("scenario_params", scenario_passed)
+    def test_scenario_passed(self, scenario_params, tested_object):
+        RuleTestBase.test_scenario_passed(self, scenario_params, tested_object)
+
+    @pytest.mark.parametrize("scenario_params", scenario_failed)
+    def test_scenario_failed(self, scenario_params, tested_object):
+        RuleTestBase.test_scenario_failed(self, scenario_params, tested_object)
 
 
 class TestAllPodsReadyAndRunning:


### PR DESCRIPTION
## Summary
Implements node readiness validation rule for the K8s domain that verifies all cluster nodes are in Ready state with no warning conditions.

**Jira Ticket:** https://redhat.atlassian.net/browse/PDRIVE-582

## Changes
- Created `NodesAreReady` class in `k8s_validations.py` that checks:
  - All nodes have Ready condition set to True
  - No nodes have warning conditions (DiskPressure, MemoryPressure, PIDPressure, NetworkUnavailable)
- Registered rule in `K8sValidationDomain`
- Added comprehensive test coverage with 5 test scenarios covering:
  - All nodes ready (pass)
  - Node not ready (fail)
  - Node with warning conditions (fail)
  - Mixed node states (fail)
  - No nodes found (fail)

## Test Plan
- [x] All unit tests passing (5 passed, 5 skipped)
- [x] Rule properly categorizes nodes into ready, not ready, and warned lists
- [x] Clear failure messages with node names and conditions
- [x] Registered in K8sValidationDomain

## Wiki Documentation
Wiki page content created following project standards. Ready to be added to:
`https://github.com/RedHatInsights/incluster-checks/wiki/K8s-‐-Verify-nodes-are-ready`

🤖 Generated with [Claude Code](https://claude.com/claude-code)