### PR TITLE
fix(PDRIVE-598): pass instead of warn when no RHACM policies found

### DIFF
--- a/src/in_cluster_checks/rules/k8s/k8s_validations.py
+++ b/src/in_cluster_checks/rules/k8s/k8s_validations.py
@@ -661,7 +661,7 @@ class ValidateAllPoliciesCompliant(OrchestratorRule):
         items = policies_data.get("items", [])
         # Check if there are any policies
         if not items:
-            return RuleResult.warning("No policies found in cluster")
+            return RuleResult.passed()
 
         non_compliant_policies = []
 

--- a/tests/rules/k8s/test_k8s_validations.py
+++ b/tests/rules/k8s/test_k8s_validations.py
@@ -1094,7 +1094,6 @@ class TestValidateAllPoliciesCompliant(RuleTestBase):
     # No policies found
     no_policies = {"items": []}
 
-    # Scenario where all policies are compliant
     scenario_passed = [
         RuleScenarioParams(
             "all policies are compliant",
@@ -1102,8 +1101,12 @@ class TestValidateAllPoliciesCompliant(RuleTestBase):
                 "oc_api.run_oc_command": Mock(return_value=(0, json.dumps(all_compliant_policies), ""))
             },
         ),
+        RuleScenarioParams(
+            "no policies found in cluster",
+            tested_object_mock_dict={"oc_api.run_oc_command": Mock(return_value=(0, json.dumps(no_policies), ""))},
+        ),
     ]
-    # Scenario where some policies are non-compliant
+
     scenario_failed = [
         RuleScenarioParams(
             "some policies are non-compliant",
@@ -1116,15 +1119,6 @@ class TestValidateAllPoliciesCompliant(RuleTestBase):
         ),
     ]
 
-    # Scenario where no policies are found
-    scenario_warning = [
-        RuleScenarioParams(
-            "no policies found in cluster",
-            tested_object_mock_dict={"oc_api.run_oc_command": Mock(return_value=(0, json.dumps(no_policies), ""))},
-            failed_msg="No policies found in cluster",
-        ),
-    ]
-
     @pytest.mark.parametrize("scenario_params", scenario_passed)
     def test_scenario_passed(self, scenario_params, tested_object):
         RuleTestBase.test_scenario_passed(self, scenario_params, tested_object)
@@ -1132,10 +1126,6 @@ class TestValidateAllPoliciesCompliant(RuleTestBase):
     @pytest.mark.parametrize("scenario_params", scenario_failed)
     def test_scenario_failed(self, scenario_params, tested_object):
         RuleTestBase.test_scenario_failed(self, scenario_params, tested_object)
-
-    @pytest.mark.parametrize("scenario_params", scenario_warning)
-    def test_scenario_warning(self, scenario_params, tested_object):
-        RuleTestBase.test_scenario_warning(self, scenario_params, tested_object)
 
 
 def create_mock_registry_pod(name, namespace, phase, all_containers_ready=True):


### PR DESCRIPTION
## Summary

- `ValidateAllPoliciesCompliant` now returns PASS instead of WARNING when RHACM is installed but no policies are configured
- RHACM policies are optional (governance is one feature among many), so their absence is not an issue
- Removes false alarm noise on clusters that use RHACM for management without governance policies

## Jira

[PDRIVE-598](https://redhat.atlassian.net/browse/PDRIVE-598)

## Test plan

- [x] `pytest tests/rules/k8s/test_k8s_validations.py::TestValidateAllPoliciesCompliant -v` — all pass
- [x] `pre-commit run --all-files` — all pass


[PDRIVE-598]: https://redhat.atlassian.net/browse/PDRIVE-598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * When no Kubernetes policies are found in a cluster, the validation now passes instead of returning a warning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->