### PR TITLE
feat: add VerifyWebConsoleDisabled rule for edge/SNO clusters

### DIFF
--- a/src/in_cluster_checks/domains/k8s_domain.py
+++ b/src/in_cluster_checks/domains/k8s_domain.py
@@ -20,6 +20,7 @@ from in_cluster_checks.rules.k8s.k8s_validations import (
     ValidateAllPoliciesCompliant,
     ValidateNamespaceStatus,
     VerifyInternalRegistry,
+    VerifyWebConsoleDisabled,
 )
 
 
@@ -53,4 +54,5 @@ class K8sValidationDomain(RuleDomain):
             OpenshiftOperatorStatus,
             ValidateAllPoliciesCompliant,
             VerifyInternalRegistry,
+            VerifyWebConsoleDisabled,
         ]

--- a/src/in_cluster_checks/rules/k8s/k8s_validations.py
+++ b/src/in_cluster_checks/rules/k8s/k8s_validations.py
@@ -745,3 +745,72 @@ class VerifyInternalRegistry(OrchestratorRule):
             return RuleResult.failed(message)
 
         return RuleResult.passed()
+
+
+class VerifyWebConsoleDisabled(OrchestratorRule):
+    """Verify OpenShift web console is disabled and no pods exist in openshift-console namespace.
+
+    On edge clusters (SNO), the web console should be disabled to reduce resource usage.
+    This rule checks that the console operator managementState is not 'Managed' and
+    that no pods are running in the openshift-console namespace.
+    """
+
+    objective_hosts = [Objectives.ORCHESTRATOR]
+    unique_name = "verify_web_console_disabled"
+    title = "Verify web console is disabled (edge/SNO clusters)"
+    links = [
+        "https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-web-console-disabled",
+        "https://docs.openshift.com/container-platform/latest/web_console/disabling-web-console.html",
+    ]
+
+    def is_prerequisite_fulfilled(self) -> PrerequisiteResult:
+        """Check if the web console is configured as disabled.
+
+        The rule is only applicable when the console operator's managementState
+        is not 'Managed' (i.e., 'Removed' or 'Unmanaged'), indicating that the
+        web console is intentionally disabled.
+        """
+        try:
+            _, console_config_output, _ = self.oc_api.run_oc_command(
+                "get",
+                ["console.operator.openshift.io", "cluster", "-o", "json"],
+                timeout=45,
+            )
+        except UnExpectedSystemOutput:
+            return PrerequisiteResult.not_met("Failed to get console operator configuration")
+
+        try:
+            console_config = json.loads(console_config_output)
+        except json.JSONDecodeError as e:
+            return PrerequisiteResult.not_met(f"Failed to parse console operator configuration: {e}")
+
+        spec = console_config.get("spec", {})
+        management_state = spec.get("managementState", "Unknown")
+
+        if management_state == "Managed":
+            return PrerequisiteResult.not_met(
+                f"Console operator managementState is '{management_state}' - "
+                "web console is enabled, this check is for edge/SNO clusters where console should be disabled"
+            )
+
+        return PrerequisiteResult.met()
+
+    def run_rule(self):
+        """Verify no pods exist in the openshift-console namespace."""
+        pod_objects = self.oc_api.get_all_pods(namespace="openshift-console")
+
+        if pod_objects:
+            pod_names = []
+            for pod in pod_objects:
+                pod_data = pod.as_dict()
+                pod_name = pod_data["metadata"]["name"]
+                pod_names.append(pod_name)
+
+            message = (
+                f"Found {len(pod_objects)} pod(s) in openshift-console namespace "
+                "but web console should be disabled:\n  "
+            )
+            message += "\n  ".join(pod_names)
+            return RuleResult.failed(message)
+
+        return RuleResult.passed()

--- a/src/in_cluster_checks/rules/k8s/k8s_validations.py
+++ b/src/in_cluster_checks/rules/k8s/k8s_validations.py
@@ -787,13 +787,13 @@ class VerifyWebConsoleDisabled(OrchestratorRule):
         spec = console_config.get("spec", {})
         management_state = spec.get("managementState", "Unknown")
 
-        if management_state == "Managed":
-            return PrerequisiteResult.not_met(
-                f"Console operator managementState is '{management_state}' - "
-                "web console is enabled, this check is for edge/SNO clusters where console should be disabled"
-            )
+        if management_state in {"Removed", "Unmanaged"}:
+            return PrerequisiteResult.met()
 
-        return PrerequisiteResult.met()
+        return PrerequisiteResult.not_met(
+            f"Console operator managementState is '{management_state}' - "
+            "this check only applies when web console is explicitly disabled (Removed/Unmanaged)"
+        )
 
     def run_rule(self):
         """Verify no pods exist in the openshift-console namespace."""

--- a/tests/domains/test_k8s_domain.py
+++ b/tests/domains/test_k8s_domain.py
@@ -10,6 +10,7 @@ from in_cluster_checks.rules.k8s.k8s_validations import (
     ValidateNamespaceStatus,
     ValidateAllPoliciesCompliant,
     VerifyInternalRegistry,
+    VerifyWebConsoleDisabled,
 )
 
 
@@ -24,7 +25,7 @@ def test_k8s_domain_rules():
     domain = K8sValidationDomain()
     rules = domain.get_rule_classes()
 
-    assert len(rules) == 11
+    assert len(rules) == 12
     assert AllPodsReadyAndRunning in rules
     assert NodesAreReady in rules
     assert NodesCpuAndMemoryStatus in rules
@@ -33,3 +34,4 @@ def test_k8s_domain_rules():
     assert OpenshiftOperatorStatus in rules
     assert ValidateAllPoliciesCompliant in rules
     assert VerifyInternalRegistry in rules
+    assert VerifyWebConsoleDisabled in rules

--- a/tests/rules/k8s/test_k8s_validations.py
+++ b/tests/rules/k8s/test_k8s_validations.py
@@ -21,6 +21,7 @@ from in_cluster_checks.rules.k8s.k8s_validations import (
     ValidateAllPoliciesCompliant,
     ValidateNamespaceStatus,
     VerifyInternalRegistry,
+    VerifyWebConsoleDisabled,
 )
 from in_cluster_checks.utils.enums import Status
 from tests.pytest_tools.test_rule_base import RuleScenarioParams, RuleTestBase
@@ -1261,6 +1262,114 @@ class TestVerifyInternalRegistry(RuleTestBase):
             },
             failed_msg="Image registry is Managed but following pods are not ready:\n"
             "  image-registry-1 - Running, Not all containers ready",
+        ),
+    ]
+
+    @pytest.mark.parametrize("scenario_params", scenario_prerequisite_not_fulfilled)
+    def test_prerequisite_not_fulfilled(self, scenario_params, tested_object):
+        RuleTestBase.test_prerequisite_not_fulfilled(self, scenario_params, tested_object)
+
+    @pytest.mark.parametrize("scenario_params", scenario_passed)
+    def test_scenario_passed(self, scenario_params, tested_object):
+        RuleTestBase.test_scenario_passed(self, scenario_params, tested_object)
+
+    @pytest.mark.parametrize("scenario_params", scenario_failed)
+    def test_scenario_failed(self, scenario_params, tested_object):
+        RuleTestBase.test_scenario_failed(self, scenario_params, tested_object)
+
+
+def create_mock_console_pod(name):
+    """Create a mock console pod object."""
+    mock_pod = Mock()
+    mock_pod.as_dict.return_value = {
+        "metadata": {"namespace": "openshift-console", "name": name},
+        "status": {
+            "phase": "Running",
+            "containerStatuses": [{"ready": True}],
+        },
+    }
+    return mock_pod
+
+
+class TestVerifyWebConsoleDisabled(RuleTestBase):
+    """Test VerifyWebConsoleDisabled rule."""
+
+    tested_type = VerifyWebConsoleDisabled
+
+    # Console config - Removed state (web console disabled)
+    console_config_removed = {
+        "spec": {
+            "managementState": "Removed",
+        },
+        "status": {},
+    }
+
+    # Console config - Unmanaged state (web console disabled)
+    console_config_unmanaged = {
+        "spec": {
+            "managementState": "Unmanaged",
+        },
+        "status": {},
+    }
+
+    # Console config - Managed state (web console enabled)
+    console_config_managed = {
+        "spec": {
+            "managementState": "Managed",
+        },
+        "status": {},
+    }
+
+    scenario_passed = [
+        RuleScenarioParams(
+            "console is disabled (Removed) and no pods in openshift-console namespace",
+            tested_object_mock_dict={
+                "oc_api.run_oc_command": Mock(
+                    return_value=(0, json.dumps(console_config_removed), "")
+                ),
+                "oc_api.get_all_pods": Mock(return_value=[]),
+            },
+        ),
+        RuleScenarioParams(
+            "console is disabled (Unmanaged) and no pods in openshift-console namespace",
+            tested_object_mock_dict={
+                "oc_api.run_oc_command": Mock(
+                    return_value=(0, json.dumps(console_config_unmanaged), "")
+                ),
+                "oc_api.get_all_pods": Mock(return_value=[]),
+            },
+        ),
+    ]
+
+    scenario_prerequisite_not_fulfilled = [
+        RuleScenarioParams(
+            "console operator is Managed (web console enabled)",
+            tested_object_mock_dict={
+                "oc_api.run_oc_command": Mock(
+                    return_value=(0, json.dumps(console_config_managed), "")
+                ),
+            },
+        ),
+    ]
+
+    scenario_failed = [
+        RuleScenarioParams(
+            "console is disabled but pods still exist in openshift-console namespace",
+            tested_object_mock_dict={
+                "oc_api.run_oc_command": Mock(
+                    return_value=(0, json.dumps(console_config_removed), "")
+                ),
+                "oc_api.get_all_pods": Mock(
+                    return_value=[
+                        create_mock_console_pod("console-7b4f8c6d9-abc12"),
+                        create_mock_console_pod("downloads-6f5d7c8b4-xyz34"),
+                    ]
+                ),
+            },
+            failed_msg="Found 2 pod(s) in openshift-console namespace "
+            "but web console should be disabled:\n"
+            "  console-7b4f8c6d9-abc12\n"
+            "  downloads-6f5d7c8b4-xyz34",
         ),
     ]
 

--- a/tests/rules/k8s/test_k8s_validations.py
+++ b/tests/rules/k8s/test_k8s_validations.py
@@ -1320,6 +1320,12 @@ class TestVerifyWebConsoleDisabled(RuleTestBase):
         "status": {},
     }
 
+    # Console config - missing managementState
+    console_config_unknown = {
+        "spec": {},
+        "status": {},
+    }
+
     scenario_passed = [
         RuleScenarioParams(
             "console is disabled (Removed) and no pods in openshift-console namespace",
@@ -1347,6 +1353,14 @@ class TestVerifyWebConsoleDisabled(RuleTestBase):
             tested_object_mock_dict={
                 "oc_api.run_oc_command": Mock(
                     return_value=(0, json.dumps(console_config_managed), "")
+                ),
+            },
+        ),
+        RuleScenarioParams(
+            "console operator managementState is missing",
+            tested_object_mock_dict={
+                "oc_api.run_oc_command": Mock(
+                    return_value=(0, json.dumps(console_config_unknown), "")
                 ),
             },
         ),

--- a/tests/rules/k8s/test_k8s_validations.py
+++ b/tests/rules/k8s/test_k8s_validations.py
@@ -1291,47 +1291,23 @@ def create_mock_console_pod(name):
     return mock_pod
 
 
+def _console_config(management_state=None):
+    """Build a console operator config with the given managementState."""
+    spec = {"managementState": management_state} if management_state else {}
+    return {"spec": spec, "status": {}}
+
+
 class TestVerifyWebConsoleDisabled(RuleTestBase):
     """Test VerifyWebConsoleDisabled rule."""
 
     tested_type = VerifyWebConsoleDisabled
-
-    # Console config - Removed state (web console disabled)
-    console_config_removed = {
-        "spec": {
-            "managementState": "Removed",
-        },
-        "status": {},
-    }
-
-    # Console config - Unmanaged state (web console disabled)
-    console_config_unmanaged = {
-        "spec": {
-            "managementState": "Unmanaged",
-        },
-        "status": {},
-    }
-
-    # Console config - Managed state (web console enabled)
-    console_config_managed = {
-        "spec": {
-            "managementState": "Managed",
-        },
-        "status": {},
-    }
-
-    # Console config - missing managementState
-    console_config_unknown = {
-        "spec": {},
-        "status": {},
-    }
 
     scenario_passed = [
         RuleScenarioParams(
             "console is disabled (Removed) and no pods in openshift-console namespace",
             tested_object_mock_dict={
                 "oc_api.run_oc_command": Mock(
-                    return_value=(0, json.dumps(console_config_removed), "")
+                    return_value=(0, json.dumps(_console_config("Removed")), "")
                 ),
                 "oc_api.get_all_pods": Mock(return_value=[]),
             },
@@ -1340,7 +1316,7 @@ class TestVerifyWebConsoleDisabled(RuleTestBase):
             "console is disabled (Unmanaged) and no pods in openshift-console namespace",
             tested_object_mock_dict={
                 "oc_api.run_oc_command": Mock(
-                    return_value=(0, json.dumps(console_config_unmanaged), "")
+                    return_value=(0, json.dumps(_console_config("Unmanaged")), "")
                 ),
                 "oc_api.get_all_pods": Mock(return_value=[]),
             },
@@ -1352,7 +1328,7 @@ class TestVerifyWebConsoleDisabled(RuleTestBase):
             "console operator is Managed (web console enabled)",
             tested_object_mock_dict={
                 "oc_api.run_oc_command": Mock(
-                    return_value=(0, json.dumps(console_config_managed), "")
+                    return_value=(0, json.dumps(_console_config("Managed")), "")
                 ),
             },
         ),
@@ -1360,7 +1336,7 @@ class TestVerifyWebConsoleDisabled(RuleTestBase):
             "console operator managementState is missing",
             tested_object_mock_dict={
                 "oc_api.run_oc_command": Mock(
-                    return_value=(0, json.dumps(console_config_unknown), "")
+                    return_value=(0, json.dumps(_console_config()), "")
                 ),
             },
         ),
@@ -1371,7 +1347,7 @@ class TestVerifyWebConsoleDisabled(RuleTestBase):
             "console is disabled but pods still exist in openshift-console namespace",
             tested_object_mock_dict={
                 "oc_api.run_oc_command": Mock(
-                    return_value=(0, json.dumps(console_config_removed), "")
+                    return_value=(0, json.dumps(_console_config("Removed")), "")
                 ),
                 "oc_api.get_all_pods": Mock(
                     return_value=[


### PR DESCRIPTION
Verify that the OpenShift web console is disabled and no pods exist in the openshift-console namespace. Includes a prerequisite check that the console operator managementState is not 'Managed', making the rule only applicable to clusters where the console is intentionally disabled.