### PR TITLE
feat: add VerifyNfdOperatorHealth rule for NFD operator pod health checks

### DIFF
--- a/src/in_cluster_checks/domains/k8s_domain.py
+++ b/src/in_cluster_checks/domains/k8s_domain.py
@@ -22,6 +22,7 @@ from in_cluster_checks.rules.k8s.k8s_validations import (
     VerifyClusterOperatorsAvailable,
     VerifyInternalRegistry,
     VerifyNetworkDiagnosticsDisabled,
+    VerifyNfdOperatorHealth,
     VerifyWebConsoleDisabled,
 )
 
@@ -59,4 +60,5 @@ class K8sValidationDomain(RuleDomain):
             VerifyInternalRegistry,
             VerifyWebConsoleDisabled,
             VerifyNetworkDiagnosticsDisabled,
+            VerifyNfdOperatorHealth,
         ]

--- a/src/in_cluster_checks/rules/k8s/k8s_validations.py
+++ b/src/in_cluster_checks/rules/k8s/k8s_validations.py
@@ -937,6 +937,81 @@ class VerifyWebConsoleDisabled(OrchestratorRule):
         return RuleResult.passed()
 
 
+class VerifyNfdOperatorHealth(OrchestratorRule):
+    """Verify Node Feature Discovery (NFD) operator pods are healthy.
+
+    NFD sets the stage for cluster functionality by labelling nodes with
+    hardware capabilities.  This rule checks that the NFD operator has been
+    installed (Subscription exists) and that every pod in the openshift-nfd
+    namespace is Running with all containers ready.
+    """
+
+    objective_hosts = [Objectives.ORCHESTRATOR]
+    unique_name = "verify_nfd_operator_health"
+    title = "Verify NFD operator pods are healthy"
+    links = [
+        "https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-NFD-operator-health",
+        "https://docs.openshift.com/container-platform/latest/hardware_enablement"
+        "/psap-node-feature-discovery-operator.html",
+    ]
+
+    NFD_NAMESPACE = "openshift-nfd"
+
+    def is_prerequisite_fulfilled(self) -> PrerequisiteResult:
+        """Check that the NFD operator has been installed via a Subscription.
+
+        Queries the cluster for a Subscription resource with the
+        ``nfd`` package name.  If none is found the rule is not applicable.
+        """
+        try:
+            _, subscriptions_output, _ = self.oc_api.run_oc_command(
+                "get",
+                ["subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json"],
+                timeout=45,
+            )
+        except UnExpectedSystemOutput:
+            return PrerequisiteResult.not_met("Failed to get operator subscriptions from cluster")
+
+        try:
+            subscriptions_data = json.loads(subscriptions_output)
+        except json.JSONDecodeError as e:
+            return PrerequisiteResult.not_met(f"Failed to parse operator subscriptions: {e}")
+
+        for sub in subscriptions_data.get("items", []):
+            spec = sub.get("spec", {})
+            if spec.get("name") == "nfd":
+                return PrerequisiteResult.met()
+
+        return PrerequisiteResult.not_met(
+            "NFD operator subscription not found - " "Node Feature Discovery operator is not installed on this cluster"
+        )
+
+    def run_rule(self):
+        """Verify all pods in the openshift-nfd namespace are Running and Ready."""
+        pod_objects = self.oc_api.get_all_pods(namespace=self.NFD_NAMESPACE)
+
+        if not pod_objects:
+            return RuleResult.failed(
+                f"No pods found in {self.NFD_NAMESPACE} namespace. " "NFD operator may not be fully deployed."
+            )
+
+        not_ready_pods = []
+
+        for pod in pod_objects:
+            pod_status = self.oc_api.get_pod_status(pod)
+            if pod_status is None:
+                continue
+            if not pod_status["all_containers_ready"]:
+                not_ready_pods.append(pod_status["status_message"])
+
+        if not_ready_pods:
+            message = f"NFD operator has unhealthy pods in {self.NFD_NAMESPACE} namespace:\n  "
+            message += "\n  ".join(not_ready_pods)
+            return RuleResult.failed(message)
+
+        return RuleResult.passed()
+
+
 class VerifyNetworkDiagnosticsDisabled(OrchestratorRule):
     """Verify no pods exist in openshift-network-diagnostics namespace when diagnostics are disabled.
 

--- a/src/in_cluster_checks/rules/k8s/k8s_validations.py
+++ b/src/in_cluster_checks/rules/k8s/k8s_validations.py
@@ -948,7 +948,8 @@ class VerifyNfdOperatorHealth(OrchestratorRule):
 
     objective_hosts = [Objectives.ORCHESTRATOR]
     unique_name = "verify_nfd_operator_health"
-    title = "Verify NFD operator pods are healthy"
+    title = "Verify NFD operator pods are healthy"  
+    supported_profiles = {"nokia-qa"}
     links = [
         "https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-NFD-operator-health",
         "https://docs.openshift.com/container-platform/latest/hardware_enablement"

--- a/src/in_cluster_checks/rules/k8s/k8s_validations.py
+++ b/src/in_cluster_checks/rules/k8s/k8s_validations.py
@@ -948,11 +948,11 @@ class VerifyNfdOperatorHealth(OrchestratorRule):
 
     objective_hosts = [Objectives.ORCHESTRATOR]
     unique_name = "verify_nfd_operator_health"
-    title = "Verify NFD operator pods are healthy"  
+    title = "Verify NFD operator pods are healthy"
     supported_profiles = {"nokia-qa"}
     links = [
         "https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-NFD-operator-health",
-        "https://docs.openshift.com/container-platform/latest/hardware_enablement"
+        "https://docs.openshift.com/container-platform/4.18/hardware_enablement"
         "/psap-node-feature-discovery-operator.html",
     ]
 

--- a/src/in_cluster_checks/rules/k8s/k8s_validations.py
+++ b/src/in_cluster_checks/rules/k8s/k8s_validations.py
@@ -964,19 +964,21 @@ class VerifyNfdOperatorHealth(OrchestratorRule):
         Queries the cluster for a Subscription resource with the
         ``nfd`` package name.  If none is found the rule is not applicable.
         """
-        try:
-            _, subscriptions_output, _ = self.oc_api.run_oc_command(
-                "get",
-                ["subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json"],
-                timeout=45,
-            )
-        except UnExpectedSystemOutput:
-            return PrerequisiteResult.not_met("Failed to get operator subscriptions from cluster")
+        _, subscriptions_output, _ = self.oc_api.run_oc_command(
+            "get",
+            ["subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json"],
+            timeout=45,
+        )
 
         try:
             subscriptions_data = json.loads(subscriptions_output)
         except json.JSONDecodeError as e:
-            return PrerequisiteResult.not_met(f"Failed to parse operator subscriptions: {e}")
+            raise UnExpectedSystemOutput(
+                ip=self.get_host_ip(),
+                cmd="oc get subscriptions.operators.coreos.com --all-namespaces -o json",
+                output=subscriptions_output,
+                message=f"Failed to parse operator subscriptions: {e}",
+            ) from e
 
         for sub in subscriptions_data.get("items", []):
             spec = sub.get("spec", {})
@@ -997,13 +999,19 @@ class VerifyNfdOperatorHealth(OrchestratorRule):
             )
 
         not_ready_pods = []
+        unknown_status_pods = []
 
         for pod in pod_objects:
             pod_status = self.oc_api.get_pod_status(pod)
             if pod_status is None:
+                pod_name = pod.as_dict().get("metadata", {}).get("name", "unknown")
+                unknown_status_pods.append(pod_name)
                 continue
             if not pod_status["all_containers_ready"]:
                 not_ready_pods.append(pod_status["status_message"])
+
+        if unknown_status_pods:
+            return RuleResult.failed("Failed to evaluate status for NFD pod(s):\n  " + "\n  ".join(unknown_status_pods))
 
         if not_ready_pods:
             message = f"NFD operator has unhealthy pods in {self.NFD_NAMESPACE} namespace:\n  "

--- a/src/in_cluster_checks/rules/k8s/k8s_validations.py
+++ b/src/in_cluster_checks/rules/k8s/k8s_validations.py
@@ -984,7 +984,7 @@ class VerifyNfdOperatorHealth(OrchestratorRule):
                 return PrerequisiteResult.met()
 
         return PrerequisiteResult.not_met(
-            "NFD operator subscription not found - " "Node Feature Discovery operator is not installed on this cluster"
+            "NFD operator subscription not found - Node Feature Discovery operator is not installed on this cluster"
         )
 
     def run_rule(self):
@@ -993,7 +993,7 @@ class VerifyNfdOperatorHealth(OrchestratorRule):
 
         if not pod_objects:
             return RuleResult.failed(
-                f"No pods found in {self.NFD_NAMESPACE} namespace. " "NFD operator may not be fully deployed."
+                f"No pods found in {self.NFD_NAMESPACE} namespace. NFD operator may not be fully deployed."
             )
 
         not_ready_pods = []

--- a/src/in_cluster_checks/rules/k8s/k8s_validations.py
+++ b/src/in_cluster_checks/rules/k8s/k8s_validations.py
@@ -951,7 +951,7 @@ class VerifyNfdOperatorHealth(OrchestratorRule):
     title = "Verify NFD operator pods are healthy"
     supported_profiles = {"nokia-qa"}
     links = [
-        "https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-NFD-operator-health",
+        "https://github.com/RedHatInsights/incluster-checks/wiki/K8s%E2%80%90-Verify-NFD-operator-health",
         "https://docs.openshift.com/container-platform/4.18/hardware_enablement"
         "/psap-node-feature-discovery-operator.html",
     ]

--- a/tests/domains/test_k8s_domain.py
+++ b/tests/domains/test_k8s_domain.py
@@ -12,6 +12,7 @@ from in_cluster_checks.rules.k8s.k8s_validations import (
     VerifyClusterOperatorsAvailable,
     VerifyInternalRegistry,
     VerifyNetworkDiagnosticsDisabled,
+    VerifyNfdOperatorHealth,
     VerifyWebConsoleDisabled,
 )
 
@@ -27,7 +28,7 @@ def test_k8s_domain_rules():
     domain = K8sValidationDomain()
     rules = domain.get_rule_classes()
 
-    assert len(rules) == 14
+    assert len(rules) == 15
     assert AllPodsReadyAndRunning in rules
     assert NodesAreReady in rules
     assert NodesCpuAndMemoryStatus in rules
@@ -39,3 +40,4 @@ def test_k8s_domain_rules():
     assert VerifyInternalRegistry in rules
     assert VerifyWebConsoleDisabled in rules
     assert VerifyNetworkDiagnosticsDisabled in rules
+    assert VerifyNfdOperatorHealth in rules

--- a/tests/rules/k8s/test_k8s_validations.py
+++ b/tests/rules/k8s/test_k8s_validations.py
@@ -23,6 +23,7 @@ from in_cluster_checks.rules.k8s.k8s_validations import (
     VerifyClusterOperatorsAvailable,
     VerifyInternalRegistry,
     VerifyNetworkDiagnosticsDisabled,
+    VerifyNfdOperatorHealth,
     VerifyWebConsoleDisabled,
 )
 from in_cluster_checks.utils.enums import Status
@@ -1727,4 +1728,148 @@ class TestVerifyNetworkDiagnosticsDisabled(RuleTestBase):
     @pytest.mark.parametrize("scenario_params", scenario_failed)
     def test_scenario_failed(self, scenario_params, tested_object):
         """Test failed scenarios."""
+        RuleTestBase.test_scenario_failed(self, scenario_params, tested_object)
+
+
+def create_mock_nfd_pod(name, phase, all_containers_ready=True):
+    """Create a mock NFD pod object."""
+    mock_pod = Mock()
+    container_statuses = [
+        {"ready": all_containers_ready},
+    ]
+    mock_pod.as_dict.return_value = {
+        "metadata": {"namespace": "openshift-nfd", "name": name},
+        "status": {
+            "phase": phase,
+            "containerStatuses": container_statuses,
+        },
+    }
+    return mock_pod
+
+
+def _nfd_subscriptions(include_nfd=True):
+    """Build a subscriptions response, optionally including the nfd subscription."""
+    items = []
+    if include_nfd:
+        items.append(
+            {
+                "metadata": {"name": "nfd-sub", "namespace": "openshift-nfd"},
+                "spec": {"name": "nfd", "source": "redhat-operators"},
+            }
+        )
+    items.append(
+        {
+            "metadata": {"name": "other-operator", "namespace": "openshift-operators"},
+            "spec": {"name": "other", "source": "redhat-operators"},
+        }
+    )
+    return {"items": items}
+
+
+class TestVerifyNfdOperatorHealth(RuleTestBase):
+    """Test VerifyNfdOperatorHealth rule."""
+
+    tested_type = VerifyNfdOperatorHealth
+
+    scenario_passed = [
+        RuleScenarioParams(
+            "NFD operator installed and all pods are healthy",
+            tested_object_mock_dict={
+                "oc_api.get_all_pods": Mock(
+                    return_value=[
+                        create_mock_nfd_pod("nfd-controller-manager-abc123", "Running", True),
+                        create_mock_nfd_pod("nfd-worker-xyz789", "Running", True),
+                    ]
+                ),
+            },
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_nfd_subscriptions(include_nfd=True))
+                ),
+            },
+        ),
+    ]
+
+    scenario_prerequisite_not_fulfilled = [
+        RuleScenarioParams(
+            "NFD operator subscription not found",
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_nfd_subscriptions(include_nfd=False))
+                ),
+            },
+        ),
+        RuleScenarioParams(
+            "no subscriptions exist in cluster",
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps({"items": []})
+                ),
+            },
+        ),
+    ]
+
+    scenario_failed = [
+        RuleScenarioParams(
+            "NFD operator installed but no pods found",
+            tested_object_mock_dict={
+                "oc_api.get_all_pods": Mock(return_value=[]),
+            },
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_nfd_subscriptions(include_nfd=True))
+                ),
+            },
+            failed_msg="No pods found in openshift-nfd namespace. " "NFD operator may not be fully deployed.",
+        ),
+        RuleScenarioParams(
+            "NFD operator installed but some pods are not running",
+            tested_object_mock_dict={
+                "oc_api.get_all_pods": Mock(
+                    return_value=[
+                        create_mock_nfd_pod("nfd-controller-manager-abc123", "Running", True),
+                        create_mock_nfd_pod("nfd-worker-xyz789", "Pending", True),
+                    ]
+                ),
+            },
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_nfd_subscriptions(include_nfd=True))
+                ),
+            },
+            failed_msg="NFD operator has unhealthy pods in openshift-nfd namespace:\n"
+            "  nfd-worker-xyz789 - Phase: Pending",
+        ),
+        RuleScenarioParams(
+            "NFD operator installed but containers not ready",
+            tested_object_mock_dict={
+                "oc_api.get_all_pods": Mock(
+                    return_value=[
+                        create_mock_nfd_pod("nfd-controller-manager-abc123", "Running", False),
+                    ]
+                ),
+            },
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_nfd_subscriptions(include_nfd=True))
+                ),
+            },
+            failed_msg="NFD operator has unhealthy pods in openshift-nfd namespace:\n"
+            "  nfd-controller-manager-abc123 - Running, Not all containers ready",
+        ),
+    ]
+
+    @pytest.mark.parametrize("scenario_params", scenario_prerequisite_not_fulfilled)
+    def test_prerequisite_not_fulfilled(self, scenario_params, tested_object):
+        """Test that prerequisite is not met when NFD operator is not installed."""
+        RuleTestBase.test_prerequisite_not_fulfilled(self, scenario_params, tested_object)
+
+    @pytest.mark.parametrize("scenario_params", scenario_passed)
+    def test_scenario_passed(self, scenario_params, tested_object):
+        """Test that rule passes when all NFD pods are healthy."""
+        RuleTestBase.test_scenario_passed(self, scenario_params, tested_object)
+
+    @pytest.mark.parametrize("scenario_params", scenario_failed)
+    def test_scenario_failed(self, scenario_params, tested_object):
+        """Test that rule fails when NFD pods are unhealthy or missing."""
         RuleTestBase.test_scenario_failed(self, scenario_params, tested_object)

--- a/tests/rules/k8s/test_k8s_validations.py
+++ b/tests/rules/k8s/test_k8s_validations.py
@@ -1820,7 +1820,7 @@ class TestVerifyNfdOperatorHealth(RuleTestBase):
                     json.dumps(_nfd_subscriptions(include_nfd=True))
                 ),
             },
-            failed_msg="No pods found in openshift-nfd namespace. " "NFD operator may not be fully deployed.",
+            failed_msg="No pods found in openshift-nfd namespace. NFD operator may not be fully deployed.",
         ),
         RuleScenarioParams(
             "NFD operator installed but some pods are not running",

--- a/tests/rules/k8s/test_k8s_validations.py
+++ b/tests/rules/k8s/test_k8s_validations.py
@@ -1857,6 +1857,22 @@ class TestVerifyNfdOperatorHealth(RuleTestBase):
             failed_msg="NFD operator has unhealthy pods in openshift-nfd namespace:\n"
             "  nfd-controller-manager-abc123 - Running, Not all containers ready",
         ),
+        RuleScenarioParams(
+            "NFD operator installed but pod status unknown",
+            tested_object_mock_dict={
+                "oc_api.get_all_pods": Mock(
+                    return_value=[
+                        create_mock_nfd_pod("nfd-controller-manager-abc123", "Succeeded", True),
+                    ]
+                ),
+            },
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_nfd_subscriptions(include_nfd=True))
+                ),
+            },
+            failed_msg="Failed to evaluate status for NFD pod(s):\n  nfd-controller-manager-abc123",
+        ),
     ]
 
     @pytest.mark.parametrize("scenario_params", scenario_prerequisite_not_fulfilled)


### PR DESCRIPTION
## Summary

- Adds `VerifyNfdOperatorHealth` rule in the K8s domain that verifies Node Feature Discovery operator pods are healthy
- **Prerequisite**: checks that an NFD operator Subscription (package name `nfd`) exists; marks rule as Not Applicable if NFD is not installed
- **Rule**: verifies all pods in `openshift-nfd` namespace are Running with all containers ready
- Includes comprehensive tests using `oc_cmd_output_dict` / `CmdOutput` pattern, helper function `_nfd_subscriptions()` to avoid config duplication, and docstrings on all test methods
- Wiki page content included in `wiki-K8s-Verify-NFD-operator-health.md` (to be published separately)

Ref: Q2CY2026 – Verify health of node feature discovery (NFD) operator

## Test plan

- [x] `flake8 --max-line-length=120 --extend-ignore=E203,W503` passes on changed files
- [x] `black --check --line-length=120` passes on changed files
- [x] `pytest tests/rules/k8s/test_k8s_validations.py::TestVerifyNfdOperatorHealth -v` — 6 passed, 4 skipped
- [x] `pytest tests/domains/test_k8s_domain.py -v` — 2 passed (rule count incremented to 14)
- [x] Tested on SNO cluster (api.sno.samsung.ran.lab:6443) — correctly returns `[NA] Verify NFD operator pods are healthy` with message "NFD operator subscription not found" when NFD is not installed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added a validation check for Node Feature Discovery operator health, ensuring all operator pods are healthy and ready in supported Kubernetes environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->