### PR TITLE
refactor: migrate commands to skills structure

### DIFF
--- a/.claude/skills/create-wiki-page/SKILL.md
+++ b/.claude/skills/create-wiki-page/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: create-wiki-page
+description: Use when creating wiki documentation for an in-cluster-checks validation rule - follows 7-section template with proper formatting
+---
+
 Create a wiki page for an in-cluster-checks validation rule.
 
 $ARGUMENTS

--- a/.claude/skills/implement-jira/SKILL.md
+++ b/.claude/skills/implement-jira/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: implement-jira
+description: Use when user provides a Jira ticket number and wants to implement it - fetches ticket, creates branch, guides implementation, and handles PR creation
+---
+
 Fetch a Jira ticket, create a branch, and help implement it.
 
 **Args**: Jira ticket number (e.g., PDRIVE-123)

--- a/.claude/skills/implement-rule-from-jira/SKILL.md
+++ b/.claude/skills/implement-rule-from-jira/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: implement-rule-from-jira
+description: Use when user wants to create a new validation rule from a Jira ticket (Story type only) - validates ticket, scaffolds rule with tests and wiki docs
+---
+
 Create a new in-cluster validation rule from a Jira ticket.
 
 **Args**: Jira ticket number (e.g., PDRIVE-123)

--- a/.claude/skills/new-rule/SKILL.md
+++ b/.claude/skills/new-rule/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: new-rule
+description: Use when creating a new in-cluster validation rule from scratch - provides rule templates, domain registration, and test scaffolding
+---
+
 Create a new in-cluster rule based on the following description:
 
 $ARGUMENTS

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: release
+description: Use when preparing a new version release - generates changelog, updates version, creates tags and GitHub release
+---
+
 Create release notes and prepare for a new version release.
 
 $ARGUMENTS


### PR DESCRIPTION
Convert all commands to skills following the standard superpowers pattern. Commands are now discoverable as skills and work with both slash command invocation (/new-rule) and Skill tool invocation (Skill("new-rule")).

Changes:
- Migrated .claude/commands/*.md to .claude/skills/*/SKILL.md
- Added YAML frontmatter with name and description to each skill
- Removed .claude/commands/ directory
- Skills maintain all original functionality with dual invocation support

Skills migrated:
- implement-jira: Fetch Jira ticket, create branch, guide implementation
- implement-rule-from-jira: Create validation rules from Jira tickets
- new-rule: Create new in-cluster validation rules from scratch
- create-wiki-page: Generate wiki documentation for validation rules
- release: Prepare version releases with changelog and tags

Assisted-by: Claude Code (Claude Sonnet 4.5) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added metadata organization to skill documentation for improved discoverability and clarity.
  * Introduced comprehensive documentation for a new workflow skill enabling validation rule creation from Jira tickets, including step-by-step guidance for scaffolding, testing, and wiki generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->