### PR TITLE
Feature/far operator health

### DIFF
--- a/src/in_cluster_checks/domains/k8s_domain.py
+++ b/src/in_cluster_checks/domains/k8s_domain.py
@@ -21,6 +21,7 @@ from in_cluster_checks.rules.k8s.k8s_validations import (
     ValidateNamespaceStatus,
     VerifyAcmOperatorHealth,
     VerifyClusterOperatorsAvailable,
+    VerifyFarOperatorHealth,
     VerifyInternalRegistry,
     VerifyNetworkDiagnosticsDisabled,
     VerifyNfdOperatorHealth,
@@ -63,4 +64,5 @@ class K8sValidationDomain(RuleDomain):
             VerifyNetworkDiagnosticsDisabled,
             VerifyNfdOperatorHealth,
             VerifyAcmOperatorHealth,
+            VerifyFarOperatorHealth,
         ]

--- a/src/in_cluster_checks/rules/k8s/k8s_validations.py
+++ b/src/in_cluster_checks/rules/k8s/k8s_validations.py
@@ -962,7 +962,37 @@ class VerifyWebConsoleDisabled(OrchestratorRule):
         return RuleResult.passed()
 
 
-class VerifyNfdOperatorHealth(OrchestratorRule):
+class SubscriptionOperatorRule(OrchestratorRule):
+    """Base class for operator health validation rules that check OLM subscriptions.
+
+    Subclasses must define:
+        operator_subscription_name (str): The operator package name in the Subscription (e.g., "nfd")
+        operator_display_name (str): Human-readable operator name for error messages (e.g., "Node Feature Discovery")
+    """
+
+    operator_subscription_name: str = NotImplemented
+    operator_display_name: str = NotImplemented
+
+    def is_prerequisite_fulfilled(self) -> PrerequisiteResult:
+        """Check that the operator has been installed via a Subscription.
+
+        Queries the cluster for a Subscription resource with the
+        operator_subscription_name package.  If none is found the rule is not applicable.
+        """
+        subscriptions_data = self.oc_api.get_operator_subscriptions()
+
+        for sub in subscriptions_data.get("items", []):
+            spec = sub.get("spec", {})
+            if spec.get("name") == self.operator_subscription_name:
+                return PrerequisiteResult.met()
+
+        return PrerequisiteResult.not_met(
+            f"{self.operator_subscription_name} operator subscription not found - "
+            f"{self.operator_display_name} operator is not installed on this cluster"
+        )
+
+
+class VerifyNfdOperatorHealth(SubscriptionOperatorRule):
     """Verify Node Feature Discovery (NFD) operator pods are healthy.
 
     NFD sets the stage for cluster functionality by labelling nodes with
@@ -981,38 +1011,10 @@ class VerifyNfdOperatorHealth(OrchestratorRule):
         "/psap-node-feature-discovery-operator.html",
     ]
 
+    operator_subscription_name = "nfd"
+    operator_display_name = "Node Feature Discovery"
+
     NFD_NAMESPACE = "openshift-nfd"
-
-    def is_prerequisite_fulfilled(self) -> PrerequisiteResult:
-        """Check that the NFD operator has been installed via a Subscription.
-
-        Queries the cluster for a Subscription resource with the
-        ``nfd`` package name.  If none is found the rule is not applicable.
-        """
-        _, subscriptions_output, _ = self.oc_api.run_oc_command(
-            "get",
-            ["subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json"],
-            timeout=45,
-        )
-
-        try:
-            subscriptions_data = json.loads(subscriptions_output)
-        except json.JSONDecodeError as e:
-            raise UnExpectedSystemOutput(
-                ip=self.get_host_ip(),
-                cmd="oc get subscriptions.operators.coreos.com --all-namespaces -o json",
-                output=subscriptions_output,
-                message=f"Failed to parse operator subscriptions: {e}",
-            ) from e
-
-        for sub in subscriptions_data.get("items", []):
-            spec = sub.get("spec", {})
-            if spec.get("name") == "nfd":
-                return PrerequisiteResult.met()
-
-        return PrerequisiteResult.not_met(
-            "NFD operator subscription not found - Node Feature Discovery operator is not installed on this cluster"
-        )
 
     def run_rule(self):
         """Verify all pods in the openshift-nfd namespace are Running and Ready."""
@@ -1117,7 +1119,7 @@ class VerifyNetworkDiagnosticsDisabled(OrchestratorRule):
         return RuleResult.passed()
 
 
-class VerifyAcmOperatorHealth(OrchestratorRule):
+class VerifyAcmOperatorHealth(SubscriptionOperatorRule):
     """Verify Advanced Cluster Management (ACM) operator pods are healthy.
 
     ACM orchestrates multicluster lifecycle management on the hub cluster.
@@ -1136,40 +1138,10 @@ class VerifyAcmOperatorHealth(OrchestratorRule):
         "/2.12/html/install/installing#installing-while-connected-online",
     ]
 
+    operator_subscription_name = "advanced-cluster-management"
+    operator_display_name = "Advanced Cluster Management"
+
     ACM_NAMESPACE = "open-cluster-management"
-
-    def is_prerequisite_fulfilled(self) -> PrerequisiteResult:
-        """Check that the ACM operator has been installed via a Subscription.
-
-        Queries the cluster for a Subscription resource with the
-        ``advanced-cluster-management`` package name.  If none is found the
-        rule is not applicable.
-        """
-        _, subscriptions_output, _ = self.oc_api.run_oc_command(
-            "get",
-            ["subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json"],
-            timeout=45,
-        )
-
-        try:
-            subscriptions_data = json.loads(subscriptions_output)
-        except json.JSONDecodeError as e:
-            raise UnExpectedSystemOutput(
-                ip=self.get_host_ip(),
-                cmd="oc get subscriptions.operators.coreos.com --all-namespaces -o json",
-                output=subscriptions_output,
-                message=f"Failed to parse operator subscriptions: {e}",
-            ) from e
-
-        for sub in subscriptions_data.get("items", []):
-            spec = sub.get("spec", {})
-            if spec.get("name") == "advanced-cluster-management":
-                return PrerequisiteResult.met()
-
-        return PrerequisiteResult.not_met(
-            "ACM operator subscription not found - "
-            "Advanced Cluster Management operator is not installed on this cluster"
-        )
 
     def run_rule(self):
         """Verify all pods in the open-cluster-management namespace are Running and Ready."""
@@ -1199,6 +1171,64 @@ class VerifyAcmOperatorHealth(OrchestratorRule):
             if not_ready_pods:
                 parts.append(
                     f"ACM operator has unhealthy pods in {self.ACM_NAMESPACE} namespace:\n  "
+                    + "\n  ".join(not_ready_pods)
+                )
+            return RuleResult.failed("\n\n".join(parts))
+
+        return RuleResult.passed()
+
+
+class VerifyFarOperatorHealth(SubscriptionOperatorRule):
+    """Verify Fence Agents Remediation (FAR) operator pods are healthy.
+
+    FAR provides automatic node fencing and recovery for hardware failures.
+    This rule checks that the FAR operator has been installed (Subscription
+    exists) and that every pod in the openshift-workload-availability namespace
+    is Running with all containers ready.
+    """
+
+    objective_hosts = [Objectives.ORCHESTRATOR]
+    unique_name = "verify_far_operator_health"
+    title = "Verify FAR operator pods are healthy"
+    supported_profiles = {"telco-base"}
+    links = [
+        "https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-FAR-operator-health",
+        "https://docs.openshift.com/container-platform/4.18/nodes/nodes/eco-fence-agents-remediation-operator.html",
+    ]
+
+    operator_subscription_name = "fence-agents-remediation"
+    operator_display_name = "Fence Agents Remediation"
+
+    FAR_NAMESPACE = "openshift-workload-availability"
+
+    def run_rule(self):
+        """Verify all pods in the openshift-workload-availability namespace are Running and Ready."""
+        pod_objects = self.oc_api.get_all_pods(namespace=self.FAR_NAMESPACE)
+
+        if not pod_objects:
+            return RuleResult.failed(
+                f"No pods found in {self.FAR_NAMESPACE} namespace. FAR operator may not be fully deployed."
+            )
+
+        not_ready_pods = []
+        unknown_status_pods = []
+
+        for pod in pod_objects:
+            pod_status = self.oc_api.get_pod_status(pod)
+            if pod_status is None:
+                pod_name = pod.as_dict().get("metadata", {}).get("name", "unknown")
+                unknown_status_pods.append(pod_name)
+                continue
+            if not pod_status["all_containers_ready"]:
+                not_ready_pods.append(pod_status["status_message"])
+
+        if unknown_status_pods or not_ready_pods:
+            parts = []
+            if unknown_status_pods:
+                parts.append("Failed to evaluate status for FAR pod(s):\n  " + "\n  ".join(unknown_status_pods))
+            if not_ready_pods:
+                parts.append(
+                    f"FAR operator has unhealthy pods in {self.FAR_NAMESPACE} namespace:\n  "
                     + "\n  ".join(not_ready_pods)
                 )
             return RuleResult.failed("\n\n".join(parts))

--- a/src/in_cluster_checks/utils/oc_api_utils.py
+++ b/src/in_cluster_checks/utils/oc_api_utils.py
@@ -21,12 +21,13 @@ Usage:
 """
 
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import openshift_client as oc
 
 from in_cluster_checks import global_config
 from in_cluster_checks.core.exceptions import UnExpectedSystemOutput
+from in_cluster_checks.utils.parsing_utils import parse_json
 from in_cluster_checks.utils.safe_cmd_string import SafeCmdString
 
 
@@ -368,3 +369,26 @@ class OcApiUtils:
             "all_containers_ready": phase == "Running" and all_ready,
             "status_message": status_message,
         }
+
+    def get_operator_subscriptions(self, namespace: Optional[str] = None) -> dict:
+        """Fetch operator Subscription resources from the cluster.
+
+        Args:
+            namespace: Optional namespace to query. Defaults to --all-namespaces.
+
+        Returns:
+            Parsed JSON dict of the subscriptions response.
+
+        Raises:
+            UnExpectedSystemOutput: If the command fails or JSON output cannot be parsed.
+        """
+        if namespace:
+            args = ["subscriptions.operators.coreos.com", "-n", namespace, "-o", "json"]
+            cmd_desc = f"oc get subscriptions.operators.coreos.com -n {namespace} -o json"
+        else:
+            args = ["subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json"]
+            cmd_desc = "oc get subscriptions.operators.coreos.com --all-namespaces -o json"
+
+        _, subscriptions_output, _ = self.run_oc_command("get", args, timeout=45)
+
+        return parse_json(subscriptions_output, cmd_desc, self.operator.get_host_ip())

--- a/tests/domains/test_k8s_domain.py
+++ b/tests/domains/test_k8s_domain.py
@@ -11,6 +11,7 @@ from in_cluster_checks.rules.k8s.k8s_validations import (
     ValidateAllPoliciesCompliant,
     VerifyAcmOperatorHealth,
     VerifyClusterOperatorsAvailable,
+    VerifyFarOperatorHealth,
     VerifyInternalRegistry,
     VerifyNetworkDiagnosticsDisabled,
     VerifyNfdOperatorHealth,
@@ -29,7 +30,7 @@ def test_k8s_domain_rules():
     domain = K8sValidationDomain()
     rules = domain.get_rule_classes()
 
-    assert len(rules) == 16
+    assert len(rules) == 17
     assert AllPodsReadyAndRunning in rules
     assert NodesAreReady in rules
     assert NodesCpuAndMemoryStatus in rules
@@ -43,3 +44,4 @@ def test_k8s_domain_rules():
     assert VerifyNetworkDiagnosticsDisabled in rules
     assert VerifyNfdOperatorHealth in rules
     assert VerifyAcmOperatorHealth in rules
+    assert VerifyFarOperatorHealth in rules

--- a/tests/rules/k8s/test_k8s_validations.py
+++ b/tests/rules/k8s/test_k8s_validations.py
@@ -22,6 +22,7 @@ from in_cluster_checks.rules.k8s.k8s_validations import (
     ValidateNamespaceStatus,
     VerifyAcmOperatorHealth,
     VerifyClusterOperatorsAvailable,
+    VerifyFarOperatorHealth,
     VerifyInternalRegistry,
     VerifyNetworkDiagnosticsDisabled,
     VerifyNfdOperatorHealth,
@@ -2047,4 +2048,196 @@ class TestVerifyAcmOperatorHealth(RuleTestBase):
     @pytest.mark.parametrize("scenario_params", scenario_failed)
     def test_scenario_failed(self, scenario_params, tested_object):
         """Test that rule fails when ACM pods are unhealthy or missing."""
+        RuleTestBase.test_scenario_failed(self, scenario_params, tested_object)
+
+
+def create_mock_far_pod(name, phase, all_containers_ready=True):
+    """Create a mock FAR pod object."""
+    mock_pod = Mock()
+    container_statuses = [
+        {"ready": all_containers_ready},
+    ]
+    mock_pod.as_dict.return_value = {
+        "metadata": {"namespace": "openshift-workload-availability", "name": name},
+        "status": {
+            "phase": phase,
+            "containerStatuses": container_statuses,
+        },
+    }
+    return mock_pod
+
+
+def _far_subscriptions(include_far=True):
+    """Build a subscriptions response, optionally including the FAR subscription."""
+    items = []
+    if include_far:
+        items.append(
+            {
+                "metadata": {"name": "far-sub", "namespace": "openshift-workload-availability"},
+                "spec": {"name": "fence-agents-remediation", "source": "redhat-operators"},
+            }
+        )
+    return {"items": items}
+
+
+class TestVerifyFarOperatorHealth(RuleTestBase):
+    """Tests for VerifyFarOperatorHealth rule."""
+
+    tested_type = VerifyFarOperatorHealth
+
+    scenario_prerequisite_fulfilled = [
+        RuleScenarioParams(
+            "FAR operator subscription found",
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_far_subscriptions(include_far=True))
+                ),
+            },
+        ),
+    ]
+
+    scenario_passed = [
+        RuleScenarioParams(
+            "FAR operator installed and all pods healthy",
+            tested_object_mock_dict={
+                "oc_api.get_all_pods": Mock(
+                    return_value=[
+                        create_mock_far_pod("fence-agents-remediation-controller-manager-abc123", "Running", True),
+                        create_mock_far_pod("fence-agents-remediation-worker-xyz789", "Running", True),
+                    ]
+                ),
+            },
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_far_subscriptions(include_far=True))
+                ),
+            },
+        ),
+    ]
+
+    scenario_prerequisite_not_fulfilled = [
+        RuleScenarioParams(
+            "FAR operator subscription not found",
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_far_subscriptions(include_far=False))
+                ),
+            },
+        ),
+        RuleScenarioParams(
+            "no subscriptions exist in cluster",
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps({"items": []})
+                ),
+            },
+        ),
+    ]
+
+    scenario_failed = [
+        RuleScenarioParams(
+            "FAR operator installed but no pods found",
+            tested_object_mock_dict={
+                "oc_api.get_all_pods": Mock(return_value=[]),
+            },
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_far_subscriptions(include_far=True))
+                ),
+            },
+            failed_msg="No pods found in openshift-workload-availability namespace."
+            " FAR operator may not be fully deployed.",
+        ),
+        RuleScenarioParams(
+            "FAR operator installed but some pods are not running",
+            tested_object_mock_dict={
+                "oc_api.get_all_pods": Mock(
+                    return_value=[
+                        create_mock_far_pod("fence-agents-remediation-controller-manager-abc123", "Running", True),
+                        create_mock_far_pod("fence-agents-remediation-worker-xyz789", "Pending", True),
+                    ]
+                ),
+            },
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_far_subscriptions(include_far=True))
+                ),
+            },
+            failed_msg="FAR operator has unhealthy pods in openshift-workload-availability namespace:\n"
+            "  fence-agents-remediation-worker-xyz789 - Phase: Pending",
+        ),
+        RuleScenarioParams(
+            "FAR operator installed but containers not ready",
+            tested_object_mock_dict={
+                "oc_api.get_all_pods": Mock(
+                    return_value=[
+                        create_mock_far_pod("fence-agents-remediation-controller-manager-abc123", "Running", False),
+                    ]
+                ),
+            },
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_far_subscriptions(include_far=True))
+                ),
+            },
+            failed_msg="FAR operator has unhealthy pods in openshift-workload-availability namespace:\n"
+            "  fence-agents-remediation-controller-manager-abc123 - Running, Not all containers ready",
+        ),
+        RuleScenarioParams(
+            "FAR operator installed but pod status unknown",
+            tested_object_mock_dict={
+                "oc_api.get_all_pods": Mock(
+                    return_value=[
+                        create_mock_far_pod("fence-agents-remediation-controller-manager-abc123", "Succeeded", True),
+                    ]
+                ),
+            },
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_far_subscriptions(include_far=True))
+                ),
+            },
+            failed_msg="Failed to evaluate status for FAR pod(s):\n"
+            "  fence-agents-remediation-controller-manager-abc123",
+        ),
+        RuleScenarioParams(
+            "FAR operator installed with unknown and unhealthy pods",
+            tested_object_mock_dict={
+                "oc_api.get_all_pods": Mock(
+                    return_value=[
+                        create_mock_far_pod("fence-agents-remediation-controller-manager-abc123", "Succeeded", True),
+                        create_mock_far_pod("fence-agents-remediation-worker-xyz789", "Running", False),
+                    ]
+                ),
+            },
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_far_subscriptions(include_far=True))
+                ),
+            },
+            failed_msg="Failed to evaluate status for FAR pod(s):\n"
+            "  fence-agents-remediation-controller-manager-abc123\n\n"
+            "FAR operator has unhealthy pods in openshift-workload-availability namespace:\n"
+            "  fence-agents-remediation-worker-xyz789 - Running, Not all containers ready",
+        ),
+    ]
+
+    @pytest.mark.parametrize("scenario_params", scenario_prerequisite_fulfilled)
+    def test_prerequisite_fulfilled(self, scenario_params, tested_object):
+        """Test that prerequisite is met when FAR operator is installed."""
+        RuleTestBase.test_prerequisite_fulfilled(self, scenario_params, tested_object)
+
+    @pytest.mark.parametrize("scenario_params", scenario_prerequisite_not_fulfilled)
+    def test_prerequisite_not_fulfilled(self, scenario_params, tested_object):
+        """Test that prerequisite is not met when FAR operator is not installed."""
+        RuleTestBase.test_prerequisite_not_fulfilled(self, scenario_params, tested_object)
+
+    @pytest.mark.parametrize("scenario_params", scenario_passed)
+    def test_scenario_passed(self, scenario_params, tested_object):
+        """Test that rule passes when all FAR pods are healthy."""
+        RuleTestBase.test_scenario_passed(self, scenario_params, tested_object)
+
+    @pytest.mark.parametrize("scenario_params", scenario_failed)
+    def test_scenario_failed(self, scenario_params, tested_object):
+        """Test that rule fails when FAR pods are unhealthy or missing."""
         RuleTestBase.test_scenario_failed(self, scenario_params, tested_object)


### PR DESCRIPTION
## Summary
- Add new `VerifyFarOperatorHealth` rule that verifies Fence Agents Remediation (FAR) operator pods are healthy
- Prerequisite checks for a `fence-agents-remediation` Subscription — rule is skipped if FAR is not installed
- Validates all pods in `openshift-workload-availability` namespace are Running with all containers ready; reports both unknown-status and not-ready pods in a single failure message
- Registered in `K8sValidationDomain` with `supported_profiles = {"telco-base"}`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a FAR (Fence Agents Remediation) operator health check to the Kubernetes/OpenShift healthcheck domain; verifies FAR pods are present, running, and have all containers ready.

* **Bug Fixes**
  * Improved prerequisite handling for operator health checks so operator subscription presence is detected more reliably.

* **Tests**
  * Added comprehensive tests covering FAR validator: passing, prerequisite, and multiple failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->