### PR TITLE
Feature/nmo operator health check

### DIFF
--- a/src/in_cluster_checks/domains/k8s_domain.py
+++ b/src/in_cluster_checks/domains/k8s_domain.py
@@ -26,6 +26,7 @@ from in_cluster_checks.rules.k8s.k8s_validations import (
     VerifyInternalRegistry,
     VerifyNetworkDiagnosticsDisabled,
     VerifyNfdOperatorHealth,
+    VerifyNmoOperatorHealth,
     VerifyWebConsoleDisabled,
 )
 
@@ -65,6 +66,7 @@ class K8sValidationDomain(RuleDomain):
             VerifyNetworkDiagnosticsDisabled,
             VerifyNfdOperatorHealth,
             VerifyAcmOperatorHealth,
+            VerifyNmoOperatorHealth,
             VerifyFarOperatorHealth,
             VerifyFarContainerNonRoot,
         ]

--- a/src/in_cluster_checks/rules/k8s/k8s_validations.py
+++ b/src/in_cluster_checks/rules/k8s/k8s_validations.py
@@ -1302,6 +1302,66 @@ class VerifyAcmOperatorHealth(SubscriptionOperatorRule):
         return None
 
 
+class VerifyNmoOperatorHealth(SubscriptionOperatorRule):
+    """Verify Node Maintenance Operator (NMO) pods are healthy.
+
+    NMO provides declarative node maintenance for OpenShift clusters,
+    enabling administrators to cordon and drain nodes safely.  This rule
+    checks that the NMO operator has been installed (Subscription exists)
+    and that every pod in the openshift-workload-availability namespace
+    is Running with all containers ready.
+    """
+
+    objective_hosts = [Objectives.ORCHESTRATOR]
+    unique_name = "verify_nmo_operator_health"
+    title = "Verify NMO operator pods are healthy"
+    supported_profiles = {"telco-base"}
+    links = [
+        "https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-NMO-operator-health",
+        "https://docs.redhat.com/en/documentation/workload_availability_for_red_hat_openshift"
+        "/24.1/html/remediation_fencing_and_maintenance/node-maintenance-operator",
+    ]
+
+    operator_subscription_name = "node-maintenance-operator"
+    operator_display_name = "Node Maintenance Operator"
+
+    NMO_NAMESPACE = "openshift-workload-availability"
+
+    def run_rule(self):
+        """Verify all pods in the openshift-workload-availability namespace are Running and Ready."""
+        pod_objects = self.oc_api.get_all_pods(namespace=self.NMO_NAMESPACE)
+
+        if not pod_objects:
+            return RuleResult.failed(
+                f"No pods found in {self.NMO_NAMESPACE} namespace. NMO operator may not be fully deployed."
+            )
+
+        not_ready_pods = []
+        unknown_status_pods = []
+
+        for pod in pod_objects:
+            pod_status = self.oc_api.get_pod_status(pod)
+            if pod_status is None:
+                pod_name = pod.as_dict().get("metadata", {}).get("name", "unknown")
+                unknown_status_pods.append(pod_name)
+                continue
+            if not pod_status["all_containers_ready"]:
+                not_ready_pods.append(pod_status["status_message"])
+
+        if unknown_status_pods or not_ready_pods:
+            parts = []
+            if unknown_status_pods:
+                parts.append("Failed to evaluate status for NMO pod(s):\n  " + "\n  ".join(unknown_status_pods))
+            if not_ready_pods:
+                parts.append(
+                    f"NMO operator has unhealthy pods in {self.NMO_NAMESPACE} namespace:\n  "
+                    + "\n  ".join(not_ready_pods)
+                )
+            return RuleResult.failed("\n\n".join(parts))
+
+        return RuleResult.passed()
+
+
 class VerifyFarOperatorHealth(SubscriptionOperatorRule):
     """Verify Fence Agents Remediation (FAR) operator pods are healthy.
 

--- a/tests/domains/test_k8s_domain.py
+++ b/tests/domains/test_k8s_domain.py
@@ -16,6 +16,7 @@ from in_cluster_checks.rules.k8s.k8s_validations import (
     VerifyInternalRegistry,
     VerifyNetworkDiagnosticsDisabled,
     VerifyNfdOperatorHealth,
+    VerifyNmoOperatorHealth,
     VerifyWebConsoleDisabled,
 )
 
@@ -31,7 +32,7 @@ def test_k8s_domain_rules():
     domain = K8sValidationDomain()
     rules = domain.get_rule_classes()
 
-    assert len(rules) == 18
+    assert len(rules) == 19
     assert AllPodsReadyAndRunning in rules
     assert NodesAreReady in rules
     assert NodesCpuAndMemoryStatus in rules
@@ -46,4 +47,5 @@ def test_k8s_domain_rules():
     assert VerifyNetworkDiagnosticsDisabled in rules
     assert VerifyNfdOperatorHealth in rules
     assert VerifyAcmOperatorHealth in rules
+    assert VerifyNmoOperatorHealth in rules
     assert VerifyFarOperatorHealth in rules

--- a/tests/rules/k8s/test_k8s_validations.py
+++ b/tests/rules/k8s/test_k8s_validations.py
@@ -27,6 +27,7 @@ from in_cluster_checks.rules.k8s.k8s_validations import (
     VerifyInternalRegistry,
     VerifyNetworkDiagnosticsDisabled,
     VerifyNfdOperatorHealth,
+    VerifyNmoOperatorHealth,
     VerifyWebConsoleDisabled,
 )
 from in_cluster_checks.utils.enums import Status
@@ -2706,4 +2707,195 @@ class TestVerifyFarContainerNonRoot(RuleTestBase):
 
     @pytest.mark.parametrize("scenario_params", scenario_failed)
     def test_scenario_failed(self, scenario_params, tested_object):
+        RuleTestBase.test_scenario_failed(self, scenario_params, tested_object)
+
+
+def create_mock_nmo_pod(name, phase, all_containers_ready=True):
+    """Create a mock NMO pod object."""
+    mock_pod = Mock()
+    container_statuses = [
+        {"ready": all_containers_ready},
+    ]
+    mock_pod.as_dict.return_value = {
+        "metadata": {"namespace": "openshift-workload-availability", "name": name},
+        "status": {
+            "phase": phase,
+            "containerStatuses": container_statuses,
+        },
+    }
+    return mock_pod
+
+
+def _nmo_subscriptions(include_nmo=True):
+    """Build a subscriptions response, optionally including the NMO subscription."""
+    items = []
+    if include_nmo:
+        items.append(
+            {
+                "metadata": {"name": "nmo-sub", "namespace": "openshift-workload-availability"},
+                "spec": {"name": "node-maintenance-operator", "source": "redhat-operators"},
+            }
+        )
+    return {"items": items}
+
+
+class TestVerifyNmoOperatorHealth(RuleTestBase):
+    """Tests for VerifyNmoOperatorHealth rule."""
+
+    tested_type = VerifyNmoOperatorHealth
+
+    scenario_prerequisite_fulfilled = [
+        RuleScenarioParams(
+            "NMO operator subscription found",
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_nmo_subscriptions(include_nmo=True))
+                ),
+            },
+        ),
+    ]
+
+    scenario_passed = [
+        RuleScenarioParams(
+            "NMO operator installed and all pods healthy",
+            tested_object_mock_dict={
+                "oc_api.get_all_pods": Mock(
+                    return_value=[
+                        create_mock_nmo_pod("node-maintenance-operator-controller-manager-abc123", "Running", True),
+                    ]
+                ),
+            },
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_nmo_subscriptions(include_nmo=True))
+                ),
+            },
+        ),
+    ]
+
+    scenario_prerequisite_not_fulfilled = [
+        RuleScenarioParams(
+            "NMO operator subscription not found",
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_nmo_subscriptions(include_nmo=False))
+                ),
+            },
+        ),
+        RuleScenarioParams(
+            "no subscriptions exist in cluster",
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps({"items": []})
+                ),
+            },
+        ),
+    ]
+
+    scenario_failed = [
+        RuleScenarioParams(
+            "NMO operator installed but no pods found",
+            tested_object_mock_dict={
+                "oc_api.get_all_pods": Mock(return_value=[]),
+            },
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_nmo_subscriptions(include_nmo=True))
+                ),
+            },
+            failed_msg="No pods found in openshift-workload-availability namespace."
+            " NMO operator may not be fully deployed.",
+        ),
+        RuleScenarioParams(
+            "NMO operator installed but some pods are not running",
+            tested_object_mock_dict={
+                "oc_api.get_all_pods": Mock(
+                    return_value=[
+                        create_mock_nmo_pod("node-maintenance-operator-controller-manager-abc123", "Running", True),
+                        create_mock_nmo_pod("node-maintenance-operator-worker-xyz789", "Pending", True),
+                    ]
+                ),
+            },
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_nmo_subscriptions(include_nmo=True))
+                ),
+            },
+            failed_msg="NMO operator has unhealthy pods in openshift-workload-availability namespace:\n"
+            "  node-maintenance-operator-worker-xyz789 - Phase: Pending",
+        ),
+        RuleScenarioParams(
+            "NMO operator installed but containers not ready",
+            tested_object_mock_dict={
+                "oc_api.get_all_pods": Mock(
+                    return_value=[
+                        create_mock_nmo_pod("node-maintenance-operator-controller-manager-abc123", "Running", False),
+                    ]
+                ),
+            },
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_nmo_subscriptions(include_nmo=True))
+                ),
+            },
+            failed_msg="NMO operator has unhealthy pods in openshift-workload-availability namespace:\n"
+            "  node-maintenance-operator-controller-manager-abc123 - Running, Not all containers ready",
+        ),
+        RuleScenarioParams(
+            "NMO operator installed but pod status unknown",
+            tested_object_mock_dict={
+                "oc_api.get_all_pods": Mock(
+                    return_value=[
+                        create_mock_nmo_pod("node-maintenance-operator-controller-manager-abc123", "Succeeded", True),
+                    ]
+                ),
+            },
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_nmo_subscriptions(include_nmo=True))
+                ),
+            },
+            failed_msg="Failed to evaluate status for NMO pod(s):\n"
+            "  node-maintenance-operator-controller-manager-abc123",
+        ),
+        RuleScenarioParams(
+            "NMO operator installed with unknown and unhealthy pods",
+            tested_object_mock_dict={
+                "oc_api.get_all_pods": Mock(
+                    return_value=[
+                        create_mock_nmo_pod("node-maintenance-operator-controller-manager-abc123", "Succeeded", True),
+                        create_mock_nmo_pod("node-maintenance-operator-worker-xyz789", "Running", False),
+                    ]
+                ),
+            },
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_nmo_subscriptions(include_nmo=True))
+                ),
+            },
+            failed_msg="Failed to evaluate status for NMO pod(s):\n"
+            "  node-maintenance-operator-controller-manager-abc123\n\n"
+            "NMO operator has unhealthy pods in openshift-workload-availability namespace:\n"
+            "  node-maintenance-operator-worker-xyz789 - Running, Not all containers ready",
+        ),
+    ]
+
+    @pytest.mark.parametrize("scenario_params", scenario_prerequisite_fulfilled)
+    def test_prerequisite_fulfilled(self, scenario_params, tested_object):
+        """Test that prerequisite is met when NMO operator is installed."""
+        RuleTestBase.test_prerequisite_fulfilled(self, scenario_params, tested_object)
+
+    @pytest.mark.parametrize("scenario_params", scenario_prerequisite_not_fulfilled)
+    def test_prerequisite_not_fulfilled(self, scenario_params, tested_object):
+        """Test that prerequisite is not met when NMO operator is not installed."""
+        RuleTestBase.test_prerequisite_not_fulfilled(self, scenario_params, tested_object)
+
+    @pytest.mark.parametrize("scenario_params", scenario_passed)
+    def test_scenario_passed(self, scenario_params, tested_object):
+        """Test that rule passes when all NMO pods are healthy."""
+        RuleTestBase.test_scenario_passed(self, scenario_params, tested_object)
+
+    @pytest.mark.parametrize("scenario_params", scenario_failed)
+    def test_scenario_failed(self, scenario_params, tested_object):
+        """Test that rule fails when NMO pods are unhealthy or missing."""
         RuleTestBase.test_scenario_failed(self, scenario_params, tested_object)


### PR DESCRIPTION
## Summary
- Add `VerifyNmoOperatorHealth` rule to validate Node Maintenance Operator health in telco clusters
- Checks NMO OLM subscription exists and all pods in `openshift-workload-availability` namespace are running and ready
- Ref: telco quarterly objective — NMO operator health validation

## Test plan
- [x] `pre-commit run --all-files` passes
- [x] `pytest tests/rules/k8s/test_k8s_validations.py::TestVerifyNmoOperatorHealth -v` passes
- [x] `pytest tests/domains/test_k8s_domain.py -v` passes
- [x] `python3 -m black --check --line-length=120` on all changed files
- [x] Tested on real cluster: `--debug-rule verify_nmo_operator_health --profile telco-base`
- [x] Verify CI coverage passes (patch coverage ≥95%) — add `scenario_prerequisite_fulfilled` if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Kubernetes health check that validates Node Maintenance Operator (NMO) pod presence and container readiness in the workload availability namespace.

* **Tests**
  * Added comprehensive test coverage for the NMO health check, including prerequisite checks, passing scenarios, and multiple failing cases (missing pods, non-running phases, unready containers, mixed outcomes) with test helpers for mock pods and subscriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->