### PR TITLE
Verify far container non root

### DIFF
--- a/src/in_cluster_checks/domains/k8s_domain.py
+++ b/src/in_cluster_checks/domains/k8s_domain.py
@@ -21,6 +21,7 @@ from in_cluster_checks.rules.k8s.k8s_validations import (
     ValidateNamespaceStatus,
     VerifyAcmOperatorHealth,
     VerifyClusterOperatorsAvailable,
+    VerifyFarContainerNonRoot,
     VerifyFarOperatorHealth,
     VerifyInternalRegistry,
     VerifyNetworkDiagnosticsDisabled,
@@ -65,4 +66,5 @@ class K8sValidationDomain(RuleDomain):
             VerifyNfdOperatorHealth,
             VerifyAcmOperatorHealth,
             VerifyFarOperatorHealth,
+            VerifyFarContainerNonRoot,
         ]

--- a/src/in_cluster_checks/rules/k8s/k8s_validations.py
+++ b/src/in_cluster_checks/rules/k8s/k8s_validations.py
@@ -10,7 +10,6 @@ from in_cluster_checks.core.exceptions import UnExpectedSystemOutput
 from in_cluster_checks.core.rule import OrchestratorRule
 from in_cluster_checks.core.rule_result import PrerequisiteResult, RuleResult
 from in_cluster_checks.utils.enums import Objectives, Status
-from in_cluster_checks.utils.parsing_utils import parse_json
 
 
 class AllPodsReadyAndRunning(OrchestratorRule):
@@ -1237,7 +1236,7 @@ class VerifyFarOperatorHealth(SubscriptionOperatorRule):
         return RuleResult.passed()
 
 
-class VerifyFarContainerNonRoot(OrchestratorRule):
+class VerifyFarContainerNonRoot(SubscriptionOperatorRule):
     """Verify FAR (Fence Agents Remediation) container runs as non-root user.
 
     Checks that FAR operator pods have proper security context:
@@ -1254,32 +1253,44 @@ class VerifyFarContainerNonRoot(OrchestratorRule):
         "https://docs.openshift.com/container-platform/4.18/nodes/pods/nodes-pods-configuring.html",
     ]
 
-    FAR_SUBSCRIPTION_NAME = "fence-agents-remediation"
+    operator_subscription_name = "fence-agents-remediation"
+    operator_display_name = "Fence Agents Remediation"
+
     FAR_POD_LABEL_KEY = "app.kubernetes.io/name"
     FAR_POD_LABEL_VALUE = "fence-agents-remediation-operator"
 
-    def is_prerequisite_fulfilled(self) -> PrerequisiteResult:
-        """Check if FAR operator is installed via OLM subscription."""
-        _, subscriptions_output, _ = self.oc_api.run_oc_command(
-            "get",
-            ["subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json"],
-            timeout=45,
-        )
+    @staticmethod
+    def _check_pod_security_context(pod_name, security_context):
+        """Validate pod-level security context has runAsNonRoot set to true."""
+        errors = []
+        if security_context is None:
+            errors.append(f"Pod {pod_name} has nil SecurityContext")
+        elif security_context.get("runAsNonRoot") is None:
+            errors.append(f"Pod {pod_name} has nil runAsNonRoot")
+        elif not security_context.get("runAsNonRoot"):
+            errors.append(
+                f"Incorrect runAsNonRoot for pod {pod_name}. "
+                f"Expected true, found: {security_context.get('runAsNonRoot')}"
+            )
+        return errors
 
-        subscriptions_data = parse_json(
-            subscriptions_output,
-            "oc get subscriptions.operators.coreos.com --all-namespaces -o json",
-            self.get_host_ip(),
-        )
-
-        for item in subscriptions_data.get("items", []):
-            spec = item.get("spec", {})
-            if spec.get("name") == self.FAR_SUBSCRIPTION_NAME:
-                return PrerequisiteResult.met()
-
-        return PrerequisiteResult.not_met(
-            f"FAR operator subscription '{self.FAR_SUBSCRIPTION_NAME}' not found - operator is not installed"
-        )
+    @staticmethod
+    def _check_containers_non_root(pod_name, all_containers):
+        """Validate no container runs as root (runAsUser != 0)."""
+        errors = []
+        if not all_containers:
+            errors.append(f"Pod {pod_name} has no containers")
+            return errors
+        for i, container in enumerate(all_containers):
+            container_sc = container.get("securityContext")
+            if container_sc is not None:
+                run_as_user = container_sc.get("runAsUser")
+                if run_as_user is not None and run_as_user == 0:
+                    errors.append(
+                        f"Incorrect user running container [{i}] in pod {pod_name}, "
+                        f"expected non 0, found: {run_as_user}"
+                    )
+        return errors
 
     def run_rule(self):
         """Check if FAR pods run as non-root user with proper security context."""
@@ -1293,36 +1304,13 @@ class VerifyFarContainerNonRoot(OrchestratorRule):
         error_messages = []
 
         for pod in pod_objects:
-            pod_data = pod.as_dict()
-            pod_name = pod_data["metadata"]["name"]
-            spec = pod_data.get("spec", {})
+            pod_name = pod.name()
+            spec = pod.as_dict().get("spec", {})
 
-            security_context = spec.get("securityContext")
-            if security_context is None:
-                error_messages.append(f"Pod {pod_name} has nil SecurityContext")
-            elif security_context.get("runAsNonRoot") is None:
-                error_messages.append(f"Pod {pod_name} has nil runAsNonRoot")
-            elif not security_context.get("runAsNonRoot"):
-                error_messages.append(
-                    f"Incorrect runAsNonRoot for pod {pod_name}. "
-                    f"Expected true, found: {security_context.get('runAsNonRoot')}"
-                )
+            error_messages.extend(self._check_pod_security_context(pod_name, spec.get("securityContext")))
 
-            containers = spec.get("containers", [])
-            init_containers = spec.get("initContainers", [])
-            all_containers = containers + init_containers
-            if not all_containers:
-                error_messages.append(f"Pod {pod_name} has no containers")
-            else:
-                for i, container in enumerate(all_containers):
-                    container_sc = container.get("securityContext")
-                    if container_sc is not None:
-                        run_as_user = container_sc.get("runAsUser")
-                        if run_as_user is not None and run_as_user == 0:
-                            error_messages.append(
-                                f"Incorrect user running container [{i}] in pod {pod_name}, "
-                                f"expected non 0, found: {run_as_user}"
-                            )
+            all_containers = spec.get("containers", []) + spec.get("initContainers", [])
+            error_messages.extend(self._check_containers_non_root(pod_name, all_containers))
 
         if error_messages:
             message = "Testing user running FAR container failed due to:\n"

--- a/src/in_cluster_checks/rules/k8s/k8s_validations.py
+++ b/src/in_cluster_checks/rules/k8s/k8s_validations.py
@@ -1260,8 +1260,16 @@ class VerifyFarContainerNonRoot(SubscriptionOperatorRule):
     FAR_POD_LABEL_VALUE = "fence-agents-remediation-operator"
 
     @staticmethod
-    def _check_pod_security_context(pod_name, security_context):
-        """Validate pod-level security context has runAsNonRoot set to true."""
+    def _check_pod_security_context(pod_name: str, security_context: dict[str, object] | None) -> list[str]:
+        """Validate pod-level security context has runAsNonRoot set to true.
+
+        Args:
+            pod_name: Pod name.
+            security_context: Pod-level security context.
+
+        Returns:
+            List of validation error messages.
+        """
         errors = []
         if security_context is None:
             errors.append(f"Pod {pod_name} has nil SecurityContext")
@@ -1275,8 +1283,16 @@ class VerifyFarContainerNonRoot(SubscriptionOperatorRule):
         return errors
 
     @staticmethod
-    def _check_containers_non_root(pod_name, all_containers):
-        """Validate no container runs as root (runAsUser != 0)."""
+    def _check_containers_non_root(pod_name: str, all_containers: list[dict[str, object]]) -> list[str]:
+        """Validate no container runs as root (runAsUser != 0).
+
+        Args:
+            pod_name: Pod name.
+            all_containers: Combined containers and initContainers list.
+
+        Returns:
+            List of validation error messages.
+        """
         errors = []
         if not all_containers:
             errors.append(f"Pod {pod_name} has no containers")

--- a/src/in_cluster_checks/rules/k8s/k8s_validations.py
+++ b/src/in_cluster_checks/rules/k8s/k8s_validations.py
@@ -1027,15 +1027,18 @@ class SubscriptionOperatorRule(OrchestratorRule):
         if not all_containers:
             errors.append(f"Pod {pod_name} has no containers")
             return errors
-        for i, container in enumerate(all_containers):
+        for container in all_containers:
+            container_name = container.get("name", "unknown")
             container_sc = container.get("securityContext")
             if container_sc is not None:
                 run_as_user = container_sc.get("runAsUser")
-                if run_as_user is not None and run_as_user == 0:
-                    errors.append(
-                        f"Incorrect user running container [{i}] in pod {pod_name}, "
-                        f"expected non 0, found: {run_as_user}"
-                    )
+                if run_as_user is not None:
+                    if not isinstance(run_as_user, int) or run_as_user < 0:
+                        errors.append(
+                            f"Container '{container_name}' in pod {pod_name} has invalid runAsUser: {run_as_user}"
+                        )
+                    elif run_as_user == 0:
+                        errors.append(f"Container '{container_name}' in pod {pod_name} runs as root (runAsUser=0)")
         return errors
 
 
@@ -1327,7 +1330,7 @@ class VerifyFarContainerNonRoot(SubscriptionOperatorRule):
             error_messages.extend(self._check_containers_non_root(pod_name, all_containers))
 
         if error_messages:
-            message = "Testing user running FAR container failed due to:\n"
+            message = "FAR operator pods doesn't have proper security context:\n"
             for msg in error_messages:
                 message += f"- {msg}\n"
             return RuleResult.failed(message)

--- a/src/in_cluster_checks/rules/k8s/k8s_validations.py
+++ b/src/in_cluster_checks/rules/k8s/k8s_validations.py
@@ -10,6 +10,7 @@ from in_cluster_checks.core.exceptions import UnExpectedSystemOutput
 from in_cluster_checks.core.rule import OrchestratorRule
 from in_cluster_checks.core.rule_result import PrerequisiteResult, RuleResult
 from in_cluster_checks.utils.enums import Objectives, Status
+from in_cluster_checks.utils.parsing_utils import parse_json
 
 
 class AllPodsReadyAndRunning(OrchestratorRule):
@@ -1232,5 +1233,102 @@ class VerifyFarOperatorHealth(SubscriptionOperatorRule):
                     + "\n  ".join(not_ready_pods)
                 )
             return RuleResult.failed("\n\n".join(parts))
+
+        return RuleResult.passed()
+
+
+class VerifyFarContainerNonRoot(OrchestratorRule):
+    """Verify FAR (Fence Agents Remediation) container runs as non-root user.
+
+    Checks that FAR operator pods have proper security context:
+    - Pod-level runAsNonRoot is set to true
+    - No container runs as root (runAsUser != 0)
+    """
+
+    objective_hosts = [Objectives.ORCHESTRATOR]
+    unique_name = "verify_far_container_non_root"
+    title = "Verify FAR container runs as non-root user"
+    supported_profiles = {"telco-base"}
+    links = [
+        "https://docs.openshift.com/container-platform/4.18/nodes/pods/nodes-pods-configuring.html",
+    ]
+
+    FAR_SUBSCRIPTION_NAME = "fence-agents-remediation"
+    FAR_POD_LABEL_KEY = "app.kubernetes.io/name"
+    FAR_POD_LABEL_VALUE = "fence-agents-remediation-operator"
+
+    def is_prerequisite_fulfilled(self) -> PrerequisiteResult:
+        """Check if FAR operator is installed via OLM subscription."""
+        try:
+            _, subscriptions_output, _ = self.oc_api.run_oc_command(
+                "get",
+                ["subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json"],
+                timeout=45,
+            )
+        except UnExpectedSystemOutput:
+            return PrerequisiteResult.not_met("Failed to get OLM subscriptions")
+
+        subscriptions_data = parse_json(
+            subscriptions_output,
+            "oc get subscriptions.operators.coreos.com --all-namespaces -o json",
+            self.get_host_ip(),
+        )
+
+        for item in subscriptions_data.get("items", []):
+            metadata = item.get("metadata", {})
+            name = metadata.get("name", "")
+            if self.FAR_SUBSCRIPTION_NAME in name:
+                return PrerequisiteResult.met()
+
+        return PrerequisiteResult.not_met(
+            f"FAR operator subscription '{self.FAR_SUBSCRIPTION_NAME}' not found - operator is not installed"
+        )
+
+    def run_rule(self):
+        """Check if FAR pods run as non-root user with proper security context."""
+        pod_objects = self.oc_api.get_pods(labels={self.FAR_POD_LABEL_KEY: self.FAR_POD_LABEL_VALUE})
+
+        if not pod_objects:
+            return RuleResult.failed(
+                f"No FAR pods found with label {self.FAR_POD_LABEL_KEY}={self.FAR_POD_LABEL_VALUE}"
+            )
+
+        error_messages = []
+
+        for pod in pod_objects:
+            pod_data = pod.as_dict()
+            pod_name = pod_data["metadata"]["name"]
+            spec = pod_data.get("spec", {})
+
+            security_context = spec.get("securityContext")
+            if security_context is None:
+                error_messages.append(f"Pod {pod_name} has nil SecurityContext")
+            elif security_context.get("runAsNonRoot") is None:
+                error_messages.append(f"Pod {pod_name} has nil runAsNonRoot")
+            elif not security_context.get("runAsNonRoot"):
+                error_messages.append(
+                    f"Incorrect runAsNonRoot for pod {pod_name}. "
+                    f"Expected true, found: {security_context.get('runAsNonRoot')}"
+                )
+
+            containers = spec.get("containers", [])
+            if not containers:
+                error_messages.append(f"Pod {pod_name} has no containers")
+            else:
+                for i, container in enumerate(containers):
+                    container_sc = container.get("securityContext")
+                    if container_sc is not None:
+                        run_as_user = container_sc.get("runAsUser")
+                        if run_as_user is not None and run_as_user == 0:
+                            error_messages.append(
+                                f"Incorrect user running container [{i}] in pod {pod_name}, "
+                                f"expected non 0, found: {run_as_user}"
+                            )
+
+        if error_messages:
+            message = "Testing user running FAR container failed due to:\n"
+            for msg in error_messages:
+                message += f"- {msg}\n"
+            return RuleResult.failed(message)
 
         return RuleResult.passed()

--- a/src/in_cluster_checks/rules/k8s/k8s_validations.py
+++ b/src/in_cluster_checks/rules/k8s/k8s_validations.py
@@ -1321,11 +1321,11 @@ class VerifyFarContainerNonRoot(SubscriptionOperatorRule):
 
         for pod in pod_objects:
             pod_name = pod.name()
-            spec = pod.as_dict().get("spec", {})
+            spec = pod.model.spec
 
-            error_messages.extend(self._check_pod_security_context(pod_name, spec.get("securityContext")))
+            error_messages.extend(self._check_pod_security_context(pod_name, spec.securityContext))
 
-            all_containers = spec.get("containers", []) + spec.get("initContainers", [])
+            all_containers = (spec.containers or []) + (spec.initContainers or [])
             error_messages.extend(self._check_containers_non_root(pod_name, all_containers))
 
         if error_messages:

--- a/src/in_cluster_checks/rules/k8s/k8s_validations.py
+++ b/src/in_cluster_checks/rules/k8s/k8s_validations.py
@@ -991,6 +991,53 @@ class SubscriptionOperatorRule(OrchestratorRule):
             f"{self.operator_display_name} operator is not installed on this cluster"
         )
 
+    def _check_pod_security_context(self, pod_name: str, security_context: dict[str, object] | None) -> list[str]:
+        """Validate pod-level security context has runAsNonRoot set to true.
+
+        Args:
+            pod_name: Pod name.
+            security_context: Pod-level security context.
+
+        Returns:
+            List of validation error messages.
+        """
+        errors = []
+        if security_context is None:
+            errors.append(f"Pod {pod_name} has nil SecurityContext")
+        elif security_context.get("runAsNonRoot") is None:
+            errors.append(f"Pod {pod_name} has nil runAsNonRoot")
+        elif not security_context.get("runAsNonRoot"):
+            errors.append(
+                f"Incorrect runAsNonRoot for pod {pod_name}. "
+                f"Expected true, found: {security_context.get('runAsNonRoot')}"
+            )
+        return errors
+
+    def _check_containers_non_root(self, pod_name: str, all_containers: list[dict[str, object]]) -> list[str]:
+        """Validate no container runs as root (runAsUser != 0).
+
+        Args:
+            pod_name: Pod name.
+            all_containers: Combined containers and initContainers list.
+
+        Returns:
+            List of validation error messages.
+        """
+        errors = []
+        if not all_containers:
+            errors.append(f"Pod {pod_name} has no containers")
+            return errors
+        for i, container in enumerate(all_containers):
+            container_sc = container.get("securityContext")
+            if container_sc is not None:
+                run_as_user = container_sc.get("runAsUser")
+                if run_as_user is not None and run_as_user == 0:
+                    errors.append(
+                        f"Incorrect user running container [{i}] in pod {pod_name}, "
+                        f"expected non 0, found: {run_as_user}"
+                    )
+        return errors
+
 
 class VerifyNfdOperatorHealth(SubscriptionOperatorRule):
     """Verify Node Feature Discovery (NFD) operator pods are healthy.
@@ -1258,55 +1305,6 @@ class VerifyFarContainerNonRoot(SubscriptionOperatorRule):
 
     FAR_POD_LABEL_KEY = "app.kubernetes.io/name"
     FAR_POD_LABEL_VALUE = "fence-agents-remediation-operator"
-
-    @staticmethod
-    def _check_pod_security_context(pod_name: str, security_context: dict[str, object] | None) -> list[str]:
-        """Validate pod-level security context has runAsNonRoot set to true.
-
-        Args:
-            pod_name: Pod name.
-            security_context: Pod-level security context.
-
-        Returns:
-            List of validation error messages.
-        """
-        errors = []
-        if security_context is None:
-            errors.append(f"Pod {pod_name} has nil SecurityContext")
-        elif security_context.get("runAsNonRoot") is None:
-            errors.append(f"Pod {pod_name} has nil runAsNonRoot")
-        elif not security_context.get("runAsNonRoot"):
-            errors.append(
-                f"Incorrect runAsNonRoot for pod {pod_name}. "
-                f"Expected true, found: {security_context.get('runAsNonRoot')}"
-            )
-        return errors
-
-    @staticmethod
-    def _check_containers_non_root(pod_name: str, all_containers: list[dict[str, object]]) -> list[str]:
-        """Validate no container runs as root (runAsUser != 0).
-
-        Args:
-            pod_name: Pod name.
-            all_containers: Combined containers and initContainers list.
-
-        Returns:
-            List of validation error messages.
-        """
-        errors = []
-        if not all_containers:
-            errors.append(f"Pod {pod_name} has no containers")
-            return errors
-        for i, container in enumerate(all_containers):
-            container_sc = container.get("securityContext")
-            if container_sc is not None:
-                run_as_user = container_sc.get("runAsUser")
-                if run_as_user is not None and run_as_user == 0:
-                    errors.append(
-                        f"Incorrect user running container [{i}] in pod {pod_name}, "
-                        f"expected non 0, found: {run_as_user}"
-                    )
-        return errors
 
     def run_rule(self):
         """Check if FAR pods run as non-root user with proper security context."""

--- a/src/in_cluster_checks/rules/k8s/k8s_validations.py
+++ b/src/in_cluster_checks/rules/k8s/k8s_validations.py
@@ -1321,11 +1321,11 @@ class VerifyFarContainerNonRoot(SubscriptionOperatorRule):
 
         for pod in pod_objects:
             pod_name = pod.name()
-            spec = pod.model.spec
+            spec = pod.as_dict().get("spec", {})
 
-            error_messages.extend(self._check_pod_security_context(pod_name, spec.securityContext))
+            error_messages.extend(self._check_pod_security_context(pod_name, spec.get("securityContext")))
 
-            all_containers = (spec.containers or []) + (spec.initContainers or [])
+            all_containers = spec.get("containers", []) + spec.get("initContainers", [])
             error_messages.extend(self._check_containers_non_root(pod_name, all_containers))
 
         if error_messages:

--- a/src/in_cluster_checks/rules/k8s/k8s_validations.py
+++ b/src/in_cluster_checks/rules/k8s/k8s_validations.py
@@ -1250,6 +1250,7 @@ class VerifyFarContainerNonRoot(OrchestratorRule):
     title = "Verify FAR container runs as non-root user"
     supported_profiles = {"telco-base"}
     links = [
+        "https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-FAR-container-non-root",
         "https://docs.openshift.com/container-platform/4.18/nodes/pods/nodes-pods-configuring.html",
     ]
 
@@ -1259,14 +1260,11 @@ class VerifyFarContainerNonRoot(OrchestratorRule):
 
     def is_prerequisite_fulfilled(self) -> PrerequisiteResult:
         """Check if FAR operator is installed via OLM subscription."""
-        try:
-            _, subscriptions_output, _ = self.oc_api.run_oc_command(
-                "get",
-                ["subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json"],
-                timeout=45,
-            )
-        except UnExpectedSystemOutput:
-            return PrerequisiteResult.not_met("Failed to get OLM subscriptions")
+        _, subscriptions_output, _ = self.oc_api.run_oc_command(
+            "get",
+            ["subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json"],
+            timeout=45,
+        )
 
         subscriptions_data = parse_json(
             subscriptions_output,
@@ -1275,9 +1273,8 @@ class VerifyFarContainerNonRoot(OrchestratorRule):
         )
 
         for item in subscriptions_data.get("items", []):
-            metadata = item.get("metadata", {})
-            name = metadata.get("name", "")
-            if self.FAR_SUBSCRIPTION_NAME in name:
+            spec = item.get("spec", {})
+            if spec.get("name") == self.FAR_SUBSCRIPTION_NAME:
                 return PrerequisiteResult.met()
 
         return PrerequisiteResult.not_met(
@@ -1312,10 +1309,12 @@ class VerifyFarContainerNonRoot(OrchestratorRule):
                 )
 
             containers = spec.get("containers", [])
-            if not containers:
+            init_containers = spec.get("initContainers", [])
+            all_containers = containers + init_containers
+            if not all_containers:
                 error_messages.append(f"Pod {pod_name} has no containers")
             else:
-                for i, container in enumerate(containers):
+                for i, container in enumerate(all_containers):
                     container_sc = container.get("securityContext")
                     if container_sc is not None:
                         run_as_user = container_sc.get("runAsUser")

--- a/src/in_cluster_checks/rules/k8s/k8s_validations.py
+++ b/src/in_cluster_checks/rules/k8s/k8s_validations.py
@@ -1250,7 +1250,7 @@ class VerifyFarContainerNonRoot(OrchestratorRule):
     title = "Verify FAR container runs as non-root user"
     supported_profiles = {"telco-base"}
     links = [
-        "https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-FAR-container-non-root",
+        "https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-FAR-container-non%E2%80%90root",
         "https://docs.openshift.com/container-platform/4.18/nodes/pods/nodes-pods-configuring.html",
     ]
 

--- a/tests/domains/test_k8s_domain.py
+++ b/tests/domains/test_k8s_domain.py
@@ -11,6 +11,7 @@ from in_cluster_checks.rules.k8s.k8s_validations import (
     ValidateAllPoliciesCompliant,
     VerifyAcmOperatorHealth,
     VerifyClusterOperatorsAvailable,
+    VerifyFarContainerNonRoot,
     VerifyFarOperatorHealth,
     VerifyInternalRegistry,
     VerifyNetworkDiagnosticsDisabled,
@@ -30,7 +31,7 @@ def test_k8s_domain_rules():
     domain = K8sValidationDomain()
     rules = domain.get_rule_classes()
 
-    assert len(rules) == 17
+    assert len(rules) == 18
     assert AllPodsReadyAndRunning in rules
     assert NodesAreReady in rules
     assert NodesCpuAndMemoryStatus in rules
@@ -39,6 +40,7 @@ def test_k8s_domain_rules():
     assert OpenshiftOperatorStatus in rules
     assert ValidateAllPoliciesCompliant in rules
     assert VerifyClusterOperatorsAvailable in rules
+    assert VerifyFarContainerNonRoot in rules
     assert VerifyInternalRegistry in rules
     assert VerifyWebConsoleDisabled in rules
     assert VerifyNetworkDiagnosticsDisabled in rules

--- a/tests/rules/k8s/test_k8s_validations.py
+++ b/tests/rules/k8s/test_k8s_validations.py
@@ -2326,6 +2326,7 @@ def _create_far_pod(
             init_containers.append(ic)
         spec["initContainers"] = init_containers
 
+    mock_pod.name.return_value = name
     mock_pod.as_dict.return_value = {
         "metadata": {"name": name, "namespace": "openshift-workload-availability"},
         "spec": spec,

--- a/tests/rules/k8s/test_k8s_validations.py
+++ b/tests/rules/k8s/test_k8s_validations.py
@@ -2327,6 +2327,9 @@ def _create_far_pod(
         spec["initContainers"] = init_containers
 
     mock_pod.name.return_value = name
+    mock_pod.model.spec.securityContext = spec.get("securityContext")
+    mock_pod.model.spec.containers = spec.get("containers") or None
+    mock_pod.model.spec.initContainers = spec.get("initContainers") or None
     mock_pod.as_dict.return_value = {
         "metadata": {"name": name, "namespace": "openshift-workload-availability"},
         "spec": spec,

--- a/tests/rules/k8s/test_k8s_validations.py
+++ b/tests/rules/k8s/test_k8s_validations.py
@@ -2327,9 +2327,6 @@ def _create_far_pod(
         spec["initContainers"] = init_containers
 
     mock_pod.name.return_value = name
-    mock_pod.model.spec.securityContext = spec.get("securityContext")
-    mock_pod.model.spec.containers = spec.get("containers") or None
-    mock_pod.model.spec.initContainers = spec.get("initContainers") or None
     mock_pod.as_dict.return_value = {
         "metadata": {"name": name, "namespace": "openshift-workload-availability"},
         "spec": spec,

--- a/tests/rules/k8s/test_k8s_validations.py
+++ b/tests/rules/k8s/test_k8s_validations.py
@@ -22,6 +22,7 @@ from in_cluster_checks.rules.k8s.k8s_validations import (
     ValidateNamespaceStatus,
     VerifyAcmOperatorHealth,
     VerifyClusterOperatorsAvailable,
+    VerifyFarContainerNonRoot,
     VerifyFarOperatorHealth,
     VerifyInternalRegistry,
     VerifyNetworkDiagnosticsDisabled,
@@ -2240,4 +2241,268 @@ class TestVerifyFarOperatorHealth(RuleTestBase):
     @pytest.mark.parametrize("scenario_params", scenario_failed)
     def test_scenario_failed(self, scenario_params, tested_object):
         """Test that rule fails when FAR pods are unhealthy or missing."""
+        RuleTestBase.test_scenario_failed(self, scenario_params, tested_object)
+
+
+def _far_subscription_response(has_far=True):
+    """Build OLM subscription list response."""
+    items = []
+    if has_far:
+        items.append(
+            {
+                "metadata": {"name": "fence-agents-remediation", "namespace": "openshift-workload-availability"},
+                "spec": {"name": "fence-agents-remediation"},
+            }
+        )
+    return {"items": items}
+
+
+def _create_far_pod(
+    name,
+    run_as_non_root=True,
+    containers_run_as_user=None,
+    has_security_context=True,
+    has_run_as_non_root=True,
+    has_containers=True,
+):
+    """Create a mock FAR pod object for security context tests.
+
+    Args:
+        name: Pod name
+        run_as_non_root: Value for pod-level runAsNonRoot
+        containers_run_as_user: List of runAsUser values per container (None means no securityContext)
+        has_security_context: Whether pod has a securityContext at all
+        has_run_as_non_root: Whether runAsNonRoot is present in securityContext
+        has_containers: Whether the pod has containers
+    """
+    mock_pod = Mock()
+    spec = {}
+
+    if has_security_context:
+        sc = {}
+        if has_run_as_non_root:
+            sc["runAsNonRoot"] = run_as_non_root
+        spec["securityContext"] = sc
+    else:
+        spec["securityContext"] = None
+
+    if has_containers:
+        containers = []
+        if containers_run_as_user is None:
+            containers_run_as_user = [1000]
+        for uid in containers_run_as_user:
+            container = {"name": f"container-{uid}"}
+            if uid is not None:
+                container["securityContext"] = {"runAsUser": uid}
+            else:
+                container["securityContext"] = None
+            containers.append(container)
+        spec["containers"] = containers
+    else:
+        spec["containers"] = []
+
+    mock_pod.as_dict.return_value = {
+        "metadata": {"name": name, "namespace": "openshift-workload-availability"},
+        "spec": spec,
+    }
+    return mock_pod
+
+
+class TestVerifyFarContainerNonRoot(RuleTestBase):
+    """Test VerifyFarContainerNonRoot rule."""
+
+    tested_type = VerifyFarContainerNonRoot
+
+    scenario_passed = [
+        RuleScenarioParams(
+            "FAR pod runs as non-root with proper security context",
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_far_subscription_response(has_far=True))
+                ),
+            },
+            tested_object_mock_dict={
+                "oc_api.get_pods": Mock(
+                    return_value=[
+                        _create_far_pod(
+                            "far-controller-manager-abc123", run_as_non_root=True, containers_run_as_user=[1000]
+                        ),
+                    ]
+                ),
+            },
+        ),
+        RuleScenarioParams(
+            "multiple FAR pods all run as non-root",
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_far_subscription_response(has_far=True))
+                ),
+            },
+            tested_object_mock_dict={
+                "oc_api.get_pods": Mock(
+                    return_value=[
+                        _create_far_pod(
+                            "far-controller-manager-abc123", run_as_non_root=True, containers_run_as_user=[1000]
+                        ),
+                        _create_far_pod(
+                            "far-controller-manager-def456", run_as_non_root=True, containers_run_as_user=[1000, 65534]
+                        ),
+                    ]
+                ),
+            },
+        ),
+    ]
+
+    scenario_prerequisite_not_fulfilled = [
+        RuleScenarioParams(
+            "FAR operator subscription not found",
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_far_subscription_response(has_far=False))
+                ),
+            },
+        ),
+    ]
+
+    scenario_prerequisite_fulfilled = [
+        RuleScenarioParams(
+            "FAR operator subscription exists",
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_far_subscription_response(has_far=True))
+                ),
+            },
+        ),
+    ]
+
+    scenario_failed = [
+        RuleScenarioParams(
+            "no FAR pods found",
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_far_subscription_response(has_far=True))
+                ),
+            },
+            tested_object_mock_dict={
+                "oc_api.get_pods": Mock(return_value=[]),
+            },
+            failed_msg="No FAR pods found with label app.kubernetes.io/name=fence-agents-remediation-operator",
+        ),
+        RuleScenarioParams(
+            "FAR pod has nil SecurityContext",
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_far_subscription_response(has_far=True))
+                ),
+            },
+            tested_object_mock_dict={
+                "oc_api.get_pods": Mock(
+                    return_value=[
+                        _create_far_pod("far-pod-1", has_security_context=False),
+                    ]
+                ),
+            },
+            failed_msg="Testing user running FAR container failed due to:\n- Pod far-pod-1 has nil SecurityContext\n",
+        ),
+        RuleScenarioParams(
+            "FAR pod has nil runAsNonRoot",
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_far_subscription_response(has_far=True))
+                ),
+            },
+            tested_object_mock_dict={
+                "oc_api.get_pods": Mock(
+                    return_value=[
+                        _create_far_pod("far-pod-1", has_run_as_non_root=False),
+                    ]
+                ),
+            },
+            failed_msg="Testing user running FAR container failed due to:\n- Pod far-pod-1 has nil runAsNonRoot\n",
+        ),
+        RuleScenarioParams(
+            "FAR pod has runAsNonRoot set to false",
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_far_subscription_response(has_far=True))
+                ),
+            },
+            tested_object_mock_dict={
+                "oc_api.get_pods": Mock(
+                    return_value=[
+                        _create_far_pod("far-pod-1", run_as_non_root=False),
+                    ]
+                ),
+            },
+            failed_msg="Testing user running FAR container failed due to:\n"
+            "- Incorrect runAsNonRoot for pod far-pod-1. Expected true, found: False\n",
+        ),
+        RuleScenarioParams(
+            "FAR pod has no containers",
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_far_subscription_response(has_far=True))
+                ),
+            },
+            tested_object_mock_dict={
+                "oc_api.get_pods": Mock(
+                    return_value=[
+                        _create_far_pod("far-pod-1", has_containers=False),
+                    ]
+                ),
+            },
+            failed_msg="Testing user running FAR container failed due to:\n- Pod far-pod-1 has no containers\n",
+        ),
+        RuleScenarioParams(
+            "FAR container runs as root (runAsUser=0)",
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_far_subscription_response(has_far=True))
+                ),
+            },
+            tested_object_mock_dict={
+                "oc_api.get_pods": Mock(
+                    return_value=[
+                        _create_far_pod("far-pod-1", run_as_non_root=True, containers_run_as_user=[0]),
+                    ]
+                ),
+            },
+            failed_msg="Testing user running FAR container failed due to:\n"
+            "- Incorrect user running container [0] in pod far-pod-1, expected non 0, found: 0\n",
+        ),
+        RuleScenarioParams(
+            "mixed failures - nil SecurityContext and root container",
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_far_subscription_response(has_far=True))
+                ),
+            },
+            tested_object_mock_dict={
+                "oc_api.get_pods": Mock(
+                    return_value=[
+                        _create_far_pod("far-pod-1", has_security_context=False),
+                        _create_far_pod("far-pod-2", run_as_non_root=True, containers_run_as_user=[0, 1000]),
+                    ]
+                ),
+            },
+            failed_msg="Testing user running FAR container failed due to:\n"
+            "- Pod far-pod-1 has nil SecurityContext\n"
+            "- Incorrect user running container [0] in pod far-pod-2, expected non 0, found: 0\n",
+        ),
+    ]
+
+    @pytest.mark.parametrize("scenario_params", scenario_prerequisite_not_fulfilled)
+    def test_prerequisite_not_fulfilled(self, scenario_params, tested_object):
+        RuleTestBase.test_prerequisite_not_fulfilled(self, scenario_params, tested_object)
+
+    @pytest.mark.parametrize("scenario_params", scenario_prerequisite_fulfilled)
+    def test_prerequisite_fulfilled(self, scenario_params, tested_object):
+        RuleTestBase.test_prerequisite_fulfilled(self, scenario_params, tested_object)
+
+    @pytest.mark.parametrize("scenario_params", scenario_passed)
+    def test_scenario_passed(self, scenario_params, tested_object):
+        RuleTestBase.test_scenario_passed(self, scenario_params, tested_object)
+
+    @pytest.mark.parametrize("scenario_params", scenario_failed)
+    def test_scenario_failed(self, scenario_params, tested_object):
         RuleTestBase.test_scenario_failed(self, scenario_params, tested_object)

--- a/tests/rules/k8s/test_k8s_validations.py
+++ b/tests/rules/k8s/test_k8s_validations.py
@@ -2436,7 +2436,7 @@ class TestVerifyFarContainerNonRoot(RuleTestBase):
                     ]
                 ),
             },
-            failed_msg="Testing user running FAR container failed due to:\n- Pod far-pod-1 has nil SecurityContext\n",
+            failed_msg="FAR operator pods doesn't have proper security context:\n- Pod far-pod-1 has nil SecurityContext\n",
         ),
         RuleScenarioParams(
             "FAR pod has nil runAsNonRoot",
@@ -2452,7 +2452,7 @@ class TestVerifyFarContainerNonRoot(RuleTestBase):
                     ]
                 ),
             },
-            failed_msg="Testing user running FAR container failed due to:\n- Pod far-pod-1 has nil runAsNonRoot\n",
+            failed_msg="FAR operator pods doesn't have proper security context:\n- Pod far-pod-1 has nil runAsNonRoot\n",
         ),
         RuleScenarioParams(
             "FAR pod has runAsNonRoot set to false",
@@ -2468,7 +2468,7 @@ class TestVerifyFarContainerNonRoot(RuleTestBase):
                     ]
                 ),
             },
-            failed_msg="Testing user running FAR container failed due to:\n"
+            failed_msg="FAR operator pods doesn't have proper security context:\n"
             "- Incorrect runAsNonRoot for pod far-pod-1. Expected true, found: False\n",
         ),
         RuleScenarioParams(
@@ -2485,7 +2485,7 @@ class TestVerifyFarContainerNonRoot(RuleTestBase):
                     ]
                 ),
             },
-            failed_msg="Testing user running FAR container failed due to:\n- Pod far-pod-1 has no containers\n",
+            failed_msg="FAR operator pods doesn't have proper security context:\n- Pod far-pod-1 has no containers\n",
         ),
         RuleScenarioParams(
             "FAR container runs as root (runAsUser=0)",
@@ -2501,8 +2501,8 @@ class TestVerifyFarContainerNonRoot(RuleTestBase):
                     ]
                 ),
             },
-            failed_msg="Testing user running FAR container failed due to:\n"
-            "- Incorrect user running container [0] in pod far-pod-1, expected non 0, found: 0\n",
+            failed_msg="FAR operator pods doesn't have proper security context:\n"
+            "- Container 'container-0' in pod far-pod-1 runs as root (runAsUser=0)\n",
         ),
         RuleScenarioParams(
             "FAR init container runs as root (runAsUser=0)",
@@ -2523,8 +2523,8 @@ class TestVerifyFarContainerNonRoot(RuleTestBase):
                     ]
                 ),
             },
-            failed_msg="Testing user running FAR container failed due to:\n"
-            "- Incorrect user running container [1] in pod far-pod-1, expected non 0, found: 0\n",
+            failed_msg="FAR operator pods doesn't have proper security context:\n"
+            "- Container 'init-container-0' in pod far-pod-1 runs as root (runAsUser=0)\n",
         ),
         RuleScenarioParams(
             "mixed failures - nil SecurityContext and root container",
@@ -2541,9 +2541,26 @@ class TestVerifyFarContainerNonRoot(RuleTestBase):
                     ]
                 ),
             },
-            failed_msg="Testing user running FAR container failed due to:\n"
+            failed_msg="FAR operator pods doesn't have proper security context:\n"
             "- Pod far-pod-1 has nil SecurityContext\n"
-            "- Incorrect user running container [0] in pod far-pod-2, expected non 0, found: 0\n",
+            "- Container 'container-0' in pod far-pod-2 runs as root (runAsUser=0)\n",
+        ),
+        RuleScenarioParams(
+            "FAR container has invalid runAsUser (negative value)",
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_far_subscription_response(has_far=True))
+                ),
+            },
+            tested_object_mock_dict={
+                "oc_api.get_pods": Mock(
+                    return_value=[
+                        _create_far_pod("far-pod-1", run_as_non_root=True, containers_run_as_user=[-1]),
+                    ]
+                ),
+            },
+            failed_msg="FAR operator pods doesn't have proper security context:\n"
+            "- Container 'container--1' in pod far-pod-1 has invalid runAsUser: -1\n",
         ),
     ]
 

--- a/tests/rules/k8s/test_k8s_validations.py
+++ b/tests/rules/k8s/test_k8s_validations.py
@@ -2257,6 +2257,18 @@ def _far_subscription_response(has_far=True):
     return {"items": items}
 
 
+def _far_subscription_response_custom_name():
+    """Build OLM subscription list with custom metadata.name but correct spec.name."""
+    return {
+        "items": [
+            {
+                "metadata": {"name": "my-custom-far-sub", "namespace": "openshift-workload-availability"},
+                "spec": {"name": "fence-agents-remediation"},
+            }
+        ]
+    }
+
+
 def _create_far_pod(
     name,
     run_as_non_root=True,
@@ -2264,6 +2276,7 @@ def _create_far_pod(
     has_security_context=True,
     has_run_as_non_root=True,
     has_containers=True,
+    init_containers_run_as_user=None,
 ):
     """Create a mock FAR pod object for security context tests.
 
@@ -2274,6 +2287,7 @@ def _create_far_pod(
         has_security_context: Whether pod has a securityContext at all
         has_run_as_non_root: Whether runAsNonRoot is present in securityContext
         has_containers: Whether the pod has containers
+        init_containers_run_as_user: List of runAsUser values per init container (None means no initContainers)
     """
     mock_pod = Mock()
     spec = {}
@@ -2300,6 +2314,17 @@ def _create_far_pod(
         spec["containers"] = containers
     else:
         spec["containers"] = []
+
+    if init_containers_run_as_user is not None:
+        init_containers = []
+        for uid in init_containers_run_as_user:
+            ic = {"name": f"init-container-{uid}"}
+            if uid is not None:
+                ic["securityContext"] = {"runAsUser": uid}
+            else:
+                ic["securityContext"] = None
+            init_containers.append(ic)
+        spec["initContainers"] = init_containers
 
     mock_pod.as_dict.return_value = {
         "metadata": {"name": name, "namespace": "openshift-workload-availability"},
@@ -2370,6 +2395,14 @@ class TestVerifyFarContainerNonRoot(RuleTestBase):
             oc_cmd_output_dict={
                 ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
                     json.dumps(_far_subscription_response(has_far=True))
+                ),
+            },
+        ),
+        RuleScenarioParams(
+            "FAR subscription with custom metadata.name but correct spec.name",
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_far_subscription_response_custom_name())
                 ),
             },
         ),
@@ -2469,6 +2502,28 @@ class TestVerifyFarContainerNonRoot(RuleTestBase):
             },
             failed_msg="Testing user running FAR container failed due to:\n"
             "- Incorrect user running container [0] in pod far-pod-1, expected non 0, found: 0\n",
+        ),
+        RuleScenarioParams(
+            "FAR init container runs as root (runAsUser=0)",
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_far_subscription_response(has_far=True))
+                ),
+            },
+            tested_object_mock_dict={
+                "oc_api.get_pods": Mock(
+                    return_value=[
+                        _create_far_pod(
+                            "far-pod-1",
+                            run_as_non_root=True,
+                            containers_run_as_user=[1000],
+                            init_containers_run_as_user=[0],
+                        ),
+                    ]
+                ),
+            },
+            failed_msg="Testing user running FAR container failed due to:\n"
+            "- Incorrect user running container [1] in pod far-pod-1, expected non 0, found: 0\n",
         ),
         RuleScenarioParams(
             "mixed failures - nil SecurityContext and root container",

--- a/wiki-placeholder
+++ b/wiki-placeholder
@@ -1,0 +1,1 @@
+placeholder

--- a/wiki-placeholder
+++ b/wiki-placeholder
@@ -1,1 +1,0 @@
-placeholder


### PR DESCRIPTION
## Summary
- Add `VerifyFarContainerNonRoot` rule to validate that FAR (Fence Agents Remediation) operator pods run as non-root user
- Checks pod-level `runAsNonRoot` is set to true and no container has `runAsUser=0`
- Prerequisite verifies FAR operator is installed via OLM subscription before running the check

## Test plan
- [x] `pre-commit run --all-files` passes
- [x] `pytest tests/rules/k8s/test_k8s_validations.py::TestVerifyFarContainerNonRoot -v` passes
- [x] `pytest tests/domains/test_k8s_domain.py -v` passes
- [x] `python3 -m black --check --line-length=120` on all changed files
- [x] Tested on real cluster: `--debug-rule verify_far_container_non_root --profile telco-base

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Kubernetes validation that, when the FAR operator is detected, verifies FAR pods and all containers (including initContainers) enforce non-root execution; violations are aggregated into a single failure and the check fails if no FAR pods are found.

* **Tests**
  * Added comprehensive tests covering operator detection and many pass/fail scenarios for pod- and container-level security context checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->