### PR TITLE
Add VerifyAcmOperatorHealth rule to check ACM operator pods

### DIFF
--- a/src/in_cluster_checks/domains/k8s_domain.py
+++ b/src/in_cluster_checks/domains/k8s_domain.py
@@ -19,6 +19,7 @@ from in_cluster_checks.rules.k8s.k8s_validations import (
     ValidateAllDaemonsetsScheduled,
     ValidateAllPoliciesCompliant,
     ValidateNamespaceStatus,
+    VerifyAcmOperatorHealth,
     VerifyClusterOperatorsAvailable,
     VerifyInternalRegistry,
     VerifyNetworkDiagnosticsDisabled,
@@ -61,4 +62,5 @@ class K8sValidationDomain(RuleDomain):
             VerifyWebConsoleDisabled,
             VerifyNetworkDiagnosticsDisabled,
             VerifyNfdOperatorHealth,
+            VerifyAcmOperatorHealth,
         ]

--- a/src/in_cluster_checks/rules/k8s/k8s_validations.py
+++ b/src/in_cluster_checks/rules/k8s/k8s_validations.py
@@ -1106,6 +1106,7 @@ class VerifyAcmOperatorHealth(OrchestratorRule):
     title = "Verify ACM operator pods are healthy"
     supported_profiles = {"nokia-qa"}
     links = [
+        "https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-ACM-operator-health",
         "https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes"
         "/2.12/html/install/installing#installing-while-connected-online",
     ]
@@ -1167,9 +1168,7 @@ class VerifyAcmOperatorHealth(OrchestratorRule):
                 not_ready_pods.append(pod_status["status_message"])
 
         if unknown_status_pods:
-            return RuleResult.failed(
-                "Failed to evaluate status for ACM pod(s):\n  " + "\n  ".join(unknown_status_pods)
-            )
+            return RuleResult.failed("Failed to evaluate status for ACM pod(s):\n  " + "\n  ".join(unknown_status_pods))
 
         if not_ready_pods:
             message = f"ACM operator has unhealthy pods in {self.ACM_NAMESPACE} namespace:\n  "

--- a/src/in_cluster_checks/rules/k8s/k8s_validations.py
+++ b/src/in_cluster_checks/rules/k8s/k8s_validations.py
@@ -1167,12 +1167,15 @@ class VerifyAcmOperatorHealth(OrchestratorRule):
             if not pod_status["all_containers_ready"]:
                 not_ready_pods.append(pod_status["status_message"])
 
-        if unknown_status_pods:
-            return RuleResult.failed("Failed to evaluate status for ACM pod(s):\n  " + "\n  ".join(unknown_status_pods))
-
-        if not_ready_pods:
-            message = f"ACM operator has unhealthy pods in {self.ACM_NAMESPACE} namespace:\n  "
-            message += "\n  ".join(not_ready_pods)
-            return RuleResult.failed(message)
+        if unknown_status_pods or not_ready_pods:
+            parts = []
+            if unknown_status_pods:
+                parts.append("Failed to evaluate status for ACM pod(s):\n  " + "\n  ".join(unknown_status_pods))
+            if not_ready_pods:
+                parts.append(
+                    f"ACM operator has unhealthy pods in {self.ACM_NAMESPACE} namespace:\n  "
+                    + "\n  ".join(not_ready_pods)
+                )
+            return RuleResult.failed("\n\n".join(parts))
 
         return RuleResult.passed()

--- a/src/in_cluster_checks/rules/k8s/k8s_validations.py
+++ b/src/in_cluster_checks/rules/k8s/k8s_validations.py
@@ -1090,3 +1090,90 @@ class VerifyNetworkDiagnosticsDisabled(OrchestratorRule):
             return RuleResult.failed(message)
 
         return RuleResult.passed()
+
+
+class VerifyAcmOperatorHealth(OrchestratorRule):
+    """Verify Advanced Cluster Management (ACM) operator pods are healthy.
+
+    ACM orchestrates multicluster lifecycle management on the hub cluster.
+    This rule checks that the ACM operator has been installed (Subscription
+    exists) and that every pod in the open-cluster-management namespace is
+    Running with all containers ready.
+    """
+
+    objective_hosts = [Objectives.ORCHESTRATOR]
+    unique_name = "verify_acm_operator_health"
+    title = "Verify ACM operator pods are healthy"
+    supported_profiles = {"nokia-qa"}
+    links = [
+        "https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes"
+        "/2.12/html/install/installing#installing-while-connected-online",
+    ]
+
+    ACM_NAMESPACE = "open-cluster-management"
+
+    def is_prerequisite_fulfilled(self) -> PrerequisiteResult:
+        """Check that the ACM operator has been installed via a Subscription.
+
+        Queries the cluster for a Subscription resource with the
+        ``advanced-cluster-management`` package name.  If none is found the
+        rule is not applicable.
+        """
+        _, subscriptions_output, _ = self.oc_api.run_oc_command(
+            "get",
+            ["subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json"],
+            timeout=45,
+        )
+
+        try:
+            subscriptions_data = json.loads(subscriptions_output)
+        except json.JSONDecodeError as e:
+            raise UnExpectedSystemOutput(
+                ip=self.get_host_ip(),
+                cmd="oc get subscriptions.operators.coreos.com --all-namespaces -o json",
+                output=subscriptions_output,
+                message=f"Failed to parse operator subscriptions: {e}",
+            ) from e
+
+        for sub in subscriptions_data.get("items", []):
+            spec = sub.get("spec", {})
+            if spec.get("name") == "advanced-cluster-management":
+                return PrerequisiteResult.met()
+
+        return PrerequisiteResult.not_met(
+            "ACM operator subscription not found - "
+            "Advanced Cluster Management operator is not installed on this cluster"
+        )
+
+    def run_rule(self):
+        """Verify all pods in the open-cluster-management namespace are Running and Ready."""
+        pod_objects = self.oc_api.get_all_pods(namespace=self.ACM_NAMESPACE)
+
+        if not pod_objects:
+            return RuleResult.failed(
+                f"No pods found in {self.ACM_NAMESPACE} namespace. ACM operator may not be fully deployed."
+            )
+
+        not_ready_pods = []
+        unknown_status_pods = []
+
+        for pod in pod_objects:
+            pod_status = self.oc_api.get_pod_status(pod)
+            if pod_status is None:
+                pod_name = pod.as_dict().get("metadata", {}).get("name", "unknown")
+                unknown_status_pods.append(pod_name)
+                continue
+            if not pod_status["all_containers_ready"]:
+                not_ready_pods.append(pod_status["status_message"])
+
+        if unknown_status_pods:
+            return RuleResult.failed(
+                "Failed to evaluate status for ACM pod(s):\n  " + "\n  ".join(unknown_status_pods)
+            )
+
+        if not_ready_pods:
+            message = f"ACM operator has unhealthy pods in {self.ACM_NAMESPACE} namespace:\n  "
+            message += "\n  ".join(not_ready_pods)
+            return RuleResult.failed(message)
+
+        return RuleResult.passed()

--- a/src/in_cluster_checks/rules/k8s/k8s_validations.py
+++ b/src/in_cluster_checks/rules/k8s/k8s_validations.py
@@ -1104,7 +1104,7 @@ class VerifyAcmOperatorHealth(OrchestratorRule):
     objective_hosts = [Objectives.ORCHESTRATOR]
     unique_name = "verify_acm_operator_health"
     title = "Verify ACM operator pods are healthy"
-    supported_profiles = {"nokia-qa"}
+    supported_profiles = {"telco-base"}
     links = [
         "https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-ACM-operator-health",
         "https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes"

--- a/tests/domains/test_k8s_domain.py
+++ b/tests/domains/test_k8s_domain.py
@@ -9,6 +9,7 @@ from in_cluster_checks.rules.k8s.k8s_validations import (
     ValidateAllDaemonsetsScheduled,
     ValidateNamespaceStatus,
     ValidateAllPoliciesCompliant,
+    VerifyAcmOperatorHealth,
     VerifyClusterOperatorsAvailable,
     VerifyInternalRegistry,
     VerifyNetworkDiagnosticsDisabled,
@@ -28,7 +29,7 @@ def test_k8s_domain_rules():
     domain = K8sValidationDomain()
     rules = domain.get_rule_classes()
 
-    assert len(rules) == 15
+    assert len(rules) == 16
     assert AllPodsReadyAndRunning in rules
     assert NodesAreReady in rules
     assert NodesCpuAndMemoryStatus in rules
@@ -41,3 +42,4 @@ def test_k8s_domain_rules():
     assert VerifyWebConsoleDisabled in rules
     assert VerifyNetworkDiagnosticsDisabled in rules
     assert VerifyNfdOperatorHealth in rules
+    assert VerifyAcmOperatorHealth in rules

--- a/tests/rules/k8s/test_k8s_validations.py
+++ b/tests/rules/k8s/test_k8s_validations.py
@@ -20,6 +20,7 @@ from in_cluster_checks.rules.k8s.k8s_validations import (
     ValidateAllDaemonsetsScheduled,
     ValidateAllPoliciesCompliant,
     ValidateNamespaceStatus,
+    VerifyAcmOperatorHealth,
     VerifyClusterOperatorsAvailable,
     VerifyInternalRegistry,
     VerifyNetworkDiagnosticsDisabled,
@@ -1888,4 +1889,164 @@ class TestVerifyNfdOperatorHealth(RuleTestBase):
     @pytest.mark.parametrize("scenario_params", scenario_failed)
     def test_scenario_failed(self, scenario_params, tested_object):
         """Test that rule fails when NFD pods are unhealthy or missing."""
+        RuleTestBase.test_scenario_failed(self, scenario_params, tested_object)
+
+
+def create_mock_acm_pod(name, phase, all_containers_ready=True):
+    """Create a mock ACM pod object."""
+    mock_pod = Mock()
+    container_statuses = [
+        {"ready": all_containers_ready},
+    ]
+    mock_pod.as_dict.return_value = {
+        "metadata": {"namespace": "open-cluster-management", "name": name},
+        "status": {
+            "phase": phase,
+            "containerStatuses": container_statuses,
+        },
+    }
+    return mock_pod
+
+
+def _acm_subscriptions(include_acm=True):
+    """Build a subscriptions response, optionally including the ACM subscription."""
+    items = []
+    if include_acm:
+        items.append(
+            {
+                "metadata": {"name": "acm-sub", "namespace": "open-cluster-management"},
+                "spec": {"name": "advanced-cluster-management", "source": "redhat-operators"},
+            }
+        )
+    items.append(
+        {
+            "metadata": {"name": "other-operator", "namespace": "openshift-operators"},
+            "spec": {"name": "other", "source": "redhat-operators"},
+        }
+    )
+    return {"items": items}
+
+
+class TestVerifyAcmOperatorHealth(RuleTestBase):
+    """Test VerifyAcmOperatorHealth rule."""
+
+    tested_type = VerifyAcmOperatorHealth
+
+    scenario_passed = [
+        RuleScenarioParams(
+            "ACM operator installed and all pods are healthy",
+            tested_object_mock_dict={
+                "oc_api.get_all_pods": Mock(
+                    return_value=[
+                        create_mock_acm_pod("multiclusterhub-operator-abc123", "Running", True),
+                        create_mock_acm_pod("cluster-manager-xyz789", "Running", True),
+                    ]
+                ),
+            },
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_acm_subscriptions(include_acm=True))
+                ),
+            },
+        ),
+    ]
+
+    scenario_prerequisite_not_fulfilled = [
+        RuleScenarioParams(
+            "ACM operator subscription not found",
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_acm_subscriptions(include_acm=False))
+                ),
+            },
+        ),
+        RuleScenarioParams(
+            "no subscriptions exist in cluster",
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps({"items": []})
+                ),
+            },
+        ),
+    ]
+
+    scenario_failed = [
+        RuleScenarioParams(
+            "ACM operator installed but no pods found",
+            tested_object_mock_dict={
+                "oc_api.get_all_pods": Mock(return_value=[]),
+            },
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_acm_subscriptions(include_acm=True))
+                ),
+            },
+            failed_msg="No pods found in open-cluster-management namespace. ACM operator may not be fully deployed.",
+        ),
+        RuleScenarioParams(
+            "ACM operator installed but some pods are not running",
+            tested_object_mock_dict={
+                "oc_api.get_all_pods": Mock(
+                    return_value=[
+                        create_mock_acm_pod("multiclusterhub-operator-abc123", "Running", True),
+                        create_mock_acm_pod("cluster-manager-xyz789", "Pending", True),
+                    ]
+                ),
+            },
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_acm_subscriptions(include_acm=True))
+                ),
+            },
+            failed_msg="ACM operator has unhealthy pods in open-cluster-management namespace:\n"
+            "  cluster-manager-xyz789 - Phase: Pending",
+        ),
+        RuleScenarioParams(
+            "ACM operator installed but containers not ready",
+            tested_object_mock_dict={
+                "oc_api.get_all_pods": Mock(
+                    return_value=[
+                        create_mock_acm_pod("multiclusterhub-operator-abc123", "Running", False),
+                    ]
+                ),
+            },
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_acm_subscriptions(include_acm=True))
+                ),
+            },
+            failed_msg="ACM operator has unhealthy pods in open-cluster-management namespace:\n"
+            "  multiclusterhub-operator-abc123 - Running, Not all containers ready",
+        ),
+        RuleScenarioParams(
+            "ACM operator installed but pod status unknown",
+            tested_object_mock_dict={
+                "oc_api.get_all_pods": Mock(
+                    return_value=[
+                        create_mock_acm_pod("multiclusterhub-operator-abc123", "Succeeded", True),
+                    ]
+                ),
+            },
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_acm_subscriptions(include_acm=True))
+                ),
+            },
+            failed_msg="Failed to evaluate status for ACM pod(s):\n  multiclusterhub-operator-abc123",
+        ),
+    ]
+
+    @pytest.mark.parametrize("scenario_params", scenario_prerequisite_not_fulfilled)
+    def test_prerequisite_not_fulfilled(self, scenario_params, tested_object):
+        """Test that prerequisite is not met when ACM operator is not installed."""
+        RuleTestBase.test_prerequisite_not_fulfilled(self, scenario_params, tested_object)
+
+    @pytest.mark.parametrize("scenario_params", scenario_passed)
+    def test_scenario_passed(self, scenario_params, tested_object):
+        """Test that rule passes when all ACM pods are healthy."""
+        RuleTestBase.test_scenario_passed(self, scenario_params, tested_object)
+
+    @pytest.mark.parametrize("scenario_params", scenario_failed)
+    def test_scenario_failed(self, scenario_params, tested_object):
+        """Test that rule fails when ACM pods are unhealthy or missing."""
         RuleTestBase.test_scenario_failed(self, scenario_params, tested_object)


### PR DESCRIPTION
Prerequisite checks for advanced-cluster-management subscription; run_rule verifies all pods in the open-cluster-management namespace are Running with containers ready. Tested on hub (3-node PASS) and non-hub (sno without pods NA) clusters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added health check validation for Advanced Cluster Management (ACM) operators in Kubernetes/OpenShift clusters to verify ACM operator pods are present and ready.
* **Tests**
  * Added unit tests covering ACM present, missing, unhealthy, and prerequisite-not-met scenarios to ensure correct rule behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->