### PR TITLE
feat: add MDR operator health check

### DIFF
--- a/src/in_cluster_checks/rules/k8s/k8s_validations.py
+++ b/src/in_cluster_checks/rules/k8s/k8s_validations.py
@@ -1470,7 +1470,7 @@ class VerifyFarContainerNonRoot(SubscriptionOperatorRule):
             return RuleResult.failed(message)
 
         return RuleResult.passed()
-class VerifyMdrOperatorHealth(OrchestratorRule):
+class VerifyMdrOperatorHealth(SubscriptionOperatorRule):
     """Verify Machine Deletion Remediation (MDR) operator pods are healthy.
 
     MDR is part of Red Hat Workload Availability (RHWA) and provides automated
@@ -1489,71 +1489,14 @@ class VerifyMdrOperatorHealth(OrchestratorRule):
         "/23.3/html/remediation_fencing_and_maintenance/machine-deletion-remediation-operator-remediate-nodes",
     ]
 
+    operator_subscription_name = "openshift-workload-availability"
+    operator_display_name = "Machine Deletion Remediation"
+
     MDR_NAMESPACE = "openshift-workload-availability"
-
-    def is_prerequisite_fulfilled(self) -> PrerequisiteResult:
-        """Check that the MDR operator has been installed via a Subscription.
-
-        Queries the cluster for a Subscription resource with the
-        ``openshift-workload-availability`` package name. If none is found the
-        rule is not applicable.
-        """
-        _, subscriptions_output, _ = self.oc_api.run_oc_command(
-            "get",
-            ["subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json"],
-            timeout=45,
-        )
-
-        try:
-            subscriptions_data = json.loads(subscriptions_output)
-        except json.JSONDecodeError as e:
-            raise UnExpectedSystemOutput(
-                ip=self.get_host_ip(),
-                cmd="oc get subscriptions.operators.coreos.com --all-namespaces -o json",
-                output=subscriptions_output,
-                message=f"Failed to parse operator subscriptions: {e}",
-            ) from e
-
-        for sub in subscriptions_data.get("items", []):
-            spec = sub.get("spec", {})
-            if spec.get("name") == "openshift-workload-availability":
-                return PrerequisiteResult.met()
-
-        return PrerequisiteResult.not_met(
-            "MDR operator subscription not found - "
-            "Machine Deletion Remediation operator is not installed on this cluster"
-        )
 
     def run_rule(self):
         """Verify all pods in the openshift-workload-availability namespace are Running and Ready."""
-        pod_objects = self.oc_api.get_all_pods(namespace=self.MDR_NAMESPACE)
-
-        if not pod_objects:
-            return RuleResult.failed(
-                f"No pods found in {self.MDR_NAMESPACE} namespace. MDR operator may not be fully deployed."
-            )
-
-        not_ready_pods = []
-        unknown_status_pods = []
-
-        for pod in pod_objects:
-            pod_status = self.oc_api.get_pod_status(pod)
-            if pod_status is None:
-                pod_name = pod.as_dict().get("metadata", {}).get("name", "unknown")
-                unknown_status_pods.append(pod_name)
-                continue
-            if not pod_status["all_containers_ready"]:
-                not_ready_pods.append(pod_status["status_message"])
-
-        if unknown_status_pods or not_ready_pods:
-            parts = []
-            if unknown_status_pods:
-                parts.append("Failed to evaluate status for MDR pod(s):\n  " + "\n  ".join(unknown_status_pods))
-            if not_ready_pods:
-                parts.append(
-                    f"MDR operator has unhealthy pods in {self.MDR_NAMESPACE} namespace:\n  "
-                    + "\n  ".join(not_ready_pods)
-                )
-            return RuleResult.failed("\n\n".join(parts))
-
+        errors = self.validate_namespace_pods_health(self.MDR_NAMESPACE)
+        if errors:
+            return RuleResult.failed("\n\n".join(errors))
         return RuleResult.passed()

--- a/src/in_cluster_checks/rules/k8s/k8s_validations.py
+++ b/src/in_cluster_checks/rules/k8s/k8s_validations.py
@@ -1034,13 +1034,56 @@ class SubscriptionOperatorRule(OrchestratorRule):
             if container_sc is not None:
                 run_as_user = container_sc.get("runAsUser")
                 if run_as_user is not None:
-                    if not isinstance(run_as_user, int) or run_as_user < 0:
+                    if not isinstance(run_as_user, int) or isinstance(run_as_user, bool) or run_as_user < 0:
                         errors.append(
                             f"Container '{container_name}' in pod {pod_name} has invalid runAsUser: {run_as_user}"
                         )
                     elif run_as_user == 0:
                         errors.append(f"Container '{container_name}' in pod {pod_name} runs as root (runAsUser=0)")
         return errors
+
+    def validate_namespace_pods_health(self, namespace: str) -> list[str]:
+        """Validate all pods in a namespace are Running and Ready.
+
+        Args:
+            namespace: Kubernetes namespace to check
+
+        Returns:
+            List of error messages. Empty list if all pods are healthy.
+        """
+        pod_objects = self.oc_api.get_all_pods(namespace=namespace)
+
+        if not pod_objects:
+            return [
+                f"No pods found in {namespace} namespace. "
+                f"{self.operator_display_name} operator may not be fully deployed."
+            ]
+
+        not_ready_pods = []
+        succeeded_state_pods = []
+
+        for pod in pod_objects:
+            pod_status = self.oc_api.get_pod_status(pod)
+            if pod_status is None:
+                pod_name = pod.as_dict().get("metadata", {}).get("name", "unknown")
+                succeeded_state_pods.append(pod_name)
+                continue
+            if not pod_status["all_containers_ready"]:
+                not_ready_pods.append(pod_status["status_message"])
+
+        parts = []
+        if succeeded_state_pods:
+            parts.append(
+                f"{self.operator_display_name} operator has pods in unexpected succeeded state:\n  "
+                + "\n  ".join(succeeded_state_pods)
+            )
+        if not_ready_pods:
+            parts.append(
+                f"{self.operator_display_name} operator has unhealthy pods in {namespace} namespace:\n  "
+                + "\n  ".join(not_ready_pods)
+            )
+
+        return parts
 
 
 class VerifyNfdOperatorHealth(SubscriptionOperatorRule):
@@ -1207,7 +1250,7 @@ class VerifyAcmOperatorHealth(SubscriptionOperatorRule):
 
         return RuleResult.passed()
 
-    def _verify_csv_status(self):
+    def _verify_csv_status(self) -> str | None:
         """Check that the ACM ClusterServiceVersion is in Succeeded phase.
 
         Uses status.installedCSV from the operator subscription when available
@@ -1253,7 +1296,7 @@ class VerifyAcmOperatorHealth(SubscriptionOperatorRule):
 
         return None
 
-    def _get_installed_csv_name(self):
+    def _get_installed_csv_name(self) -> str | None:
         """Look up status.installedCSV from the ACM operator subscription.
 
         Returns:
@@ -1265,7 +1308,7 @@ class VerifyAcmOperatorHealth(SubscriptionOperatorRule):
                 return sub.get("status", {}).get("installedCSV")
         return None
 
-    def _verify_pods_status(self):
+    def _verify_pods_status(self) -> str | None:
         """Check that all pods in the ACM namespace are Running and Ready.
 
         Returns:
@@ -1470,6 +1513,8 @@ class VerifyFarContainerNonRoot(SubscriptionOperatorRule):
             return RuleResult.failed(message)
 
         return RuleResult.passed()
+
+
 class VerifyMdrOperatorHealth(SubscriptionOperatorRule):
     """Verify Machine Deletion Remediation (MDR) operator pods are healthy.
 

--- a/src/in_cluster_checks/rules/k8s/k8s_validations.py
+++ b/src/in_cluster_checks/rules/k8s/k8s_validations.py
@@ -1492,11 +1492,9 @@ class VerifyMdrOperatorHealth(SubscriptionOperatorRule):
     operator_subscription_name = "openshift-workload-availability"
     operator_display_name = "Machine Deletion Remediation"
 
-    MDR_NAMESPACE = "openshift-workload-availability"
-
     def run_rule(self):
         """Verify all pods in the openshift-workload-availability namespace are Running and Ready."""
-        errors = self.validate_namespace_pods_health(self.MDR_NAMESPACE)
+        errors = self.validate_namespace_pods_health(self.operator_subscription_name)
         if errors:
             return RuleResult.failed("\n\n".join(errors))
         return RuleResult.passed()

--- a/src/in_cluster_checks/rules/k8s/k8s_validations.py
+++ b/src/in_cluster_checks/rules/k8s/k8s_validations.py
@@ -1470,3 +1470,90 @@ class VerifyFarContainerNonRoot(SubscriptionOperatorRule):
             return RuleResult.failed(message)
 
         return RuleResult.passed()
+class VerifyMdrOperatorHealth(OrchestratorRule):
+    """Verify Machine Deletion Remediation (MDR) operator pods are healthy.
+
+    MDR is part of Red Hat Workload Availability (RHWA) and provides automated
+    machine deletion remediation for unhealthy nodes. This rule checks that the
+    MDR operator has been installed (Subscription exists) and that every pod in
+    the openshift-workload-availability namespace is Running with all containers ready.
+    """
+
+    objective_hosts = [Objectives.ORCHESTRATOR]
+    unique_name = "verify_mdr_operator_health"
+    title = "Verify MDR operator pods are healthy"
+    supported_profiles = {"telco-base"}
+    links = [
+        "https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-MDR-operator-health",
+        "https://docs.redhat.com/en/documentation/workload_availability_for_red_hat_openshift"
+        "/23.3/html/remediation_fencing_and_maintenance/machine-deletion-remediation-operator-remediate-nodes",
+    ]
+
+    MDR_NAMESPACE = "openshift-workload-availability"
+
+    def is_prerequisite_fulfilled(self) -> PrerequisiteResult:
+        """Check that the MDR operator has been installed via a Subscription.
+
+        Queries the cluster for a Subscription resource with the
+        ``openshift-workload-availability`` package name. If none is found the
+        rule is not applicable.
+        """
+        _, subscriptions_output, _ = self.oc_api.run_oc_command(
+            "get",
+            ["subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json"],
+            timeout=45,
+        )
+
+        try:
+            subscriptions_data = json.loads(subscriptions_output)
+        except json.JSONDecodeError as e:
+            raise UnExpectedSystemOutput(
+                ip=self.get_host_ip(),
+                cmd="oc get subscriptions.operators.coreos.com --all-namespaces -o json",
+                output=subscriptions_output,
+                message=f"Failed to parse operator subscriptions: {e}",
+            ) from e
+
+        for sub in subscriptions_data.get("items", []):
+            spec = sub.get("spec", {})
+            if spec.get("name") == "openshift-workload-availability":
+                return PrerequisiteResult.met()
+
+        return PrerequisiteResult.not_met(
+            "MDR operator subscription not found - "
+            "Machine Deletion Remediation operator is not installed on this cluster"
+        )
+
+    def run_rule(self):
+        """Verify all pods in the openshift-workload-availability namespace are Running and Ready."""
+        pod_objects = self.oc_api.get_all_pods(namespace=self.MDR_NAMESPACE)
+
+        if not pod_objects:
+            return RuleResult.failed(
+                f"No pods found in {self.MDR_NAMESPACE} namespace. MDR operator may not be fully deployed."
+            )
+
+        not_ready_pods = []
+        unknown_status_pods = []
+
+        for pod in pod_objects:
+            pod_status = self.oc_api.get_pod_status(pod)
+            if pod_status is None:
+                pod_name = pod.as_dict().get("metadata", {}).get("name", "unknown")
+                unknown_status_pods.append(pod_name)
+                continue
+            if not pod_status["all_containers_ready"]:
+                not_ready_pods.append(pod_status["status_message"])
+
+        if unknown_status_pods or not_ready_pods:
+            parts = []
+            if unknown_status_pods:
+                parts.append("Failed to evaluate status for MDR pod(s):\n  " + "\n  ".join(unknown_status_pods))
+            if not_ready_pods:
+                parts.append(
+                    f"MDR operator has unhealthy pods in {self.MDR_NAMESPACE} namespace:\n  "
+                    + "\n  ".join(not_ready_pods)
+                )
+            return RuleResult.failed("\n\n".join(parts))
+
+        return RuleResult.passed()

--- a/tests/rules/k8s/test_k8s_validations.py
+++ b/tests/rules/k8s/test_k8s_validations.py
@@ -2899,3 +2899,161 @@ class TestVerifyNmoOperatorHealth(RuleTestBase):
     def test_scenario_failed(self, scenario_params, tested_object):
         """Test that rule fails when NMO pods are unhealthy or missing."""
         RuleTestBase.test_scenario_failed(self, scenario_params, tested_object)
+def create_mock_mdr_pod(name, phase, all_containers_ready=True):
+    """Create a mock MDR pod object."""
+    mock_pod = Mock()
+    container_statuses = [
+        {"ready": all_containers_ready},
+    ]
+    mock_pod.as_dict.return_value = {
+        "metadata": {"namespace": "openshift-workload-availability", "name": name},
+        "status": {
+            "phase": phase,
+            "containerStatuses": container_statuses,
+        },
+    }
+    return mock_pod
+
+
+def _mdr_subscriptions(include_mdr=True):
+    """Build a subscriptions response, optionally including the MDR subscription."""
+    items = []
+    if include_mdr:
+        items.append(
+            {
+                "metadata": {"name": "mdr-sub", "namespace": "openshift-workload-availability"},
+                "spec": {"name": "openshift-workload-availability", "source": "redhat-operators"},
+            }
+        )
+    items.append(
+        {
+            "metadata": {"name": "other-operator", "namespace": "openshift-operators"},
+            "spec": {"name": "other", "source": "redhat-operators"},
+        }
+    )
+    return {"items": items}
+
+
+class TestVerifyMdrOperatorHealth(RuleTestBase):
+    """Test VerifyMdrOperatorHealth rule."""
+
+    tested_type = VerifyMdrOperatorHealth
+
+    scenario_passed = [
+        RuleScenarioParams(
+            "MDR operator installed and all pods are healthy",
+            tested_object_mock_dict={
+                "oc_api.get_all_pods": Mock(
+                    return_value=[
+                        create_mock_mdr_pod("mdr-controller-manager-abc123", "Running", True),
+                        create_mock_mdr_pod("mdr-worker-xyz789", "Running", True),
+                    ]
+                ),
+            },
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_mdr_subscriptions(include_mdr=True))
+                ),
+            },
+        ),
+    ]
+
+    scenario_prerequisite_not_fulfilled = [
+        RuleScenarioParams(
+            "MDR operator subscription not found",
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_mdr_subscriptions(include_mdr=False))
+                ),
+            },
+        ),
+        RuleScenarioParams(
+            "no subscriptions exist in cluster",
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps({"items": []})
+                ),
+            },
+        ),
+    ]
+
+    scenario_failed = [
+        RuleScenarioParams(
+            "MDR operator installed but no pods found",
+            tested_object_mock_dict={
+                "oc_api.get_all_pods": Mock(return_value=[]),
+            },
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_mdr_subscriptions(include_mdr=True))
+                ),
+            },
+            failed_msg="No pods found in openshift-workload-availability namespace. MDR operator may not be fully deployed.",
+        ),
+        RuleScenarioParams(
+            "MDR operator installed but some pods are not running",
+            tested_object_mock_dict={
+                "oc_api.get_all_pods": Mock(
+                    return_value=[
+                        create_mock_mdr_pod("mdr-controller-manager-abc123", "Running", True),
+                        create_mock_mdr_pod("mdr-worker-xyz789", "Pending", True),
+                    ]
+                ),
+            },
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_mdr_subscriptions(include_mdr=True))
+                ),
+            },
+            failed_msg="MDR operator has unhealthy pods in openshift-workload-availability namespace:\n"
+            "  mdr-worker-xyz789 - Phase: Pending",
+        ),
+        RuleScenarioParams(
+            "MDR operator installed but containers not ready",
+            tested_object_mock_dict={
+                "oc_api.get_all_pods": Mock(
+                    return_value=[
+                        create_mock_mdr_pod("mdr-controller-manager-abc123", "Running", False),
+                    ]
+                ),
+            },
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_mdr_subscriptions(include_mdr=True))
+                ),
+            },
+            failed_msg="MDR operator has unhealthy pods in openshift-workload-availability namespace:\n"
+            "  mdr-controller-manager-abc123 - Running, Not all containers ready",
+        ),
+        RuleScenarioParams(
+            "MDR operator installed but pod status unknown",
+            tested_object_mock_dict={
+                "oc_api.get_all_pods": Mock(
+                    return_value=[
+                        create_mock_mdr_pod("mdr-controller-manager-abc123", "Succeeded", True),
+                    ]
+                ),
+            },
+            oc_cmd_output_dict={
+                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
+                    json.dumps(_mdr_subscriptions(include_mdr=True))
+                ),
+            },
+            failed_msg="Failed to evaluate status for MDR pod(s):\n  mdr-controller-manager-abc123",
+        ),
+    ]
+
+    @pytest.mark.parametrize("scenario_params", scenario_prerequisite_not_fulfilled)
+    def test_prerequisite_not_fulfilled(self, scenario_params, tested_object):
+        """Test that prerequisite is not met when MDR operator is not installed."""
+        RuleTestBase.test_prerequisite_not_fulfilled(self, scenario_params, tested_object)
+
+    @pytest.mark.parametrize("scenario_params", scenario_passed)
+    def test_scenario_passed(self, scenario_params, tested_object):
+        """Test that rule passes when all MDR pods are healthy."""
+        RuleTestBase.test_scenario_passed(self, scenario_params, tested_object)
+
+    @pytest.mark.parametrize("scenario_params", scenario_failed)
+    def test_scenario_failed(self, scenario_params, tested_object):
+        """Test that rule fails when MDR pods are unhealthy or missing."""
+        RuleTestBase.test_scenario_failed(self, scenario_params, tested_object)

--- a/tests/rules/k8s/test_k8s_validations.py
+++ b/tests/rules/k8s/test_k8s_validations.py
@@ -25,6 +25,7 @@ from in_cluster_checks.rules.k8s.k8s_validations import (
     VerifyFarContainerNonRoot,
     VerifyFarOperatorHealth,
     VerifyInternalRegistry,
+    VerifyMdrOperatorHealth,
     VerifyNetworkDiagnosticsDisabled,
     VerifyNfdOperatorHealth,
     VerifyNmoOperatorHealth,
@@ -3040,7 +3041,7 @@ class TestVerifyMdrOperatorHealth(RuleTestBase):
                     json.dumps(_mdr_subscriptions(include_mdr=True))
                 ),
             },
-            failed_msg="Failed to evaluate status for Machine Deletion Remediation pod(s):\n  mdr-controller-manager-abc123",
+            failed_msg="Machine Deletion Remediation operator has pods in unexpected succeeded state:\n  mdr-controller-manager-abc123",
         ),
     ]
 

--- a/tests/rules/k8s/test_k8s_validations.py
+++ b/tests/rules/k8s/test_k8s_validations.py
@@ -2988,7 +2988,8 @@ class TestVerifyMdrOperatorHealth(RuleTestBase):
                     json.dumps(_mdr_subscriptions(include_mdr=True))
                 ),
             },
-            failed_msg="No pods found in openshift-workload-availability namespace. MDR operator may not be fully deployed.",
+            failed_msg="No pods found in openshift-workload-availability namespace. "
+            "Machine Deletion Remediation operator may not be fully deployed.",
         ),
         RuleScenarioParams(
             "MDR operator installed but some pods are not running",
@@ -3005,7 +3006,7 @@ class TestVerifyMdrOperatorHealth(RuleTestBase):
                     json.dumps(_mdr_subscriptions(include_mdr=True))
                 ),
             },
-            failed_msg="MDR operator has unhealthy pods in openshift-workload-availability namespace:\n"
+            failed_msg="Machine Deletion Remediation operator has unhealthy pods in openshift-workload-availability namespace:\n"
             "  mdr-worker-xyz789 - Phase: Pending",
         ),
         RuleScenarioParams(
@@ -3022,7 +3023,7 @@ class TestVerifyMdrOperatorHealth(RuleTestBase):
                     json.dumps(_mdr_subscriptions(include_mdr=True))
                 ),
             },
-            failed_msg="MDR operator has unhealthy pods in openshift-workload-availability namespace:\n"
+            failed_msg="Machine Deletion Remediation operator has unhealthy pods in openshift-workload-availability namespace:\n"
             "  mdr-controller-manager-abc123 - Running, Not all containers ready",
         ),
         RuleScenarioParams(
@@ -3039,7 +3040,7 @@ class TestVerifyMdrOperatorHealth(RuleTestBase):
                     json.dumps(_mdr_subscriptions(include_mdr=True))
                 ),
             },
-            failed_msg="Failed to evaluate status for MDR pod(s):\n  mdr-controller-manager-abc123",
+            failed_msg="Failed to evaluate status for Machine Deletion Remediation pod(s):\n  mdr-controller-manager-abc123",
         ),
     ]
 


### PR DESCRIPTION
Verify Machine Deletion Remediation operator pods are healthy with subscription check and full test coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Machine Deletion Remediation (MDR) operator health validation for namespaces, requiring the MDR subscription and MDR pods to be running with all containers ready.
* **Bug Fixes**
  * Improved validation of container `securityContext.runAsUser`, treating non-integer (including boolean) and negative values as invalid.
* **Tests**
  * Added scenario-based tests for missing prerequisites, missing/unhealthy pods, unrecognized pod states, and a passing healthy-pods scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->