### PR TITLE
Feature/acm csv verification

### DIFF
--- a/src/in_cluster_checks/domains/k8s_domain.py
+++ b/src/in_cluster_checks/domains/k8s_domain.py
@@ -21,6 +21,7 @@ from in_cluster_checks.rules.k8s.k8s_validations import (
     ValidateNamespaceStatus,
     VerifyAcmOperatorHealth,
     VerifyClusterOperatorsAvailable,
+    VerifyFarContainerNonRoot,
     VerifyFarOperatorHealth,
     VerifyInternalRegistry,
     VerifyNetworkDiagnosticsDisabled,
@@ -65,4 +66,5 @@ class K8sValidationDomain(RuleDomain):
             VerifyNfdOperatorHealth,
             VerifyAcmOperatorHealth,
             VerifyFarOperatorHealth,
+            VerifyFarContainerNonRoot,
         ]

--- a/src/in_cluster_checks/rules/k8s/k8s_validations.py
+++ b/src/in_cluster_checks/rules/k8s/k8s_validations.py
@@ -10,6 +10,7 @@ from in_cluster_checks.core.exceptions import UnExpectedSystemOutput
 from in_cluster_checks.core.rule import OrchestratorRule
 from in_cluster_checks.core.rule_result import PrerequisiteResult, RuleResult
 from in_cluster_checks.utils.enums import Objectives, Status
+from in_cluster_checks.utils.parsing_utils import parse_json
 
 
 class AllPodsReadyAndRunning(OrchestratorRule):
@@ -991,6 +992,56 @@ class SubscriptionOperatorRule(OrchestratorRule):
             f"{self.operator_display_name} operator is not installed on this cluster"
         )
 
+    def _check_pod_security_context(self, pod_name: str, security_context: dict[str, object] | None) -> list[str]:
+        """Validate pod-level security context has runAsNonRoot set to true.
+
+        Args:
+            pod_name: Pod name.
+            security_context: Pod-level security context.
+
+        Returns:
+            List of validation error messages.
+        """
+        errors = []
+        if security_context is None:
+            errors.append(f"Pod {pod_name} has nil SecurityContext")
+        elif security_context.get("runAsNonRoot") is None:
+            errors.append(f"Pod {pod_name} has nil runAsNonRoot")
+        elif not security_context.get("runAsNonRoot"):
+            errors.append(
+                f"Incorrect runAsNonRoot for pod {pod_name}. "
+                f"Expected true, found: {security_context.get('runAsNonRoot')}"
+            )
+        return errors
+
+    def _check_containers_non_root(self, pod_name: str, all_containers: list[dict[str, object]]) -> list[str]:
+        """Validate no container runs as root (runAsUser != 0).
+
+        Args:
+            pod_name: Pod name.
+            all_containers: Combined containers and initContainers list.
+
+        Returns:
+            List of validation error messages.
+        """
+        errors = []
+        if not all_containers:
+            errors.append(f"Pod {pod_name} has no containers")
+            return errors
+        for container in all_containers:
+            container_name = container.get("name", "unknown")
+            container_sc = container.get("securityContext")
+            if container_sc is not None:
+                run_as_user = container_sc.get("runAsUser")
+                if run_as_user is not None:
+                    if not isinstance(run_as_user, int) or run_as_user < 0:
+                        errors.append(
+                            f"Container '{container_name}' in pod {pod_name} has invalid runAsUser: {run_as_user}"
+                        )
+                    elif run_as_user == 0:
+                        errors.append(f"Container '{container_name}' in pod {pod_name} runs as root (runAsUser=0)")
+        return errors
+
 
 class VerifyNfdOperatorHealth(SubscriptionOperatorRule):
     """Verify Node Feature Discovery (NFD) operator pods are healthy.
@@ -1124,8 +1175,9 @@ class VerifyAcmOperatorHealth(SubscriptionOperatorRule):
 
     ACM orchestrates multicluster lifecycle management on the hub cluster.
     This rule checks that the ACM operator has been installed (Subscription
-    exists) and that every pod in the open-cluster-management namespace is
-    Running with all containers ready.
+    exists), that the ClusterServiceVersion is in Succeeded phase, and that
+    every pod in the open-cluster-management namespace is Running with all
+    containers ready.
     """
 
     objective_hosts = [Objectives.ORCHESTRATOR]
@@ -1142,15 +1194,64 @@ class VerifyAcmOperatorHealth(SubscriptionOperatorRule):
     operator_display_name = "Advanced Cluster Management"
 
     ACM_NAMESPACE = "open-cluster-management"
+    ACM_CSV_PATTERN = "advanced-cluster-management"
 
     def run_rule(self):
-        """Verify all pods in the open-cluster-management namespace are Running and Ready."""
+        """Verify ACM CSV is Succeeded and all pods in the namespace are Running and Ready."""
+        csv_error = self._verify_csv_status()
+        pod_error = self._verify_pods_status()
+
+        errors = [e for e in (csv_error, pod_error) if e]
+        if errors:
+            return RuleResult.failed("\n\n".join(errors))
+
+        return RuleResult.passed()
+
+    def _verify_csv_status(self):
+        """Check that the ACM ClusterServiceVersion is in Succeeded phase.
+
+        Returns:
+            Error message string if CSV check fails, None if successful.
+        """
+        _, csv_output, _ = self.oc_api.run_oc_command(
+            "get", ["csv", "-n", self.ACM_NAMESPACE, "-o", "json"], timeout=45
+        )
+        csv_data = parse_json(csv_output, f"oc get csv -n {self.ACM_NAMESPACE} -o json", self.get_host_ip())
+
+        acm_csvs = [
+            csv for csv in csv_data.get("items", []) if self.ACM_CSV_PATTERN in csv.get("metadata", {}).get("name", "")
+        ]
+
+        if not acm_csvs:
+            return (
+                f"No ClusterServiceVersion matching '{self.ACM_CSV_PATTERN}' "
+                f"found in {self.ACM_NAMESPACE} namespace"
+            )
+
+        not_succeeded = []
+        for csv in acm_csvs:
+            name = csv.get("metadata", {}).get("name", "unknown")
+            phase = csv.get("status", {}).get("phase", "Unknown")
+            if phase != "Succeeded":
+                reason = csv.get("status", {}).get("reason", "Unknown")
+                message = csv.get("status", {}).get("message", "")
+                not_succeeded.append(f"{name} - Phase: {phase}, Reason: {reason}, Message: {message}")
+
+        if not_succeeded:
+            return "ACM ClusterServiceVersion is not in Succeeded phase:\n  " + "\n  ".join(not_succeeded)
+
+        return None
+
+    def _verify_pods_status(self):
+        """Check that all pods in the ACM namespace are Running and Ready.
+
+        Returns:
+            Error message string if pod check fails, None if successful.
+        """
         pod_objects = self.oc_api.get_all_pods(namespace=self.ACM_NAMESPACE)
 
         if not pod_objects:
-            return RuleResult.failed(
-                f"No pods found in {self.ACM_NAMESPACE} namespace. ACM operator may not be fully deployed."
-            )
+            return f"No pods found in {self.ACM_NAMESPACE} namespace. ACM operator may not be fully deployed."
 
         not_ready_pods = []
         unknown_status_pods = []
@@ -1173,9 +1274,9 @@ class VerifyAcmOperatorHealth(SubscriptionOperatorRule):
                     f"ACM operator has unhealthy pods in {self.ACM_NAMESPACE} namespace:\n  "
                     + "\n  ".join(not_ready_pods)
                 )
-            return RuleResult.failed("\n\n".join(parts))
+            return "\n\n".join(parts)
 
-        return RuleResult.passed()
+        return None
 
 
 class VerifyFarOperatorHealth(SubscriptionOperatorRule):
@@ -1232,5 +1333,57 @@ class VerifyFarOperatorHealth(SubscriptionOperatorRule):
                     + "\n  ".join(not_ready_pods)
                 )
             return RuleResult.failed("\n\n".join(parts))
+
+        return RuleResult.passed()
+
+
+class VerifyFarContainerNonRoot(SubscriptionOperatorRule):
+    """Verify FAR (Fence Agents Remediation) container runs as non-root user.
+
+    Checks that FAR operator pods have proper security context:
+    - Pod-level runAsNonRoot is set to true
+    - No container runs as root (runAsUser != 0)
+    """
+
+    objective_hosts = [Objectives.ORCHESTRATOR]
+    unique_name = "verify_far_container_non_root"
+    title = "Verify FAR container runs as non-root user"
+    supported_profiles = {"telco-base"}
+    links = [
+        "https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-FAR-container-non%E2%80%90root",
+        "https://docs.openshift.com/container-platform/4.18/nodes/pods/nodes-pods-configuring.html",
+    ]
+
+    operator_subscription_name = "fence-agents-remediation"
+    operator_display_name = "Fence Agents Remediation"
+
+    FAR_POD_LABEL_KEY = "app.kubernetes.io/name"
+    FAR_POD_LABEL_VALUE = "fence-agents-remediation-operator"
+
+    def run_rule(self):
+        """Check if FAR pods run as non-root user with proper security context."""
+        pod_objects = self.oc_api.get_pods(labels={self.FAR_POD_LABEL_KEY: self.FAR_POD_LABEL_VALUE})
+
+        if not pod_objects:
+            return RuleResult.failed(
+                f"No FAR pods found with label {self.FAR_POD_LABEL_KEY}={self.FAR_POD_LABEL_VALUE}"
+            )
+
+        error_messages = []
+
+        for pod in pod_objects:
+            pod_name = pod.name()
+            spec = pod.as_dict().get("spec", {})
+
+            error_messages.extend(self._check_pod_security_context(pod_name, spec.get("securityContext")))
+
+            all_containers = spec.get("containers", []) + spec.get("initContainers", [])
+            error_messages.extend(self._check_containers_non_root(pod_name, all_containers))
+
+        if error_messages:
+            message = "FAR operator pods doesn't have proper security context:\n"
+            for msg in error_messages:
+                message += f"- {msg}\n"
+            return RuleResult.failed(message)
 
         return RuleResult.passed()

--- a/src/in_cluster_checks/rules/k8s/k8s_validations.py
+++ b/src/in_cluster_checks/rules/k8s/k8s_validations.py
@@ -1210,6 +1210,9 @@ class VerifyAcmOperatorHealth(SubscriptionOperatorRule):
     def _verify_csv_status(self):
         """Check that the ACM ClusterServiceVersion is in Succeeded phase.
 
+        Uses status.installedCSV from the operator subscription when available
+        to identify the active CSV; falls back to pattern matching.
+
         Returns:
             Error message string if CSV check fails, None if successful.
         """
@@ -1218,9 +1221,17 @@ class VerifyAcmOperatorHealth(SubscriptionOperatorRule):
         )
         csv_data = parse_json(csv_output, f"oc get csv -n {self.ACM_NAMESPACE} -o json", self.get_host_ip())
 
-        acm_csvs = [
-            csv for csv in csv_data.get("items", []) if self.ACM_CSV_PATTERN in csv.get("metadata", {}).get("name", "")
-        ]
+        installed_csv_name = self._get_installed_csv_name()
+        if installed_csv_name:
+            acm_csvs = [
+                csv for csv in csv_data.get("items", []) if csv.get("metadata", {}).get("name") == installed_csv_name
+            ]
+        else:
+            acm_csvs = [
+                csv
+                for csv in csv_data.get("items", [])
+                if self.ACM_CSV_PATTERN in csv.get("metadata", {}).get("name", "")
+            ]
 
         if not acm_csvs:
             return (
@@ -1240,6 +1251,18 @@ class VerifyAcmOperatorHealth(SubscriptionOperatorRule):
         if not_succeeded:
             return "ACM ClusterServiceVersion is not in Succeeded phase:\n  " + "\n  ".join(not_succeeded)
 
+        return None
+
+    def _get_installed_csv_name(self):
+        """Look up status.installedCSV from the ACM operator subscription.
+
+        Returns:
+            The installedCSV string if found, None otherwise.
+        """
+        subscriptions_data = self.oc_api.get_operator_subscriptions()
+        for sub in subscriptions_data.get("items", []):
+            if sub.get("spec", {}).get("name") == self.operator_subscription_name:
+                return sub.get("status", {}).get("installedCSV")
         return None
 
     def _verify_pods_status(self):

--- a/tests/domains/test_k8s_domain.py
+++ b/tests/domains/test_k8s_domain.py
@@ -11,6 +11,7 @@ from in_cluster_checks.rules.k8s.k8s_validations import (
     ValidateAllPoliciesCompliant,
     VerifyAcmOperatorHealth,
     VerifyClusterOperatorsAvailable,
+    VerifyFarContainerNonRoot,
     VerifyFarOperatorHealth,
     VerifyInternalRegistry,
     VerifyNetworkDiagnosticsDisabled,
@@ -30,7 +31,7 @@ def test_k8s_domain_rules():
     domain = K8sValidationDomain()
     rules = domain.get_rule_classes()
 
-    assert len(rules) == 17
+    assert len(rules) == 18
     assert AllPodsReadyAndRunning in rules
     assert NodesAreReady in rules
     assert NodesCpuAndMemoryStatus in rules
@@ -39,6 +40,7 @@ def test_k8s_domain_rules():
     assert OpenshiftOperatorStatus in rules
     assert ValidateAllPoliciesCompliant in rules
     assert VerifyClusterOperatorsAvailable in rules
+    assert VerifyFarContainerNonRoot in rules
     assert VerifyInternalRegistry in rules
     assert VerifyWebConsoleDisabled in rules
     assert VerifyNetworkDiagnosticsDisabled in rules

--- a/tests/rules/k8s/test_k8s_validations.py
+++ b/tests/rules/k8s/test_k8s_validations.py
@@ -22,6 +22,7 @@ from in_cluster_checks.rules.k8s.k8s_validations import (
     ValidateNamespaceStatus,
     VerifyAcmOperatorHealth,
     VerifyClusterOperatorsAvailable,
+    VerifyFarContainerNonRoot,
     VerifyFarOperatorHealth,
     VerifyInternalRegistry,
     VerifyNetworkDiagnosticsDisabled,
@@ -1926,14 +1927,49 @@ def _acm_subscriptions(include_acm=True):
     return {"items": items}
 
 
+def _acm_csv_response(include_csv=True, phase="Succeeded"):
+    """Build a ClusterServiceVersion list response for ACM."""
+    items = []
+    if include_csv:
+        reason = "InstallSucceeded" if phase == "Succeeded" else "InstallFailed"
+        message = "install strategy completed with no errors" if phase == "Succeeded" else "install failed"
+        items.append(
+            {
+                "metadata": {
+                    "name": "advanced-cluster-management.v2.12.0",
+                    "namespace": "open-cluster-management",
+                },
+                "status": {
+                    "phase": phase,
+                    "reason": reason,
+                    "message": message,
+                },
+            }
+        )
+    return {"items": items}
+
+
+_ACM_SUB_CMD = ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json"))
+_ACM_CSV_CMD = ("get", ("csv", "-n", "open-cluster-management", "-o", "json"))
+
+
 class TestVerifyAcmOperatorHealth(RuleTestBase):
     """Test VerifyAcmOperatorHealth rule."""
 
     tested_type = VerifyAcmOperatorHealth
 
+    scenario_prerequisite_fulfilled = [
+        RuleScenarioParams(
+            "ACM operator subscription found",
+            oc_cmd_output_dict={
+                _ACM_SUB_CMD: CmdOutput(json.dumps(_acm_subscriptions(include_acm=True))),
+            },
+        ),
+    ]
+
     scenario_passed = [
         RuleScenarioParams(
-            "ACM operator installed and all pods are healthy",
+            "ACM operator installed, CSV succeeded, and all pods are healthy",
             tested_object_mock_dict={
                 "oc_api.get_all_pods": Mock(
                     return_value=[
@@ -1943,9 +1979,8 @@ class TestVerifyAcmOperatorHealth(RuleTestBase):
                 ),
             },
             oc_cmd_output_dict={
-                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
-                    json.dumps(_acm_subscriptions(include_acm=True))
-                ),
+                _ACM_SUB_CMD: CmdOutput(json.dumps(_acm_subscriptions(include_acm=True))),
+                _ACM_CSV_CMD: CmdOutput(json.dumps(_acm_csv_response())),
             },
         ),
     ]
@@ -1954,36 +1989,67 @@ class TestVerifyAcmOperatorHealth(RuleTestBase):
         RuleScenarioParams(
             "ACM operator subscription not found",
             oc_cmd_output_dict={
-                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
-                    json.dumps(_acm_subscriptions(include_acm=False))
-                ),
+                _ACM_SUB_CMD: CmdOutput(json.dumps(_acm_subscriptions(include_acm=False))),
             },
         ),
         RuleScenarioParams(
             "no subscriptions exist in cluster",
             oc_cmd_output_dict={
-                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
-                    json.dumps({"items": []})
-                ),
+                _ACM_SUB_CMD: CmdOutput(json.dumps({"items": []})),
             },
         ),
     ]
 
     scenario_failed = [
         RuleScenarioParams(
-            "ACM operator installed but no pods found",
+            "ACM CSV not found in namespace",
+            tested_object_mock_dict={
+                "oc_api.get_all_pods": Mock(
+                    return_value=[
+                        create_mock_acm_pod("multiclusterhub-operator-abc123", "Running", True),
+                    ]
+                ),
+            },
+            oc_cmd_output_dict={
+                _ACM_SUB_CMD: CmdOutput(json.dumps(_acm_subscriptions(include_acm=True))),
+                _ACM_CSV_CMD: CmdOutput(json.dumps(_acm_csv_response(include_csv=False))),
+            },
+            failed_msg=(
+                "No ClusterServiceVersion matching 'advanced-cluster-management' "
+                "found in open-cluster-management namespace"
+            ),
+        ),
+        RuleScenarioParams(
+            "ACM CSV in Failed phase",
+            tested_object_mock_dict={
+                "oc_api.get_all_pods": Mock(
+                    return_value=[
+                        create_mock_acm_pod("multiclusterhub-operator-abc123", "Running", True),
+                    ]
+                ),
+            },
+            oc_cmd_output_dict={
+                _ACM_SUB_CMD: CmdOutput(json.dumps(_acm_subscriptions(include_acm=True))),
+                _ACM_CSV_CMD: CmdOutput(json.dumps(_acm_csv_response(phase="Failed"))),
+            },
+            failed_msg=(
+                "ACM ClusterServiceVersion is not in Succeeded phase:\n"
+                "  advanced-cluster-management.v2.12.0 - Phase: Failed, Reason: InstallFailed, Message: install failed"
+            ),
+        ),
+        RuleScenarioParams(
+            "ACM CSV succeeded but no pods found",
             tested_object_mock_dict={
                 "oc_api.get_all_pods": Mock(return_value=[]),
             },
             oc_cmd_output_dict={
-                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
-                    json.dumps(_acm_subscriptions(include_acm=True))
-                ),
+                _ACM_SUB_CMD: CmdOutput(json.dumps(_acm_subscriptions(include_acm=True))),
+                _ACM_CSV_CMD: CmdOutput(json.dumps(_acm_csv_response())),
             },
             failed_msg="No pods found in open-cluster-management namespace. ACM operator may not be fully deployed.",
         ),
         RuleScenarioParams(
-            "ACM operator installed but some pods are not running",
+            "ACM CSV succeeded but some pods are not running",
             tested_object_mock_dict={
                 "oc_api.get_all_pods": Mock(
                     return_value=[
@@ -1993,15 +2059,16 @@ class TestVerifyAcmOperatorHealth(RuleTestBase):
                 ),
             },
             oc_cmd_output_dict={
-                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
-                    json.dumps(_acm_subscriptions(include_acm=True))
-                ),
+                _ACM_SUB_CMD: CmdOutput(json.dumps(_acm_subscriptions(include_acm=True))),
+                _ACM_CSV_CMD: CmdOutput(json.dumps(_acm_csv_response())),
             },
-            failed_msg="ACM operator has unhealthy pods in open-cluster-management namespace:\n"
-            "  cluster-manager-xyz789 - Phase: Pending",
+            failed_msg=(
+                "ACM operator has unhealthy pods in open-cluster-management namespace:\n"
+                "  cluster-manager-xyz789 - Phase: Pending"
+            ),
         ),
         RuleScenarioParams(
-            "ACM operator installed but containers not ready",
+            "ACM CSV succeeded but containers not ready",
             tested_object_mock_dict={
                 "oc_api.get_all_pods": Mock(
                     return_value=[
@@ -2010,15 +2077,16 @@ class TestVerifyAcmOperatorHealth(RuleTestBase):
                 ),
             },
             oc_cmd_output_dict={
-                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
-                    json.dumps(_acm_subscriptions(include_acm=True))
-                ),
+                _ACM_SUB_CMD: CmdOutput(json.dumps(_acm_subscriptions(include_acm=True))),
+                _ACM_CSV_CMD: CmdOutput(json.dumps(_acm_csv_response())),
             },
-            failed_msg="ACM operator has unhealthy pods in open-cluster-management namespace:\n"
-            "  multiclusterhub-operator-abc123 - Running, Not all containers ready",
+            failed_msg=(
+                "ACM operator has unhealthy pods in open-cluster-management namespace:\n"
+                "  multiclusterhub-operator-abc123 - Running, Not all containers ready"
+            ),
         ),
         RuleScenarioParams(
-            "ACM operator installed but pod status unknown",
+            "ACM CSV succeeded but pod status unknown",
             tested_object_mock_dict={
                 "oc_api.get_all_pods": Mock(
                     return_value=[
@@ -2027,13 +2095,59 @@ class TestVerifyAcmOperatorHealth(RuleTestBase):
                 ),
             },
             oc_cmd_output_dict={
-                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
-                    json.dumps(_acm_subscriptions(include_acm=True))
-                ),
+                _ACM_SUB_CMD: CmdOutput(json.dumps(_acm_subscriptions(include_acm=True))),
+                _ACM_CSV_CMD: CmdOutput(json.dumps(_acm_csv_response())),
             },
             failed_msg="Failed to evaluate status for ACM pod(s):\n  multiclusterhub-operator-abc123",
         ),
+        RuleScenarioParams(
+            "ACM CSV succeeded but mixed unknown and unhealthy pods",
+            tested_object_mock_dict={
+                "oc_api.get_all_pods": Mock(
+                    return_value=[
+                        create_mock_acm_pod("completed-job-pod", "Succeeded", True),
+                        create_mock_acm_pod("cluster-manager-xyz789", "Pending", True),
+                    ]
+                ),
+            },
+            oc_cmd_output_dict={
+                _ACM_SUB_CMD: CmdOutput(json.dumps(_acm_subscriptions(include_acm=True))),
+                _ACM_CSV_CMD: CmdOutput(json.dumps(_acm_csv_response())),
+            },
+            failed_msg=(
+                "Failed to evaluate status for ACM pod(s):\n"
+                "  completed-job-pod\n\n"
+                "ACM operator has unhealthy pods in open-cluster-management namespace:\n"
+                "  cluster-manager-xyz789 - Phase: Pending"
+            ),
+        ),
+        RuleScenarioParams(
+            "ACM CSV failed and pods unhealthy",
+            tested_object_mock_dict={
+                "oc_api.get_all_pods": Mock(
+                    return_value=[
+                        create_mock_acm_pod("multiclusterhub-operator-abc123", "Pending", True),
+                    ]
+                ),
+            },
+            oc_cmd_output_dict={
+                _ACM_SUB_CMD: CmdOutput(json.dumps(_acm_subscriptions(include_acm=True))),
+                _ACM_CSV_CMD: CmdOutput(json.dumps(_acm_csv_response(phase="Failed"))),
+            },
+            failed_msg=(
+                "ACM ClusterServiceVersion is not in Succeeded phase:\n"
+                "  advanced-cluster-management.v2.12.0 - Phase: Failed, "
+                "Reason: InstallFailed, Message: install failed\n\n"
+                "ACM operator has unhealthy pods in open-cluster-management namespace:\n"
+                "  multiclusterhub-operator-abc123 - Phase: Pending"
+            ),
+        ),
     ]
+
+    @pytest.mark.parametrize("scenario_params", scenario_prerequisite_fulfilled)
+    def test_prerequisite_fulfilled(self, scenario_params, tested_object):
+        """Test that prerequisite is met when ACM operator subscription exists."""
+        RuleTestBase.test_prerequisite_fulfilled(self, scenario_params, tested_object)
 
     @pytest.mark.parametrize("scenario_params", scenario_prerequisite_not_fulfilled)
     def test_prerequisite_not_fulfilled(self, scenario_params, tested_object):
@@ -2042,12 +2156,12 @@ class TestVerifyAcmOperatorHealth(RuleTestBase):
 
     @pytest.mark.parametrize("scenario_params", scenario_passed)
     def test_scenario_passed(self, scenario_params, tested_object):
-        """Test that rule passes when all ACM pods are healthy."""
+        """Test that rule passes when ACM CSV is succeeded and all pods are healthy."""
         RuleTestBase.test_scenario_passed(self, scenario_params, tested_object)
 
     @pytest.mark.parametrize("scenario_params", scenario_failed)
     def test_scenario_failed(self, scenario_params, tested_object):
-        """Test that rule fails when ACM pods are unhealthy or missing."""
+        """Test that rule fails when ACM CSV or pods are unhealthy."""
         RuleTestBase.test_scenario_failed(self, scenario_params, tested_object)
 
 
@@ -2240,4 +2354,341 @@ class TestVerifyFarOperatorHealth(RuleTestBase):
     @pytest.mark.parametrize("scenario_params", scenario_failed)
     def test_scenario_failed(self, scenario_params, tested_object):
         """Test that rule fails when FAR pods are unhealthy or missing."""
+        RuleTestBase.test_scenario_failed(self, scenario_params, tested_object)
+
+
+def _far_subscription_response(has_far=True):
+    """Build OLM subscription list response."""
+    items = []
+    if has_far:
+        items.append(
+            {
+                "metadata": {"name": "fence-agents-remediation", "namespace": "openshift-workload-availability"},
+                "spec": {"name": "fence-agents-remediation"},
+            }
+        )
+    return {"items": items}
+
+
+def _far_subscription_response_custom_name():
+    """Build OLM subscription list with custom metadata.name but correct spec.name."""
+    return {
+        "items": [
+            {
+                "metadata": {"name": "my-custom-far-sub", "namespace": "openshift-workload-availability"},
+                "spec": {"name": "fence-agents-remediation"},
+            }
+        ]
+    }
+
+
+def _create_far_pod(
+    name,
+    run_as_non_root=True,
+    containers_run_as_user=None,
+    has_security_context=True,
+    has_run_as_non_root=True,
+    has_containers=True,
+    init_containers_run_as_user=None,
+):
+    """Create a mock FAR pod object for security context tests.
+
+    Args:
+        name: Pod name
+        run_as_non_root: Value for pod-level runAsNonRoot
+        containers_run_as_user: List of runAsUser values per container (None means no securityContext)
+        has_security_context: Whether pod has a securityContext at all
+        has_run_as_non_root: Whether runAsNonRoot is present in securityContext
+        has_containers: Whether the pod has containers
+        init_containers_run_as_user: List of runAsUser values per init container (None means no initContainers)
+    """
+    mock_pod = Mock()
+    spec = {}
+
+    if has_security_context:
+        sc = {}
+        if has_run_as_non_root:
+            sc["runAsNonRoot"] = run_as_non_root
+        spec["securityContext"] = sc
+    else:
+        spec["securityContext"] = None
+
+    if has_containers:
+        containers = []
+        if containers_run_as_user is None:
+            containers_run_as_user = [1000]
+        for uid in containers_run_as_user:
+            container = {"name": f"container-{uid}"}
+            if uid is not None:
+                container["securityContext"] = {"runAsUser": uid}
+            else:
+                container["securityContext"] = None
+            containers.append(container)
+        spec["containers"] = containers
+    else:
+        spec["containers"] = []
+
+    if init_containers_run_as_user is not None:
+        init_containers = []
+        for uid in init_containers_run_as_user:
+            ic = {"name": f"init-container-{uid}"}
+            if uid is not None:
+                ic["securityContext"] = {"runAsUser": uid}
+            else:
+                ic["securityContext"] = None
+            init_containers.append(ic)
+        spec["initContainers"] = init_containers
+
+    mock_pod.name.return_value = name
+    mock_pod.as_dict.return_value = {
+        "metadata": {"name": name, "namespace": "openshift-workload-availability"},
+        "spec": spec,
+    }
+    return mock_pod
+
+
+class TestVerifyFarContainerNonRoot(RuleTestBase):
+    """Test VerifyFarContainerNonRoot rule."""
+
+    tested_type = VerifyFarContainerNonRoot
+
+    scenario_passed = [
+        RuleScenarioParams(
+            "FAR pod runs as non-root with proper security context",
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_far_subscription_response(has_far=True))
+                ),
+            },
+            tested_object_mock_dict={
+                "oc_api.get_pods": Mock(
+                    return_value=[
+                        _create_far_pod(
+                            "far-controller-manager-abc123", run_as_non_root=True, containers_run_as_user=[1000]
+                        ),
+                    ]
+                ),
+            },
+        ),
+        RuleScenarioParams(
+            "multiple FAR pods all run as non-root",
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_far_subscription_response(has_far=True))
+                ),
+            },
+            tested_object_mock_dict={
+                "oc_api.get_pods": Mock(
+                    return_value=[
+                        _create_far_pod(
+                            "far-controller-manager-abc123", run_as_non_root=True, containers_run_as_user=[1000]
+                        ),
+                        _create_far_pod(
+                            "far-controller-manager-def456", run_as_non_root=True, containers_run_as_user=[1000, 65534]
+                        ),
+                    ]
+                ),
+            },
+        ),
+    ]
+
+    scenario_prerequisite_not_fulfilled = [
+        RuleScenarioParams(
+            "FAR operator subscription not found",
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_far_subscription_response(has_far=False))
+                ),
+            },
+        ),
+    ]
+
+    scenario_prerequisite_fulfilled = [
+        RuleScenarioParams(
+            "FAR operator subscription exists",
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_far_subscription_response(has_far=True))
+                ),
+            },
+        ),
+        RuleScenarioParams(
+            "FAR subscription with custom metadata.name but correct spec.name",
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_far_subscription_response_custom_name())
+                ),
+            },
+        ),
+    ]
+
+    scenario_failed = [
+        RuleScenarioParams(
+            "no FAR pods found",
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_far_subscription_response(has_far=True))
+                ),
+            },
+            tested_object_mock_dict={
+                "oc_api.get_pods": Mock(return_value=[]),
+            },
+            failed_msg="No FAR pods found with label app.kubernetes.io/name=fence-agents-remediation-operator",
+        ),
+        RuleScenarioParams(
+            "FAR pod has nil SecurityContext",
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_far_subscription_response(has_far=True))
+                ),
+            },
+            tested_object_mock_dict={
+                "oc_api.get_pods": Mock(
+                    return_value=[
+                        _create_far_pod("far-pod-1", has_security_context=False),
+                    ]
+                ),
+            },
+            failed_msg="FAR operator pods doesn't have proper security context:\n- Pod far-pod-1 has nil SecurityContext\n",
+        ),
+        RuleScenarioParams(
+            "FAR pod has nil runAsNonRoot",
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_far_subscription_response(has_far=True))
+                ),
+            },
+            tested_object_mock_dict={
+                "oc_api.get_pods": Mock(
+                    return_value=[
+                        _create_far_pod("far-pod-1", has_run_as_non_root=False),
+                    ]
+                ),
+            },
+            failed_msg="FAR operator pods doesn't have proper security context:\n- Pod far-pod-1 has nil runAsNonRoot\n",
+        ),
+        RuleScenarioParams(
+            "FAR pod has runAsNonRoot set to false",
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_far_subscription_response(has_far=True))
+                ),
+            },
+            tested_object_mock_dict={
+                "oc_api.get_pods": Mock(
+                    return_value=[
+                        _create_far_pod("far-pod-1", run_as_non_root=False),
+                    ]
+                ),
+            },
+            failed_msg="FAR operator pods doesn't have proper security context:\n"
+            "- Incorrect runAsNonRoot for pod far-pod-1. Expected true, found: False\n",
+        ),
+        RuleScenarioParams(
+            "FAR pod has no containers",
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_far_subscription_response(has_far=True))
+                ),
+            },
+            tested_object_mock_dict={
+                "oc_api.get_pods": Mock(
+                    return_value=[
+                        _create_far_pod("far-pod-1", has_containers=False),
+                    ]
+                ),
+            },
+            failed_msg="FAR operator pods doesn't have proper security context:\n- Pod far-pod-1 has no containers\n",
+        ),
+        RuleScenarioParams(
+            "FAR container runs as root (runAsUser=0)",
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_far_subscription_response(has_far=True))
+                ),
+            },
+            tested_object_mock_dict={
+                "oc_api.get_pods": Mock(
+                    return_value=[
+                        _create_far_pod("far-pod-1", run_as_non_root=True, containers_run_as_user=[0]),
+                    ]
+                ),
+            },
+            failed_msg="FAR operator pods doesn't have proper security context:\n"
+            "- Container 'container-0' in pod far-pod-1 runs as root (runAsUser=0)\n",
+        ),
+        RuleScenarioParams(
+            "FAR init container runs as root (runAsUser=0)",
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_far_subscription_response(has_far=True))
+                ),
+            },
+            tested_object_mock_dict={
+                "oc_api.get_pods": Mock(
+                    return_value=[
+                        _create_far_pod(
+                            "far-pod-1",
+                            run_as_non_root=True,
+                            containers_run_as_user=[1000],
+                            init_containers_run_as_user=[0],
+                        ),
+                    ]
+                ),
+            },
+            failed_msg="FAR operator pods doesn't have proper security context:\n"
+            "- Container 'init-container-0' in pod far-pod-1 runs as root (runAsUser=0)\n",
+        ),
+        RuleScenarioParams(
+            "mixed failures - nil SecurityContext and root container",
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_far_subscription_response(has_far=True))
+                ),
+            },
+            tested_object_mock_dict={
+                "oc_api.get_pods": Mock(
+                    return_value=[
+                        _create_far_pod("far-pod-1", has_security_context=False),
+                        _create_far_pod("far-pod-2", run_as_non_root=True, containers_run_as_user=[0, 1000]),
+                    ]
+                ),
+            },
+            failed_msg="FAR operator pods doesn't have proper security context:\n"
+            "- Pod far-pod-1 has nil SecurityContext\n"
+            "- Container 'container-0' in pod far-pod-2 runs as root (runAsUser=0)\n",
+        ),
+        RuleScenarioParams(
+            "FAR container has invalid runAsUser (negative value)",
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_far_subscription_response(has_far=True))
+                ),
+            },
+            tested_object_mock_dict={
+                "oc_api.get_pods": Mock(
+                    return_value=[
+                        _create_far_pod("far-pod-1", run_as_non_root=True, containers_run_as_user=[-1]),
+                    ]
+                ),
+            },
+            failed_msg="FAR operator pods doesn't have proper security context:\n"
+            "- Container 'container--1' in pod far-pod-1 has invalid runAsUser: -1\n",
+        ),
+    ]
+
+    @pytest.mark.parametrize("scenario_params", scenario_prerequisite_not_fulfilled)
+    def test_prerequisite_not_fulfilled(self, scenario_params, tested_object):
+        RuleTestBase.test_prerequisite_not_fulfilled(self, scenario_params, tested_object)
+
+    @pytest.mark.parametrize("scenario_params", scenario_prerequisite_fulfilled)
+    def test_prerequisite_fulfilled(self, scenario_params, tested_object):
+        RuleTestBase.test_prerequisite_fulfilled(self, scenario_params, tested_object)
+
+    @pytest.mark.parametrize("scenario_params", scenario_passed)
+    def test_scenario_passed(self, scenario_params, tested_object):
+        RuleTestBase.test_scenario_passed(self, scenario_params, tested_object)
+
+    @pytest.mark.parametrize("scenario_params", scenario_failed)
+    def test_scenario_failed(self, scenario_params, tested_object):
         RuleTestBase.test_scenario_failed(self, scenario_params, tested_object)

--- a/tests/rules/k8s/test_k8s_validations.py
+++ b/tests/rules/k8s/test_k8s_validations.py
@@ -1908,16 +1908,17 @@ def create_mock_acm_pod(name, phase, all_containers_ready=True):
     return mock_pod
 
 
-def _acm_subscriptions(include_acm=True):
+def _acm_subscriptions(include_acm=True, installed_csv="advanced-cluster-management.v2.12.0"):
     """Build a subscriptions response, optionally including the ACM subscription."""
     items = []
     if include_acm:
-        items.append(
-            {
-                "metadata": {"name": "acm-sub", "namespace": "open-cluster-management"},
-                "spec": {"name": "advanced-cluster-management", "source": "redhat-operators"},
-            }
-        )
+        sub = {
+            "metadata": {"name": "acm-sub", "namespace": "open-cluster-management"},
+            "spec": {"name": "advanced-cluster-management", "source": "redhat-operators"},
+        }
+        if installed_csv:
+            sub["status"] = {"installedCSV": installed_csv}
+        items.append(sub)
     items.append(
         {
             "metadata": {"name": "other-operator", "namespace": "openshift-operators"},
@@ -1969,7 +1970,7 @@ class TestVerifyAcmOperatorHealth(RuleTestBase):
 
     scenario_passed = [
         RuleScenarioParams(
-            "ACM operator installed, CSV succeeded, and all pods are healthy",
+            "ACM operator installed, CSV succeeded via installedCSV, and all pods are healthy",
             tested_object_mock_dict={
                 "oc_api.get_all_pods": Mock(
                     return_value=[
@@ -1980,6 +1981,20 @@ class TestVerifyAcmOperatorHealth(RuleTestBase):
             },
             oc_cmd_output_dict={
                 _ACM_SUB_CMD: CmdOutput(json.dumps(_acm_subscriptions(include_acm=True))),
+                _ACM_CSV_CMD: CmdOutput(json.dumps(_acm_csv_response())),
+            },
+        ),
+        RuleScenarioParams(
+            "ACM operator installed, CSV succeeded via pattern fallback (no installedCSV)",
+            tested_object_mock_dict={
+                "oc_api.get_all_pods": Mock(
+                    return_value=[
+                        create_mock_acm_pod("multiclusterhub-operator-abc123", "Running", True),
+                    ]
+                ),
+            },
+            oc_cmd_output_dict={
+                _ACM_SUB_CMD: CmdOutput(json.dumps(_acm_subscriptions(include_acm=True, installed_csv=None))),
                 _ACM_CSV_CMD: CmdOutput(json.dumps(_acm_csv_response())),
             },
         ),

--- a/wiki-placeholder
+++ b/wiki-placeholder
@@ -1,0 +1,1 @@
+placeholder

--- a/wiki-placeholder
+++ b/wiki-placeholder
@@ -1,1 +1,0 @@
-placeholder


### PR DESCRIPTION
## Summary
- Enhance `VerifyAcmOperatorHealth` to also verify the ACM ClusterServiceVersion (CSV) is in `Succeeded` phase, aligning with the eco-gotests assisted-hive-operators test coverage
- Add missing `scenario_prerequisite_fulfilled` test for CI coverage
- Add CSV-specific failure scenarios and mixed CSV + pod failure test
## Test plan
- [x] `pre-commit run --all-files` passes
- [x] `pytest tests/rules/k8s/test_k8s_validations.py::TestVerifyAcmOperatorHealth -v` passes (12 passed, 4 skipped)
- [x] `pytest tests/domains/test_k8s_domain.py -v` passes
- [x] `python3 -m black --check --line-length=120` on all changed files
- [x] Validated on real cluster:(ACM v2.12.8, CSV Succeeded, 30/30 pods Running) and (ACM v2.17.0, CSV Succeeded)
- [x] Verified prerequisite path on clusters without ACM  correctly returns "not applicable."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added validation for FAR operator container security contexts to ensure containers do not run as root.
  * Enhanced ACM operator health checks with improved CSV status and pod health validation.

* **Tests**
  * Added comprehensive test coverage for FAR container security context validation.
  * Extended test scenarios for ACM operator health checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->