### PR TITLE
chore: bump version to 0.1.22

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "in-cluster-checks"
-version = "0.1.21"
+version = "0.1.22"
 description = "Generic framework for running health validation rules on OpenShift cluster nodes"
 readme = "README.md"
 license = "BSD-3-Clause"


### PR DESCRIPTION
Automated version bump to 0.1.22 from Pendrive release pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped package version from 0.1.21 to 0.1.22

---

**Note:** This release includes a version update. Please refer to previous release notes for information about features and fixes included in this version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->