### PR TITLE
Fix ValidateAllPoliciesCompliant: skip rule when no policies are defined

### DIFF
--- a/src/in_cluster_checks/rules/k8s/k8s_validations.py
+++ b/src/in_cluster_checks/rules/k8s/k8s_validations.py
@@ -628,7 +628,6 @@ class OpenshiftOperatorStatus(OrchestratorRule):
         )
 
 
-# Rule to validate all policies are compliant
 class ValidateAllPoliciesCompliant(OrchestratorRule):
     """Validate all Open Cluster Management policies are compliant."""
 
@@ -638,34 +637,60 @@ class ValidateAllPoliciesCompliant(OrchestratorRule):
     supported_profiles = {"nokia-qa"}
     links = ["https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-policies-compliance"]
 
-    def run_rule(self):
-        """Check if all OCM policies are in Compliant state"""
+    _POLICIES_RESOURCE = "policies.policy.open-cluster-management.io"
+
+    def is_prerequisite_fulfilled(self) -> PrerequisiteResult:
+        """Check that RHACM policies are defined in the cluster.
+
+        Queries for policy resources.  If the CRD is missing (RHACM not
+        installed) or no policies are defined, the rule is not applicable.
+        """
         try:
-            # Run the oc command to get all policies from all namespaces
             _, policies_output, _ = self.oc_api.run_oc_command(
-                "get", ["policies.policy.open-cluster-management.io", "--all-namespaces", "-o", "json"], timeout=45
+                "get", [self._POLICIES_RESOURCE, "--all-namespaces", "-o", "json"], timeout=45
             )
         except UnExpectedSystemOutput:
-            return RuleResult.failed("Failed to get policies from cluster")
+            return PrerequisiteResult.not_met(
+                "RHACM policies CRD not available - "
+                "Open Cluster Management governance is not installed on this cluster"
+            )
 
         try:
             policies_data = json.loads(policies_output)
         except json.JSONDecodeError as e:
             raise UnExpectedSystemOutput(
                 ip=self.get_host_ip(),
-                cmd="oc get policies.policy.open-cluster-management.io --all-namespaces -o json",
+                cmd=f"oc get {self._POLICIES_RESOURCE} --all-namespaces -o json",
                 output=policies_output,
                 message=f"Failed to parse JSON: {e}",
+            ) from e
+
+        if not policies_data.get("items", []):
+            return PrerequisiteResult.not_met(
+                "No RHACM policies defined in cluster - governance policies are not configured"
             )
 
-        items = policies_data.get("items", [])
-        # Check if there are any policies
-        if not items:
-            return RuleResult.warning("No policies found in cluster")
+        return PrerequisiteResult.met()
+
+    def run_rule(self):
+        """Check if all OCM policies are in Compliant state."""
+        _, policies_output, _ = self.oc_api.run_oc_command(
+            "get", [self._POLICIES_RESOURCE, "--all-namespaces", "-o", "json"], timeout=45
+        )
+
+        try:
+            policies_data = json.loads(policies_output)
+        except json.JSONDecodeError as e:
+            raise UnExpectedSystemOutput(
+                ip=self.get_host_ip(),
+                cmd=f"oc get {self._POLICIES_RESOURCE} --all-namespaces -o json",
+                output=policies_output,
+                message=f"Failed to parse JSON: {e}",
+            ) from e
 
         non_compliant_policies = []
 
-        for policy in items:
+        for policy in policies_data.get("items", []):
             metadata = policy.get("metadata", {})
             name = metadata.get("name", "unknown")
             namespace = metadata.get("namespace", "unknown")

--- a/tests/rules/k8s/test_k8s_validations.py
+++ b/tests/rules/k8s/test_k8s_validations.py
@@ -1060,7 +1060,8 @@ class TestValidateAllPoliciesCompliant(RuleTestBase):
 
     tested_type = ValidateAllPoliciesCompliant
 
-    # Sample policy data - all compliant
+    _POLICIES_CMD_KEY = ("get", ("policies.policy.open-cluster-management.io", "--all-namespaces", "-o", "json"))
+
     all_compliant_policies = {
         "items": [
             {
@@ -1074,7 +1075,6 @@ class TestValidateAllPoliciesCompliant(RuleTestBase):
         ]
     }
 
-    # Sample policy data - some non-compliant
     some_non_compliant_policies = {
         "items": [
             {
@@ -1092,24 +1092,22 @@ class TestValidateAllPoliciesCompliant(RuleTestBase):
         ]
     }
 
-    # No policies found
     no_policies = {"items": []}
 
-    # Scenario where all policies are compliant
     scenario_passed = [
         RuleScenarioParams(
             "all policies are compliant",
-            tested_object_mock_dict={
-                "oc_api.run_oc_command": Mock(return_value=(0, json.dumps(all_compliant_policies), ""))
+            oc_cmd_output_dict={
+                _POLICIES_CMD_KEY: CmdOutput(json.dumps(all_compliant_policies)),
             },
         ),
     ]
-    # Scenario where some policies are non-compliant
+
     scenario_failed = [
         RuleScenarioParams(
             "some policies are non-compliant",
-            tested_object_mock_dict={
-                "oc_api.run_oc_command": Mock(return_value=(0, json.dumps(some_non_compliant_policies), ""))
+            oc_cmd_output_dict={
+                _POLICIES_CMD_KEY: CmdOutput(json.dumps(some_non_compliant_policies)),
             },
             failed_msg="There are 2 non-compliant policies:\n"
             "  open-cluster-management/policy2 - NonCompliant\n"
@@ -1117,12 +1115,12 @@ class TestValidateAllPoliciesCompliant(RuleTestBase):
         ),
     ]
 
-    # Scenario where no policies are found
-    scenario_warning = [
+    scenario_prerequisite_not_fulfilled = [
         RuleScenarioParams(
-            "no policies found in cluster",
-            tested_object_mock_dict={"oc_api.run_oc_command": Mock(return_value=(0, json.dumps(no_policies), ""))},
-            failed_msg="No policies found in cluster",
+            "no policies defined in cluster",
+            oc_cmd_output_dict={
+                _POLICIES_CMD_KEY: CmdOutput(json.dumps(no_policies)),
+            },
         ),
     ]
 
@@ -1134,9 +1132,9 @@ class TestValidateAllPoliciesCompliant(RuleTestBase):
     def test_scenario_failed(self, scenario_params, tested_object):
         RuleTestBase.test_scenario_failed(self, scenario_params, tested_object)
 
-    @pytest.mark.parametrize("scenario_params", scenario_warning)
-    def test_scenario_warning(self, scenario_params, tested_object):
-        RuleTestBase.test_scenario_warning(self, scenario_params, tested_object)
+    @pytest.mark.parametrize("scenario_params", scenario_prerequisite_not_fulfilled)
+    def test_prerequisite_not_fulfilled(self, scenario_params, tested_object):
+        RuleTestBase.test_prerequisite_not_fulfilled(self, scenario_params, tested_object)
 
 
 def create_mock_registry_pod(name, namespace, phase, all_containers_ready=True):


### PR DESCRIPTION
RHACM policies are optional — governance is one feature among many. Add is_prerequisite_fulfilled() so the rule is skipped (not warned/failed) when no policies exist or the CRD is missing.

Ref: PDRIVE-598
https://redhat.atlassian.net/browse/PDRIVE-598?focusedCommentId=17021305&sourceType=mention
@yogeshahiray 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation to check cluster-wide RHACM/Open Cluster Management policy compliance and surface non-compliant policies.

* **Bug Fixes**
  * Empty policy sets are now treated as a missing prerequisite rather than a runtime warning.
  * Improved error handling for malformed or unexpected policy responses.

* **Tests**
  * Updated tests to cover the prerequisite-not-fulfilled scenario and consolidated policy-fetch test setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->