### PR TITLE
fix(PDRIVE-557): select_resources no longer swallows exceptions

### DIFF
--- a/src/in_cluster_checks/utils/oc_api_utils.py
+++ b/src/in_cluster_checks/utils/oc_api_utils.py
@@ -79,10 +79,11 @@ class OcApiUtils:
 
         Returns:
             - If single=True: Single resource object or None if not found
-            - If single=False: List of resource objects (empty list if none found or error)
+            - If single=False: List of resource objects (empty list if none found)
 
         Raises:
             ValueError: If both namespace and all_namespaces are specified
+            OpenShiftPythonException: If command fails (e.g., invalid resource type, timeout)
         """
         # Validate mutually exclusive parameters
         if namespace and all_namespaces:
@@ -104,48 +105,35 @@ class OcApiUtils:
         if global_config.debug_rule_flag:
             print(f"\n[DEBUG] Executing: {cmd_str}", flush=True)
 
-        try:
-            with oc.timeout(timeout):
-                # Build selector kwargs
-                selector_kwargs = {}
-                if labels:
-                    selector_kwargs["labels"] = labels
-                if all_namespaces:
-                    selector_kwargs["all_namespaces"] = True
+        with oc.timeout(timeout):
+            # Build selector kwargs
+            selector_kwargs = {}
+            if labels:
+                selector_kwargs["labels"] = labels
+            if all_namespaces:
+                selector_kwargs["all_namespaces"] = True
 
-                # Create selector with appropriate context
-                if namespace:
-                    with oc.project(namespace):
-                        selector = oc.selector(resource_type, **selector_kwargs)
-                        result = selector.object() if single else selector.objects()
-                else:
+            # Create selector with appropriate context
+            if namespace:
+                with oc.project(namespace):
                     selector = oc.selector(resource_type, **selector_kwargs)
-                    result = selector.object() if single else selector.objects()
+                    result = selector.object(ignore_not_found=True) if single else selector.objects()
+            else:
+                selector = oc.selector(resource_type, **selector_kwargs)
+                result = selector.object(ignore_not_found=True) if single else selector.objects()
 
-                # In debug mode, print results after execution
-                if global_config.debug_rule_flag:
-                    if single:
-                        print(f"[DEBUG] Result: {result.name() if result else 'None'}", flush=True)
-                    else:
-                        print(f"[DEBUG] Found {len(result)} resources", flush=True)
-                        if result:
-                            for obj in result:
-                                print(f"[DEBUG]   - {obj.name()}", flush=True)
-                    print("=" * 60, flush=True)
-
-                return result
-
-        except Exception as e:
-            # In debug mode, print exception with command context
+            # In debug mode, print results after execution
             if global_config.debug_rule_flag:
-                print(f"[DEBUG] Command '{cmd_str}' failed with exception: {e}", flush=True)
+                if single:
+                    print(f"[DEBUG] Result: {result.name() if result else 'None'}", flush=True)
+                else:
+                    print(f"[DEBUG] Found {len(result)} resources", flush=True)
+                    if result:
+                        for obj in result:
+                            print(f"[DEBUG]   - {obj.name()}", flush=True)
                 print("=" * 60, flush=True)
 
-            # Log error with command context
-            self.logger.error(f"Failed to execute command '{cmd_str}': {e}")
-
-            # Return appropriate empty value
-            return None if single else []
+            return result
 
     def get_pods(self, namespace: str = None, labels: dict = None, timeout: int = 30) -> list:
         """Get pods from namespace with optional label filtering.

--- a/tests/unit/utils/test_oc_api_utils.py
+++ b/tests/unit/utils/test_oc_api_utils.py
@@ -1,0 +1,91 @@
+"""Tests for OcApiUtils - select_resources error handling."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+from openshift_client import OpenShiftPythonException
+
+from in_cluster_checks import global_config
+from in_cluster_checks.utils.oc_api_utils import OcApiUtils
+
+
+@pytest.fixture
+def mock_operator():
+    operator = Mock()
+    operator._add_cmd_to_log = Mock()
+    operator.get_host_ip.return_value = "10.0.0.1"
+    return operator
+
+
+@pytest.fixture
+def oc_api(mock_operator):
+    return OcApiUtils(mock_operator)
+
+
+@pytest.fixture(autouse=True)
+def disable_debug():
+    original = global_config.debug_rule_flag
+    global_config.debug_rule_flag = False
+    yield
+    global_config.debug_rule_flag = original
+
+
+class TestSelectResources:
+    """Test select_resources behavior."""
+
+    @patch("in_cluster_checks.utils.oc_api_utils.oc")
+    def test_openshift_exception_propagates(self, mock_oc, oc_api):
+        mock_oc.timeout.return_value.__enter__ = Mock()
+        mock_oc.timeout.return_value.__exit__ = Mock(return_value=False)
+        mock_oc.selector.side_effect = OpenShiftPythonException("Unable to read object")
+
+        with pytest.raises(OpenShiftPythonException, match="Unable to read object"):
+            oc_api.select_resources("faketype")
+
+    @patch("in_cluster_checks.utils.oc_api_utils.oc")
+    def test_success_returns_objects(self, mock_oc, oc_api):
+        mock_obj1 = Mock()
+        mock_obj2 = Mock()
+        mock_selector = Mock()
+        mock_selector.objects.return_value = [mock_obj1, mock_obj2]
+
+        mock_oc.timeout.return_value.__enter__ = Mock()
+        mock_oc.timeout.return_value.__exit__ = Mock(return_value=False)
+        mock_oc.selector.return_value = mock_selector
+
+        result = oc_api.select_resources("pod")
+
+        assert result == [mock_obj1, mock_obj2]
+
+    @patch("in_cluster_checks.utils.oc_api_utils.oc")
+    def test_single_returns_object(self, mock_oc, oc_api):
+        mock_obj = Mock()
+        mock_selector = Mock()
+        mock_selector.object.return_value = mock_obj
+
+        mock_oc.timeout.return_value.__enter__ = Mock()
+        mock_oc.timeout.return_value.__exit__ = Mock(return_value=False)
+        mock_oc.selector.return_value = mock_selector
+
+        result = oc_api.select_resources("network.operator/cluster", single=True)
+
+        assert result == mock_obj
+        mock_selector.object.assert_called_once_with(ignore_not_found=True)
+
+    @patch("in_cluster_checks.utils.oc_api_utils.oc")
+    def test_single_not_found_returns_none(self, mock_oc, oc_api):
+        mock_selector = Mock()
+        mock_selector.object.return_value = None
+
+        mock_oc.timeout.return_value.__enter__ = Mock()
+        mock_oc.timeout.return_value.__exit__ = Mock(return_value=False)
+        mock_oc.selector.return_value = mock_selector
+
+        result = oc_api.select_resources("namespace/nonexistent", single=True)
+
+        assert result is None
+        mock_selector.object.assert_called_once_with(ignore_not_found=True)
+
+    def test_validates_mutually_exclusive_params(self, oc_api):
+        with pytest.raises(ValueError, match="Cannot specify both"):
+            oc_api.select_resources("pod", namespace="default", all_namespaces=True)


### PR DESCRIPTION
## Summary

`select_resources()` was silently catching all exceptions and returning empty values (`None` or `[]`), masking real failures like invalid resource types and timeouts. Callers couldn't distinguish between "no resources found" and "command failed."

### Changes

- Use `object(ignore_not_found=True)` for `single=True` so "not found" returns `None` instead of raising `OpenShiftPythonException`
- Remove the `try/except` block that silently swallowed all exceptions — let `OpenShiftPythonException` propagate naturally for real errors
- The framework already catches unhandled exceptions in `run_rule()` and marks results as SKIP

### OpenShift Client Exception Behavior (tested against real cluster)

| Scenario | Behavior |
|---|---|
| Valid resource, found | Returns object/list |
| Valid resource, not found (list) | Returns `[]` |
| Valid resource, not found (single) | Returns `None` ← **fixed with `ignore_not_found=True`** |
| Invalid resource type | Raises `OpenShiftPythonException` ← **no longer swallowed** |
| Timeout | Raises `OpenShiftPythonException` ← **no longer swallowed** |

### Caller verification

All callers verified — prerequisite checks already have `try/except`, and `run_rule()` callers are protected by the framework's exception handling (marks as SKIP).

## Test plan

- [x] Unit tests added for `select_resources` behavior
- [x] `pytest` — 680 passed, 245 skipped
- [x] `pre-commit run --all-files` — all checks pass
- [x] Ran full `in-cluster-checks` against live SNO cluster — no regressions (31 pass, 3 fail from real issues, 20 NA, 0 unexpected skips)

Jira: https://redhat.atlassian.net/browse/PDRIVE-557