### PR TITLE
fix: improve OrphanCsiVolumes prerequisite handling and TLS cert form…

### DIFF
--- a/src/in_cluster_checks/rules/security/tls_certificate_validations.py
+++ b/src/in_cluster_checks/rules/security/tls_certificate_validations.py
@@ -90,8 +90,10 @@ class TlsCertificateExpiry(OrchestratorRule):
     def _build_result(self, expired, expiring_soon, valid, errors, system_info):
         if expired:
             names = [f"{c['namespace']}/{c['name']}" for c in expired]
+            message = f"Found {len(expired)} expired TLS certificate(s):\n"
+            message += "\n".join(f"  - {n}" for n in names)
             return RuleResult.failed(
-                f"Found {len(expired)} expired TLS certificate(s): {names}",
+                message,
                 system_info=system_info,
             )
 

--- a/src/in_cluster_checks/rules/storage/storage_validations.py
+++ b/src/in_cluster_checks/rules/storage/storage_validations.py
@@ -434,6 +434,48 @@ class OrphanCsiVolumes(CephRule):
     unique_name = "orphan_csi_volumes"
     title = "Check for orphaned Ceph CSI volumes"
 
+    def is_prerequisite_fulfilled(self) -> PrerequisiteResult:
+        """
+        Check if CephFS CSI subvolume group exists.
+
+        Returns:
+            PrerequisiteResult indicating if CSI storage is configured
+        """
+        # First check base Ceph prerequisites (namespace, operator, tools)
+        base_result = super().is_prerequisite_fulfilled()
+        if not base_result.met:
+            return base_result
+
+        # Check if ceph filesystem exists
+        cmd = SafeCmdString("ceph fs ls -f json")
+        return_code, stdout, _ = self._run_ceph_cmd(cmd)
+
+        if return_code != 0:
+            return PrerequisiteResult.not_met("Cannot query Ceph filesystems")
+
+        filesystems = parse_json(stdout, cmd, self.get_host_ip())
+        has_cephfs = any(fs.get("name") == "ocs-storagecluster-cephfilesystem" for fs in filesystems)
+
+        if not has_cephfs:
+            return PrerequisiteResult.not_met("CephFS filesystem 'ocs-storagecluster-cephfilesystem' not found")
+
+        # Check if CSI subvolume group exists
+        cmd = SafeCmdString("ceph fs subvolumegroup ls ocs-storagecluster-cephfilesystem -f json")
+        return_code, stdout, stderr = self._run_ceph_cmd(cmd)
+
+        if return_code != 0:
+            return PrerequisiteResult.not_met(f"Cannot query Ceph subvolume groups: {stderr}")
+
+        groups = parse_json(stdout, cmd, self.get_host_ip())
+        has_csi_group = any(group.get("name") == "csi" for group in groups)
+
+        if not has_csi_group:
+            return PrerequisiteResult.not_met(
+                "CSI subvolume group does not exist. No CephFS PVCs have been created yet."
+            )
+
+        return PrerequisiteResult.met()
+
     def run_rule(self) -> RuleResult:
         pv_subvolumes = self._get_pv_subvolume_names()
 
@@ -485,11 +527,17 @@ class OrphanCsiVolumes(CephRule):
         return_code, stdout, stderr = self._run_ceph_cmd(cmd)
 
         if return_code != 0:
+            # Check if error is "subvolume group does not exist"
+            if "does not exist" in stderr or "ENOENT" in stderr:
+                # This should be caught by prerequisite, but handle gracefully if it reaches here
+                return []
+
             error_msg = self.build_cmd_error_message("Failed to list CSI subvolumes from Ceph.", stdout, stderr)
             return RuleResult.failed(error_msg)
 
-        if not stdout:
-            return RuleResult.failed("Empty results from ceph fs subvolume ls command")
+        # Empty or [] is valid - no subvolumes exist yet
+        if not stdout or stdout.strip() in ("", "[]"):
+            return []
 
         subvolumes_data = parse_json(stdout, cmd, self.get_host_ip())
 

--- a/tests/rules/storage/test_storage_validations.py
+++ b/tests/rules/storage/test_storage_validations.py
@@ -646,6 +646,87 @@ class TestOrphanCsiVolumes(RuleTestBase):
 
     tested_type = OrphanCsiVolumes
 
+    scenario_prerequisite_not_fulfilled = [
+        RuleScenarioParams(
+            "cephfs filesystem not found",
+            rsh_cmd_output_dict={
+                ("openshift-storage", "rook-ceph-tools-xyz", "ceph fs ls -f json"): CmdOutput(
+                    out='[{"name": "other-filesystem"}]', return_code=0
+                ),
+            },
+            tested_object_mock_dict={
+                "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-xyz"),
+                "oc_api.select_resources": Mock(return_value=Mock()),
+            },
+        ),
+        RuleScenarioParams(
+            "csi subvolume group does not exist",
+            rsh_cmd_output_dict={
+                ("openshift-storage", "rook-ceph-tools-xyz", "ceph fs ls -f json"): CmdOutput(
+                    out='[{"name": "ocs-storagecluster-cephfilesystem"}]', return_code=0
+                ),
+                (
+                    "openshift-storage",
+                    "rook-ceph-tools-xyz",
+                    "ceph fs subvolumegroup ls ocs-storagecluster-cephfilesystem -f json",
+                ): CmdOutput(out='[{"name": "other-group"}]', return_code=0),
+            },
+            tested_object_mock_dict={
+                "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-xyz"),
+                "oc_api.select_resources": Mock(return_value=Mock()),
+            },
+        ),
+        RuleScenarioParams(
+            "cannot query ceph filesystems",
+            rsh_cmd_output_dict={
+                ("openshift-storage", "rook-ceph-tools-xyz", "ceph fs ls -f json"): CmdOutput(
+                    out="", err="connection refused", return_code=1
+                ),
+            },
+            tested_object_mock_dict={
+                "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-xyz"),
+                "oc_api.select_resources": Mock(return_value=Mock()),
+            },
+        ),
+        RuleScenarioParams(
+            "cannot query subvolume groups",
+            rsh_cmd_output_dict={
+                ("openshift-storage", "rook-ceph-tools-xyz", "ceph fs ls -f json"): CmdOutput(
+                    out='[{"name": "ocs-storagecluster-cephfilesystem"}]', return_code=0
+                ),
+                (
+                    "openshift-storage",
+                    "rook-ceph-tools-xyz",
+                    "ceph fs subvolumegroup ls ocs-storagecluster-cephfilesystem -f json",
+                ): CmdOutput(out="", err="timeout", return_code=1),
+            },
+            tested_object_mock_dict={
+                "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-xyz"),
+                "oc_api.select_resources": Mock(return_value=Mock()),
+            },
+        ),
+    ]
+
+    scenario_prerequisite_fulfilled = [
+        RuleScenarioParams(
+            "cephfs and csi subvolume group exist",
+            rsh_cmd_output_dict={
+                ("openshift-storage", "rook-ceph-tools-xyz", "ceph fs ls -f json"): CmdOutput(
+                    out='[{"name": "ocs-storagecluster-cephfilesystem"}]', return_code=0
+                ),
+                (
+                    "openshift-storage",
+                    "rook-ceph-tools-xyz",
+                    "ceph fs subvolumegroup ls ocs-storagecluster-cephfilesystem -f json",
+                ): CmdOutput(out='[{"name": "csi"}]', return_code=0),
+            },
+            tested_object_mock_dict={
+                "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-xyz"),
+                "oc_api.select_resources": Mock(return_value=Mock()),
+            },
+        ),
+    ]
+
     scenario_passed = [
         RuleScenarioParams(
             "no orphaned volumes",
@@ -655,6 +736,14 @@ class TestOrphanCsiVolumes(RuleTestBase):
                 ),
             },
             rsh_cmd_output_dict={
+                ("openshift-storage", "rook-ceph-tools-xyz", "ceph fs ls -f json"): CmdOutput(
+                    out='[{"name": "ocs-storagecluster-cephfilesystem"}]', return_code=0
+                ),
+                (
+                    "openshift-storage",
+                    "rook-ceph-tools-xyz",
+                    "ceph fs subvolumegroup ls ocs-storagecluster-cephfilesystem -f json",
+                ): CmdOutput(out='[{"name": "csi"}]', return_code=0),
                 (
                     "openshift-storage",
                     "rook-ceph-tools-xyz",
@@ -663,6 +752,59 @@ class TestOrphanCsiVolumes(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-xyz"),
+                "oc_api.select_resources": Mock(return_value=Mock()),
+            },
+        ),
+        RuleScenarioParams(
+            "no subvolumes exist yet - empty result",
+            oc_cmd_output_dict={
+                ("get", ("pv", "-o", "jsonpath={.items[*].spec.csi.volumeAttributes.subvolumeName}")): CmdOutput(""),
+            },
+            rsh_cmd_output_dict={
+                ("openshift-storage", "rook-ceph-tools-xyz", "ceph fs ls -f json"): CmdOutput(
+                    out='[{"name": "ocs-storagecluster-cephfilesystem"}]', return_code=0
+                ),
+                (
+                    "openshift-storage",
+                    "rook-ceph-tools-xyz",
+                    "ceph fs subvolumegroup ls ocs-storagecluster-cephfilesystem -f json",
+                ): CmdOutput(out='[{"name": "csi"}]', return_code=0),
+                (
+                    "openshift-storage",
+                    "rook-ceph-tools-xyz",
+                    "ceph fs subvolume ls ocs-storagecluster-cephfilesystem csi -f json",
+                ): CmdOutput("[]"),
+            },
+            tested_object_mock_dict={
+                "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-xyz"),
+                "oc_api.select_resources": Mock(return_value=Mock()),
+            },
+        ),
+        RuleScenarioParams(
+            "subvolume group exists but ENOENT error - graceful fallback",
+            oc_cmd_output_dict={
+                ("get", ("pv", "-o", "jsonpath={.items[*].spec.csi.volumeAttributes.subvolumeName}")): CmdOutput(""),
+            },
+            rsh_cmd_output_dict={
+                ("openshift-storage", "rook-ceph-tools-xyz", "ceph fs ls -f json"): CmdOutput(
+                    out='[{"name": "ocs-storagecluster-cephfilesystem"}]', return_code=0
+                ),
+                (
+                    "openshift-storage",
+                    "rook-ceph-tools-xyz",
+                    "ceph fs subvolumegroup ls ocs-storagecluster-cephfilesystem -f json",
+                ): CmdOutput(out='[{"name": "csi"}]', return_code=0),
+                (
+                    "openshift-storage",
+                    "rook-ceph-tools-xyz",
+                    "ceph fs subvolume ls ocs-storagecluster-cephfilesystem csi -f json",
+                ): CmdOutput(
+                    "", return_code=2, err="Error ENOENT: subvolume group 'csi' does not exist"
+                ),
+            },
+            tested_object_mock_dict={
+                "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-xyz"),
+                "oc_api.select_resources": Mock(return_value=Mock()),
             },
         ),
     ]
@@ -676,6 +818,14 @@ class TestOrphanCsiVolumes(RuleTestBase):
                 ),
             },
             rsh_cmd_output_dict={
+                ("openshift-storage", "rook-ceph-tools-xyz", "ceph fs ls -f json"): CmdOutput(
+                    out='[{"name": "ocs-storagecluster-cephfilesystem"}]', return_code=0
+                ),
+                (
+                    "openshift-storage",
+                    "rook-ceph-tools-xyz",
+                    "ceph fs subvolumegroup ls ocs-storagecluster-cephfilesystem -f json",
+                ): CmdOutput(out='[{"name": "csi"}]', return_code=0),
                 (
                     "openshift-storage",
                     "rook-ceph-tools-xyz",
@@ -684,6 +834,7 @@ class TestOrphanCsiVolumes(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-xyz"),
+                "oc_api.select_resources": Mock(return_value=Mock()),
             },
         ),
         RuleScenarioParams(
@@ -694,6 +845,14 @@ class TestOrphanCsiVolumes(RuleTestBase):
                 ),
             },
             rsh_cmd_output_dict={
+                ("openshift-storage", "rook-ceph-tools-xyz", "ceph fs ls -f json"): CmdOutput(
+                    out='[{"name": "ocs-storagecluster-cephfilesystem"}]', return_code=0
+                ),
+                (
+                    "openshift-storage",
+                    "rook-ceph-tools-xyz",
+                    "ceph fs subvolumegroup ls ocs-storagecluster-cephfilesystem -f json",
+                ): CmdOutput(out='[{"name": "csi"}]', return_code=0),
                 (
                     "openshift-storage",
                     "rook-ceph-tools-xyz",
@@ -702,6 +861,7 @@ class TestOrphanCsiVolumes(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-xyz"),
+                "oc_api.select_resources": Mock(return_value=Mock()),
             },
         ),
     ]
@@ -715,6 +875,14 @@ class TestOrphanCsiVolumes(RuleTestBase):
                 ),
             },
             rsh_cmd_output_dict={
+                ("openshift-storage", "rook-ceph-tools-xyz", "ceph fs ls -f json"): CmdOutput(
+                    out='[{"name": "ocs-storagecluster-cephfilesystem"}]', return_code=0
+                ),
+                (
+                    "openshift-storage",
+                    "rook-ceph-tools-xyz",
+                    "ceph fs subvolumegroup ls ocs-storagecluster-cephfilesystem -f json",
+                ): CmdOutput(out='[{"name": "csi"}]', return_code=0),
                 (
                     "openshift-storage",
                     "rook-ceph-tools-xyz",
@@ -723,6 +891,7 @@ class TestOrphanCsiVolumes(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-xyz"),
+                "oc_api.select_resources": Mock(return_value=Mock()),
             },
         ),
         RuleScenarioParams(
@@ -733,6 +902,14 @@ class TestOrphanCsiVolumes(RuleTestBase):
                 ),
             },
             rsh_cmd_output_dict={
+                ("openshift-storage", "rook-ceph-tools-xyz", "ceph fs ls -f json"): CmdOutput(
+                    out='[{"name": "ocs-storagecluster-cephfilesystem"}]', return_code=0
+                ),
+                (
+                    "openshift-storage",
+                    "rook-ceph-tools-xyz",
+                    "ceph fs subvolumegroup ls ocs-storagecluster-cephfilesystem -f json",
+                ): CmdOutput(out='[{"name": "csi"}]', return_code=0),
                 (
                     "openshift-storage",
                     "rook-ceph-tools-xyz",
@@ -743,6 +920,7 @@ class TestOrphanCsiVolumes(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-xyz"),
+                "oc_api.select_resources": Mock(return_value=Mock()),
             },
         ),
         RuleScenarioParams(
@@ -751,6 +929,14 @@ class TestOrphanCsiVolumes(RuleTestBase):
                 ("get", ("pv", "-o", "jsonpath={.items[*].spec.csi.volumeAttributes.subvolumeName}")): CmdOutput(""),
             },
             rsh_cmd_output_dict={
+                ("openshift-storage", "rook-ceph-tools-xyz", "ceph fs ls -f json"): CmdOutput(
+                    out='[{"name": "ocs-storagecluster-cephfilesystem"}]', return_code=0
+                ),
+                (
+                    "openshift-storage",
+                    "rook-ceph-tools-xyz",
+                    "ceph fs subvolumegroup ls ocs-storagecluster-cephfilesystem -f json",
+                ): CmdOutput(out='[{"name": "csi"}]', return_code=0),
                 (
                     "openshift-storage",
                     "rook-ceph-tools-xyz",
@@ -759,6 +945,7 @@ class TestOrphanCsiVolumes(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-xyz"),
+                "oc_api.select_resources": Mock(return_value=Mock()),
             },
         ),
         RuleScenarioParams(
@@ -769,6 +956,14 @@ class TestOrphanCsiVolumes(RuleTestBase):
                 ),
             },
             rsh_cmd_output_dict={
+                ("openshift-storage", "rook-ceph-tools-xyz", "ceph fs ls -f json"): CmdOutput(
+                    out='[{"name": "ocs-storagecluster-cephfilesystem"}]', return_code=0
+                ),
+                (
+                    "openshift-storage",
+                    "rook-ceph-tools-xyz",
+                    "ceph fs subvolumegroup ls ocs-storagecluster-cephfilesystem -f json",
+                ): CmdOutput(out='[{"name": "csi"}]', return_code=0),
                 (
                     "openshift-storage",
                     "rook-ceph-tools-xyz",
@@ -777,29 +972,19 @@ class TestOrphanCsiVolumes(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-xyz"),
+                "oc_api.select_resources": Mock(return_value=Mock()),
             },
             failed_msg="Failed to list CSI subvolumes from Ceph.\nError: Error: unable to connect to ceph cluster",
         ),
-        RuleScenarioParams(
-            "ceph empty output",
-            oc_cmd_output_dict={
-                ("get", ("pv", "-o", "jsonpath={.items[*].spec.csi.volumeAttributes.subvolumeName}")): CmdOutput(
-                    "csi-vol-abc123"
-                ),
-            },
-            rsh_cmd_output_dict={
-                (
-                    "openshift-storage",
-                    "rook-ceph-tools-xyz",
-                    "ceph fs subvolume ls ocs-storagecluster-cephfilesystem csi -f json",
-                ): CmdOutput(""),
-            },
-            tested_object_mock_dict={
-                "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-xyz"),
-            },
-            failed_msg="Empty results from ceph fs subvolume ls command",
-        ),
     ]
+
+    @pytest.mark.parametrize("scenario_params", scenario_prerequisite_not_fulfilled)
+    def test_prerequisite_not_fulfilled(self, scenario_params, tested_object):
+        RuleTestBase.test_prerequisite_not_fulfilled(self, scenario_params, tested_object)
+
+    @pytest.mark.parametrize("scenario_params", scenario_prerequisite_fulfilled)
+    def test_prerequisite_fulfilled(self, scenario_params, tested_object):
+        RuleTestBase.test_prerequisite_fulfilled(self, scenario_params, tested_object)
 
     @pytest.mark.parametrize("scenario_params", scenario_passed)
     def test_scenario_passed(self, scenario_params, tested_object):


### PR DESCRIPTION
…atting

- Add prerequisite check for OrphanCsiVolumes to skip when CephFS CSI is not configured
- Check if CephFS filesystem and CSI subvolume group exist before running the rule
- Handle ENOENT error gracefully when subvolume group doesn't exist
- Return empty list instead of failing when no subvolumes exist (valid scenario)
- Add comprehensive test coverage for prerequisite scenarios
- Fix TLS certificate expiry message formatting for better readability

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved expired TLS certificate message formatting—each expired secret now appears on its own line for clarity.
  * Orphaned CSI volumes check now validates CephFS prerequisites before volume checks to avoid false failures.
  * Missing CSI subvolume groups are treated as empty (non-fatal) conditions instead of errors.

* **Tests**
  * Added tests covering prerequisite-not-met and prerequisite-met scenarios for orphaned CSI volumes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->