### PR TITLE
feat: add VerifyNetworkDiagnosticsDisabled rule for edge/SNO clusters

### DIFF
--- a/src/in_cluster_checks/domains/k8s_domain.py
+++ b/src/in_cluster_checks/domains/k8s_domain.py
@@ -20,6 +20,7 @@ from in_cluster_checks.rules.k8s.k8s_validations import (
     ValidateAllPoliciesCompliant,
     ValidateNamespaceStatus,
     VerifyInternalRegistry,
+    VerifyNetworkDiagnosticsDisabled,
     VerifyWebConsoleDisabled,
 )
 
@@ -55,4 +56,5 @@ class K8sValidationDomain(RuleDomain):
             ValidateAllPoliciesCompliant,
             VerifyInternalRegistry,
             VerifyWebConsoleDisabled,
+            VerifyNetworkDiagnosticsDisabled,
         ]

--- a/src/in_cluster_checks/rules/k8s/k8s_validations.py
+++ b/src/in_cluster_checks/rules/k8s/k8s_validations.py
@@ -814,3 +814,73 @@ class VerifyWebConsoleDisabled(OrchestratorRule):
             return RuleResult.failed(message)
 
         return RuleResult.passed()
+
+
+class VerifyNetworkDiagnosticsDisabled(OrchestratorRule):
+    """Verify no pods exist in openshift-network-diagnostics namespace when diagnostics are disabled.
+
+    On edge clusters (SNO), network diagnostics should be disabled to reduce resource usage.
+    This rule checks that the network operator has disableNetworkDiagnostics set to true and
+    that no pods are running in the openshift-network-diagnostics namespace.
+    """
+
+    objective_hosts = [Objectives.ORCHESTRATOR]
+    unique_name = "verify_network_diagnostics_disabled"
+    title = "Verify no pods in network diagnostics namespace (edge/SNO clusters)"
+    links = [
+        "https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-network-diagnostics-disabled",
+        "https://docs.redhat.com/en/documentation/openshift_container_platform"
+        "/4.17/html/networking_operators/cluster-network-operator",
+    ]
+
+    def is_prerequisite_fulfilled(self) -> PrerequisiteResult:
+        """Check if network diagnostics is configured as disabled.
+
+        The rule is only applicable when the network operator's
+        disableNetworkDiagnostics is set to true, indicating that network
+        diagnostics is intentionally disabled.
+        """
+        try:
+            _, network_config_output, _ = self.oc_api.run_oc_command(
+                "get",
+                ["network.operator.openshift.io", "cluster", "-o", "json"],
+                timeout=45,
+            )
+        except UnExpectedSystemOutput:
+            return PrerequisiteResult.not_met("Failed to get network operator configuration")
+
+        try:
+            network_config = json.loads(network_config_output)
+        except json.JSONDecodeError as e:
+            return PrerequisiteResult.not_met(f"Failed to parse network operator configuration: {e}")
+
+        spec = network_config.get("spec", {})
+        disable_diagnostics = spec.get("disableNetworkDiagnostics")
+
+        if disable_diagnostics is True:
+            return PrerequisiteResult.met()
+
+        return PrerequisiteResult.not_met(
+            f"Network operator disableNetworkDiagnostics is '{disable_diagnostics}' - "
+            "this check only applies when network diagnostics is explicitly disabled (true)"
+        )
+
+    def run_rule(self):
+        """Verify no pods exist in the openshift-network-diagnostics namespace."""
+        pod_objects = self.oc_api.get_all_pods(namespace="openshift-network-diagnostics")
+
+        if pod_objects:
+            pod_names = []
+            for pod in pod_objects:
+                pod_data = pod.as_dict()
+                pod_name = pod_data["metadata"]["name"]
+                pod_names.append(pod_name)
+
+            message = (
+                f"Found {len(pod_objects)} pod(s) in openshift-network-diagnostics namespace "
+                "but network diagnostics should be disabled:\n  "
+            )
+            message += "\n  ".join(pod_names)
+            return RuleResult.failed(message)
+
+        return RuleResult.passed()

--- a/tests/domains/test_k8s_domain.py
+++ b/tests/domains/test_k8s_domain.py
@@ -10,6 +10,7 @@ from in_cluster_checks.rules.k8s.k8s_validations import (
     ValidateNamespaceStatus,
     ValidateAllPoliciesCompliant,
     VerifyInternalRegistry,
+    VerifyNetworkDiagnosticsDisabled,
     VerifyWebConsoleDisabled,
 )
 
@@ -25,7 +26,7 @@ def test_k8s_domain_rules():
     domain = K8sValidationDomain()
     rules = domain.get_rule_classes()
 
-    assert len(rules) == 12
+    assert len(rules) == 13
     assert AllPodsReadyAndRunning in rules
     assert NodesAreReady in rules
     assert NodesCpuAndMemoryStatus in rules
@@ -35,3 +36,4 @@ def test_k8s_domain_rules():
     assert ValidateAllPoliciesCompliant in rules
     assert VerifyInternalRegistry in rules
     assert VerifyWebConsoleDisabled in rules
+    assert VerifyNetworkDiagnosticsDisabled in rules

--- a/tests/rules/k8s/test_k8s_validations.py
+++ b/tests/rules/k8s/test_k8s_validations.py
@@ -21,9 +21,11 @@ from in_cluster_checks.rules.k8s.k8s_validations import (
     ValidateAllPoliciesCompliant,
     ValidateNamespaceStatus,
     VerifyInternalRegistry,
+    VerifyNetworkDiagnosticsDisabled,
     VerifyWebConsoleDisabled,
 )
 from in_cluster_checks.utils.enums import Status
+from tests.pytest_tools.test_operator_base import CmdOutput
 from tests.pytest_tools.test_rule_base import RuleScenarioParams, RuleTestBase
 
 
@@ -1373,4 +1375,100 @@ class TestVerifyWebConsoleDisabled(RuleTestBase):
 
     @pytest.mark.parametrize("scenario_params", scenario_failed)
     def test_scenario_failed(self, scenario_params, tested_object):
+        RuleTestBase.test_scenario_failed(self, scenario_params, tested_object)
+
+
+def create_mock_network_diagnostics_pod(name):
+    """Create a mock network diagnostics pod object."""
+    mock_pod = Mock()
+    mock_pod.as_dict.return_value = {
+        "metadata": {"namespace": "openshift-network-diagnostics", "name": name},
+        "status": {
+            "phase": "Running",
+            "containerStatuses": [{"ready": True}],
+        },
+    }
+    return mock_pod
+
+
+def _network_config(disable_diagnostics=None):
+    """Build a network operator config with the given disableNetworkDiagnostics value."""
+    spec = {"disableNetworkDiagnostics": disable_diagnostics} if disable_diagnostics is not None else {}
+    return {"spec": spec, "status": {}}
+
+
+class TestVerifyNetworkDiagnosticsDisabled(RuleTestBase):
+    """Test VerifyNetworkDiagnosticsDisabled rule."""
+
+    tested_type = VerifyNetworkDiagnosticsDisabled
+
+    scenario_passed = [
+        RuleScenarioParams(
+            "network diagnostics disabled and no pods in openshift-network-diagnostics namespace",
+            tested_object_mock_dict={
+                "oc_api.get_all_pods": Mock(return_value=[]),
+            },
+            oc_cmd_output_dict={
+                ("get", ("network.operator.openshift.io", "cluster", "-o", "json")): CmdOutput(
+                    json.dumps(_network_config(True))
+                ),
+            },
+        ),
+    ]
+
+    scenario_prerequisite_not_fulfilled = [
+        RuleScenarioParams(
+            "network diagnostics is not disabled (disableNetworkDiagnostics is false)",
+            oc_cmd_output_dict={
+                ("get", ("network.operator.openshift.io", "cluster", "-o", "json")): CmdOutput(
+                    json.dumps(_network_config(False))
+                ),
+            },
+        ),
+        RuleScenarioParams(
+            "network operator disableNetworkDiagnostics is missing",
+            oc_cmd_output_dict={
+                ("get", ("network.operator.openshift.io", "cluster", "-o", "json")): CmdOutput(
+                    json.dumps(_network_config())
+                ),
+            },
+        ),
+    ]
+
+    scenario_failed = [
+        RuleScenarioParams(
+            "network diagnostics disabled but pods still exist in openshift-network-diagnostics namespace",
+            tested_object_mock_dict={
+                "oc_api.get_all_pods": Mock(
+                    return_value=[
+                        create_mock_network_diagnostics_pod("network-check-source-7b4f8c6d9-abc12"),
+                        create_mock_network_diagnostics_pod("network-check-target-xyz34"),
+                    ]
+                ),
+            },
+            oc_cmd_output_dict={
+                ("get", ("network.operator.openshift.io", "cluster", "-o", "json")): CmdOutput(
+                    json.dumps(_network_config(True))
+                ),
+            },
+            failed_msg="Found 2 pod(s) in openshift-network-diagnostics namespace "
+            "but network diagnostics should be disabled:\n"
+            "  network-check-source-7b4f8c6d9-abc12\n"
+            "  network-check-target-xyz34",
+        ),
+    ]
+
+    @pytest.mark.parametrize("scenario_params", scenario_prerequisite_not_fulfilled)
+    def test_prerequisite_not_fulfilled(self, scenario_params, tested_object):
+        """Test prerequisite not fulfilled scenarios."""
+        RuleTestBase.test_prerequisite_not_fulfilled(self, scenario_params, tested_object)
+
+    @pytest.mark.parametrize("scenario_params", scenario_passed)
+    def test_scenario_passed(self, scenario_params, tested_object):
+        """Test passed scenarios."""
+        RuleTestBase.test_scenario_passed(self, scenario_params, tested_object)
+
+    @pytest.mark.parametrize("scenario_params", scenario_failed)
+    def test_scenario_failed(self, scenario_params, tested_object):
+        """Test failed scenarios."""
         RuleTestBase.test_scenario_failed(self, scenario_params, tested_object)


### PR DESCRIPTION
Verify that no pods exist in the openshift-network-diagnostics namespace when network diagnostics is disabled. Includes a prerequisite check that the network operator disableNetworkDiagnostics is set to true, making the rule only applicable to clusters where diagnostics is intentionally disabled.