### PR TITLE
feat: add FAR controller replica validation rule

### DIFF
--- a/src/in_cluster_checks/domains/k8s_domain.py
+++ b/src/in_cluster_checks/domains/k8s_domain.py
@@ -22,6 +22,7 @@ from in_cluster_checks.rules.k8s.k8s_validations import (
     VerifyAcmOperatorHealth,
     VerifyClusterOperatorsAvailable,
     VerifyFarContainerNonRoot,
+    VerifyFARControllerReplicas,
     VerifyFarOperatorHealth,
     VerifyInternalRegistry,
     VerifyNetworkDiagnosticsDisabled,
@@ -68,5 +69,6 @@ class K8sValidationDomain(RuleDomain):
             VerifyAcmOperatorHealth,
             VerifyNmoOperatorHealth,
             VerifyFarOperatorHealth,
+            VerifyFARControllerReplicas,
             VerifyFarContainerNonRoot,
         ]

--- a/src/in_cluster_checks/rules/k8s/k8s_validations.py
+++ b/src/in_cluster_checks/rules/k8s/k8s_validations.py
@@ -25,7 +25,9 @@ class AllPodsReadyAndRunning(OrchestratorRule):
         ready_pods, not_running_pods = self._get_pods_lists()
 
         if len(ready_pods) == 0:
-            return RuleResult.failed("Did not get any pods from 'oc get pods --all-namespaces'")
+            return RuleResult.failed(
+                "Did not get any pods from 'oc get pods --all-namespaces'"
+            )
 
         if not_running_pods:
             message = "Not all pods are running\n"
@@ -37,7 +39,9 @@ class AllPodsReadyAndRunning(OrchestratorRule):
                 pod_name = pod_info["name"]
                 status = pod_info["status"]
                 ready = pod_info["ready"]
-                message += f"  {namespace}/{pod_name} - Ready: {ready}, Status: {status}\n"
+                message += (
+                    f"  {namespace}/{pod_name} - Ready: {ready}, Status: {status}\n"
+                )
 
             return RuleResult.failed(message)
 
@@ -78,7 +82,9 @@ class AllPodsReadyAndRunning(OrchestratorRule):
 
             # Calculate ready containers
             total_containers = len(container_statuses)
-            ready_containers = sum(1 for c in container_statuses if c.get("ready", False))
+            ready_containers = sum(
+                1 for c in container_statuses if c.get("ready", False)
+            )
             ready_str = f"{ready_containers}/{total_containers}"
 
             pod_info = {
@@ -116,11 +122,14 @@ class NodesAreReady(OrchestratorRule):
         error_messages = []
 
         if not_ready_list:
-            error_messages.append("The following nodes are not ready:\n  " + "\n  ".join(not_ready_list))
+            error_messages.append(
+                "The following nodes are not ready:\n  " + "\n  ".join(not_ready_list)
+            )
 
         if warned_list:
             error_messages.append(
-                "The following nodes are ready but having some issues:\n  " + "\n  ".join(warned_list)
+                "The following nodes are ready but having some issues:\n  "
+                + "\n  ".join(warned_list)
             )
 
         if error_messages:
@@ -176,12 +185,20 @@ class NodesAreReady(OrchestratorRule):
                     if (
                         condition_type != "Ready"
                         and condition_status == "True"
-                        and condition_type in ["DiskPressure", "MemoryPressure", "PIDPressure", "NetworkUnavailable"]
+                        and condition_type
+                        in [
+                            "DiskPressure",
+                            "MemoryPressure",
+                            "PIDPressure",
+                            "NetworkUnavailable",
+                        ]
                     ):
                         warning_conditions.append(condition_type)
 
                 if warning_conditions:
-                    warned_list.append(f"{node_name} - Ready,{','.join(warning_conditions)}")
+                    warned_list.append(
+                        f"{node_name} - Ready,{','.join(warning_conditions)}"
+                    )
                 else:
                     ready_list.append(node_name)
             else:
@@ -203,12 +220,16 @@ class NodesCpuAndMemoryStatus(OrchestratorRule):
     def run_rule(self):
         """Check CPU and memory usage for all nodes."""
         try:
-            _, nodes_info, _ = self.oc_api.run_oc_command("adm", ["top", "nodes", "--no-headers"], timeout=45)
+            _, nodes_info, _ = self.oc_api.run_oc_command(
+                "adm", ["top", "nodes", "--no-headers"], timeout=45
+            )
         except UnExpectedSystemOutput:
             return RuleResult.failed("Failed to get nodes CPU and memory information")
 
         if not nodes_info or not nodes_info.strip():
-            return RuleResult.failed("No node metrics available from 'oc adm top nodes'")
+            return RuleResult.failed(
+                "No node metrics available from 'oc adm top nodes'"
+            )
 
         nodes_with_high_cpu = []
         nodes_with_high_memory = []
@@ -294,7 +315,8 @@ class NodesCpuAndMemoryStatus(OrchestratorRule):
 
         if is_critical:
             return RuleResult.failed(
-                message + f"\n\nCRITICAL: At least one node exceeds {self.THRESHOLD_CRITICAL}% threshold"
+                message
+                + f"\n\nCRITICAL: At least one node exceeds {self.THRESHOLD_CRITICAL}% threshold"
             )
 
         return RuleResult.failed(message)
@@ -343,7 +365,9 @@ class ValidateAllDaemonsetsScheduled(OrchestratorRule):
     def run_rule(self):
         """Check if all daemonsets have desired number of available copies."""
         try:
-            _, out, _ = self.oc_api.run_oc_command("get", ["daemonsets", "--all-namespaces", "-o", "json"], timeout=45)
+            _, out, _ = self.oc_api.run_oc_command(
+                "get", ["daemonsets", "--all-namespaces", "-o", "json"], timeout=45
+            )
         except UnExpectedSystemOutput:
             return RuleResult.failed("Failed to get daemonsets")
 
@@ -382,7 +406,9 @@ class ValidateAllDaemonsetsScheduled(OrchestratorRule):
             # Only flag as problematic if there are pods explicitly marked as unavailable
             # This indicates a real issue rather than just initialization delay
             elif number_unavailable > 0:
-                problematic_daemonsets.append(f"{namespace}/{name} - {number_unavailable} pod(s) unavailable")
+                problematic_daemonsets.append(
+                    f"{namespace}/{name} - {number_unavailable} pod(s) unavailable"
+                )
 
         if problematic_daemonsets:
             message = "Following daemonsets have scheduling or availability issues:\n  "
@@ -399,7 +425,9 @@ class AllDeploymentsAvailable(OrchestratorRule):
     unique_name = "all_deployments_available"
     title = "Verify all deployments are available"
     supported_profiles = {"telco-base"}
-    links = ["https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-deployments-availability"]
+    links = [
+        "https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-deployments-availability"
+    ]
 
     def run_rule(self):
         """Check if all deployments have Available condition set to True."""
@@ -428,7 +456,9 @@ class AllDeploymentsAvailable(OrchestratorRule):
 
             # If no Available condition found or it's not True, deployment is unavailable
             if not available_condition:
-                unavailable_deployments.append(f"{namespace}/{name} - No Available condition found")
+                unavailable_deployments.append(
+                    f"{namespace}/{name} - No Available condition found"
+                )
             elif available_condition.get("status") != "True":
                 reason = available_condition.get("reason", "Unknown")
                 message = available_condition.get("message", "No message")
@@ -452,7 +482,9 @@ class CheckDeploymentsReplicaStatus(OrchestratorRule):
     unique_name = "check_deployments_replica_status"
     title = "Verify deployment replica counts"
     supported_profiles = {"telco-base"}
-    links = ["https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Check-deployment-replicas-status"]
+    links = [
+        "https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Check-deployment-replicas-status"
+    ]
 
     def run_rule(self):
         """Check if all deployments have desired number of replicas ready."""
@@ -511,7 +543,9 @@ class AllStatefulsetsReady(OrchestratorRule):
     unique_name = "all_statefulsets_ready"
     title = "Verify all statefulsets are ready"
     supported_profiles = {"telco-base"}
-    links = ["https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-statefulsets-readiness"]
+    links = [
+        "https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-statefulsets-readiness"
+    ]
 
     def run_rule(self):
         """Check if all statefulsets have ready replicas matching desired replicas."""
@@ -565,11 +599,21 @@ class OpenshiftOperatorStatus(OrchestratorRule):
         unavailable_operators = []
         progressing_operators = []
         table_data = []
-        headers = ["Name", "Version", "Available", "Progressing", "Degraded", "Since", "Message"]
+        headers = [
+            "Name",
+            "Version",
+            "Available",
+            "Progressing",
+            "Degraded",
+            "Since",
+            "Message",
+        ]
 
         try:
             _, operators_output, _ = self.oc_api.run_oc_command(
-                "get", ["clusteroperators.config.openshift.io", "--no-headers"], timeout=45
+                "get",
+                ["clusteroperators.config.openshift.io", "--no-headers"],
+                timeout=45,
             )
         except UnExpectedSystemOutput:
             return RuleResult.failed("Failed to get cluster operators status")
@@ -605,11 +649,13 @@ class OpenshiftOperatorStatus(OrchestratorRule):
             error_messages = []
             if unavailable_operators:
                 error_messages.append(
-                    "The following operators are not available:\n  " + "\n  ".join(unavailable_operators)
+                    "The following operators are not available:\n  "
+                    + "\n  ".join(unavailable_operators)
                 )
             if progressing_operators:
                 error_messages.append(
-                    "The following operators are in progress:\n  " + "\n  ".join(progressing_operators)
+                    "The following operators are in progress:\n  "
+                    + "\n  ".join(progressing_operators)
                 )
 
             # Return with dedicated table fields
@@ -636,7 +682,9 @@ class ValidateAllPoliciesCompliant(OrchestratorRule):
     unique_name = "validate_all_policies_compliant"
     title = "Verify all policies are in compliant state"
     supported_profiles = {"telco-base"}
-    links = ["https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-policies-compliance"]
+    links = [
+        "https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-policies-compliance"
+    ]
 
     _POLICIES_RESOURCE = "policies.policy.open-cluster-management.io"
 
@@ -648,7 +696,9 @@ class ValidateAllPoliciesCompliant(OrchestratorRule):
         """
         try:
             _, policies_output, _ = self.oc_api.run_oc_command(
-                "get", [self._POLICIES_RESOURCE, "--all-namespaces", "-o", "json"], timeout=45
+                "get",
+                [self._POLICIES_RESOURCE, "--all-namespaces", "-o", "json"],
+                timeout=45,
             )
         except UnExpectedSystemOutput:
             return PrerequisiteResult.not_met(
@@ -676,7 +726,9 @@ class ValidateAllPoliciesCompliant(OrchestratorRule):
     def run_rule(self):
         """Check if all OCM policies are in Compliant state."""
         _, policies_output, _ = self.oc_api.run_oc_command(
-            "get", [self._POLICIES_RESOURCE, "--all-namespaces", "-o", "json"], timeout=45
+            "get",
+            [self._POLICIES_RESOURCE, "--all-namespaces", "-o", "json"],
+            timeout=45,
         )
 
         try:
@@ -698,10 +750,14 @@ class ValidateAllPoliciesCompliant(OrchestratorRule):
             status = policy.get("status", {})
             compliance_state = status.get("compliant", "Unknown")
             if compliance_state != "Compliant":
-                non_compliant_policies.append(f"{namespace}/{name} - {compliance_state}")
+                non_compliant_policies.append(
+                    f"{namespace}/{name} - {compliance_state}"
+                )
 
         if non_compliant_policies:
-            message = f"There are {len(non_compliant_policies)} non-compliant policies:\n  "
+            message = (
+                f"There are {len(non_compliant_policies)} non-compliant policies:\n  "
+            )
             message += "\n  ".join(non_compliant_policies)
             return RuleResult.failed(message)
 
@@ -716,7 +772,9 @@ class VerifyInternalRegistry(OrchestratorRule):
     unique_name = "verify_internal_registry"
     title = "Verify internal image registry is configured and available"
     supported_profiles = {"telco-base"}
-    links = ["https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-internal-image-registry"]
+    links = [
+        "https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-internal-image-registry"
+    ]
 
     def is_prerequisite_fulfilled(self) -> PrerequisiteResult:
         """
@@ -732,18 +790,24 @@ class VerifyInternalRegistry(OrchestratorRule):
                 timeout=45,
             )
         except UnExpectedSystemOutput:
-            return PrerequisiteResult.not_met("Failed to get image registry configuration")
+            return PrerequisiteResult.not_met(
+                "Failed to get image registry configuration"
+            )
 
         try:
             registry_config = json.loads(registry_config_output)
         except json.JSONDecodeError as e:
-            return PrerequisiteResult.not_met(f"Failed to parse image registry configuration: {e}")
+            return PrerequisiteResult.not_met(
+                f"Failed to parse image registry configuration: {e}"
+            )
 
         spec = registry_config.get("spec", {})
         management_state = spec.get("managementState", "Unknown")
 
         if management_state != "Managed":
-            return PrerequisiteResult.not_met(f"Image registry management state is '{management_state}', not 'Managed'")
+            return PrerequisiteResult.not_met(
+                f"Image registry management state is '{management_state}', not 'Managed'"
+            )
 
         return PrerequisiteResult.met()
 
@@ -799,7 +863,9 @@ class VerifyClusterOperatorsAvailable(OrchestratorRule):
     def run_rule(self):
         """Check cluster operator conditions: Available, Degraded, Progressing, Upgradeable."""
         try:
-            _, operators_output, _ = self.oc_api.run_oc_command("get", ["clusteroperators", "-o", "json"], timeout=45)
+            _, operators_output, _ = self.oc_api.run_oc_command(
+                "get", ["clusteroperators", "-o", "json"], timeout=45
+            )
         except UnExpectedSystemOutput:
             return RuleResult.failed("Failed to get cluster operators")
 
@@ -839,45 +905,59 @@ class VerifyClusterOperatorsAvailable(OrchestratorRule):
                 if available_condition:
                     reason = available_condition.get("reason", "Unknown")
                     message = available_condition.get("message", "")
-                unavailable_operators.append(f"{name} - Reason: {reason}, Message: {message}")
+                unavailable_operators.append(
+                    f"{name} - Reason: {reason}, Message: {message}"
+                )
 
             if degraded_condition and degraded_condition.get("status") == "True":
                 reason = degraded_condition.get("reason", "Unknown")
                 message = degraded_condition.get("message", "")
-                degraded_operators.append(f"{name} - Reason: {reason}, Message: {message}")
+                degraded_operators.append(
+                    f"{name} - Reason: {reason}, Message: {message}"
+                )
 
             if progressing_condition and progressing_condition.get("status") == "True":
                 reason = progressing_condition.get("reason", "Unknown")
                 message = progressing_condition.get("message", "")
-                progressing_operators.append(f"{name} - Reason: {reason}, Message: {message}")
+                progressing_operators.append(
+                    f"{name} - Reason: {reason}, Message: {message}"
+                )
 
             if upgradeable_condition and upgradeable_condition.get("status") == "False":
                 reason = upgradeable_condition.get("reason", "Unknown")
                 message = upgradeable_condition.get("message", "")
-                not_upgradeable_operators.append(f"{name} - Reason: {reason}, Message: {message}")
+                not_upgradeable_operators.append(
+                    f"{name} - Reason: {reason}, Message: {message}"
+                )
 
         error_messages = []
         warning_messages = []
 
         if unavailable_operators:
             error_messages.append(
-                "Following cluster operators are not available:\n  " + "\n  ".join(unavailable_operators)
+                "Following cluster operators are not available:\n  "
+                + "\n  ".join(unavailable_operators)
             )
 
         if degraded_operators:
-            error_messages.append("Following cluster operators are degraded:\n  " + "\n  ".join(degraded_operators))
+            error_messages.append(
+                "Following cluster operators are degraded:\n  "
+                + "\n  ".join(degraded_operators)
+            )
 
         if error_messages:
             return RuleResult.failed("\n\n".join(error_messages))
 
         if progressing_operators:
             warning_messages.append(
-                "Following cluster operators are progressing:\n  " + "\n  ".join(progressing_operators)
+                "Following cluster operators are progressing:\n  "
+                + "\n  ".join(progressing_operators)
             )
 
         if not_upgradeable_operators:
             warning_messages.append(
-                "Following cluster operators are not upgradeable:\n  " + "\n  ".join(not_upgradeable_operators)
+                "Following cluster operators are not upgradeable:\n  "
+                + "\n  ".join(not_upgradeable_operators)
             )
 
         if warning_messages:
@@ -924,12 +1004,16 @@ class VerifyWebConsoleDisabled(OrchestratorRule):
                 timeout=45,
             )
         except UnExpectedSystemOutput:
-            return PrerequisiteResult.not_met("Failed to get console operator configuration")
+            return PrerequisiteResult.not_met(
+                "Failed to get console operator configuration"
+            )
 
         try:
             console_config = json.loads(console_config_output)
         except json.JSONDecodeError as e:
-            return PrerequisiteResult.not_met(f"Failed to parse console operator configuration: {e}")
+            return PrerequisiteResult.not_met(
+                f"Failed to parse console operator configuration: {e}"
+            )
 
         spec = console_config.get("spec", {})
         management_state = spec.get("managementState", "Unknown")
@@ -992,7 +1076,9 @@ class SubscriptionOperatorRule(OrchestratorRule):
             f"{self.operator_display_name} operator is not installed on this cluster"
         )
 
-    def _check_pod_security_context(self, pod_name: str, security_context: dict[str, object] | None) -> list[str]:
+    def _check_pod_security_context(
+        self, pod_name: str, security_context: dict[str, object] | None
+    ) -> list[str]:
         """Validate pod-level security context has runAsNonRoot set to true.
 
         Args:
@@ -1014,7 +1100,9 @@ class SubscriptionOperatorRule(OrchestratorRule):
             )
         return errors
 
-    def _check_containers_non_root(self, pod_name: str, all_containers: list[dict[str, object]]) -> list[str]:
+    def _check_containers_non_root(
+        self, pod_name: str, all_containers: list[dict[str, object]]
+    ) -> list[str]:
         """Validate no container runs as root (runAsUser != 0).
 
         Args:
@@ -1039,7 +1127,9 @@ class SubscriptionOperatorRule(OrchestratorRule):
                             f"Container '{container_name}' in pod {pod_name} has invalid runAsUser: {run_as_user}"
                         )
                     elif run_as_user == 0:
-                        errors.append(f"Container '{container_name}' in pod {pod_name} runs as root (runAsUser=0)")
+                        errors.append(
+                            f"Container '{container_name}' in pod {pod_name} runs as root (runAsUser=0)"
+                        )
         return errors
 
 
@@ -1089,7 +1179,10 @@ class VerifyNfdOperatorHealth(SubscriptionOperatorRule):
                 not_ready_pods.append(pod_status["status_message"])
 
         if unknown_status_pods:
-            return RuleResult.failed("Failed to evaluate status for NFD pod(s):\n  " + "\n  ".join(unknown_status_pods))
+            return RuleResult.failed(
+                "Failed to evaluate status for NFD pod(s):\n  "
+                + "\n  ".join(unknown_status_pods)
+            )
 
         if not_ready_pods:
             message = f"NFD operator has unhealthy pods in {self.NFD_NAMESPACE} namespace:\n  "
@@ -1131,12 +1224,16 @@ class VerifyNetworkDiagnosticsDisabled(OrchestratorRule):
                 timeout=45,
             )
         except UnExpectedSystemOutput:
-            return PrerequisiteResult.not_met("Failed to get network operator configuration")
+            return PrerequisiteResult.not_met(
+                "Failed to get network operator configuration"
+            )
 
         try:
             network_config = json.loads(network_config_output)
         except json.JSONDecodeError as e:
-            return PrerequisiteResult.not_met(f"Failed to parse network operator configuration: {e}")
+            return PrerequisiteResult.not_met(
+                f"Failed to parse network operator configuration: {e}"
+            )
 
         spec = network_config.get("spec", {})
         disable_diagnostics = spec.get("disableNetworkDiagnostics")
@@ -1151,7 +1248,9 @@ class VerifyNetworkDiagnosticsDisabled(OrchestratorRule):
 
     def run_rule(self):
         """Verify no pods exist in the openshift-network-diagnostics namespace."""
-        pod_objects = self.oc_api.get_all_pods(namespace="openshift-network-diagnostics")
+        pod_objects = self.oc_api.get_all_pods(
+            namespace="openshift-network-diagnostics"
+        )
 
         if pod_objects:
             pod_names = []
@@ -1219,12 +1318,18 @@ class VerifyAcmOperatorHealth(SubscriptionOperatorRule):
         _, csv_output, _ = self.oc_api.run_oc_command(
             "get", ["csv", "-n", self.ACM_NAMESPACE, "-o", "json"], timeout=45
         )
-        csv_data = parse_json(csv_output, f"oc get csv -n {self.ACM_NAMESPACE} -o json", self.get_host_ip())
+        csv_data = parse_json(
+            csv_output,
+            f"oc get csv -n {self.ACM_NAMESPACE} -o json",
+            self.get_host_ip(),
+        )
 
         installed_csv_name = self._get_installed_csv_name()
         if installed_csv_name:
             acm_csvs = [
-                csv for csv in csv_data.get("items", []) if csv.get("metadata", {}).get("name") == installed_csv_name
+                csv
+                for csv in csv_data.get("items", [])
+                if csv.get("metadata", {}).get("name") == installed_csv_name
             ]
         else:
             acm_csvs = [
@@ -1246,10 +1351,15 @@ class VerifyAcmOperatorHealth(SubscriptionOperatorRule):
             if phase != "Succeeded":
                 reason = csv.get("status", {}).get("reason", "Unknown")
                 message = csv.get("status", {}).get("message", "")
-                not_succeeded.append(f"{name} - Phase: {phase}, Reason: {reason}, Message: {message}")
+                not_succeeded.append(
+                    f"{name} - Phase: {phase}, Reason: {reason}, Message: {message}"
+                )
 
         if not_succeeded:
-            return "ACM ClusterServiceVersion is not in Succeeded phase:\n  " + "\n  ".join(not_succeeded)
+            return (
+                "ACM ClusterServiceVersion is not in Succeeded phase:\n  "
+                + "\n  ".join(not_succeeded)
+            )
 
         return None
 
@@ -1291,7 +1401,10 @@ class VerifyAcmOperatorHealth(SubscriptionOperatorRule):
         if unknown_status_pods or not_ready_pods:
             parts = []
             if unknown_status_pods:
-                parts.append("Failed to evaluate status for ACM pod(s):\n  " + "\n  ".join(unknown_status_pods))
+                parts.append(
+                    "Failed to evaluate status for ACM pod(s):\n  "
+                    + "\n  ".join(unknown_status_pods)
+                )
             if not_ready_pods:
                 parts.append(
                     f"ACM operator has unhealthy pods in {self.ACM_NAMESPACE} namespace:\n  "
@@ -1351,7 +1464,10 @@ class VerifyNmoOperatorHealth(SubscriptionOperatorRule):
         if unknown_status_pods or not_ready_pods:
             parts = []
             if unknown_status_pods:
-                parts.append("Failed to evaluate status for NMO pod(s):\n  " + "\n  ".join(unknown_status_pods))
+                parts.append(
+                    "Failed to evaluate status for NMO pod(s):\n  "
+                    + "\n  ".join(unknown_status_pods)
+                )
             if not_ready_pods:
                 parts.append(
                     f"NMO operator has unhealthy pods in {self.NMO_NAMESPACE} namespace:\n  "
@@ -1409,13 +1525,108 @@ class VerifyFarOperatorHealth(SubscriptionOperatorRule):
         if unknown_status_pods or not_ready_pods:
             parts = []
             if unknown_status_pods:
-                parts.append("Failed to evaluate status for FAR pod(s):\n  " + "\n  ".join(unknown_status_pods))
+                parts.append(
+                    "Failed to evaluate status for FAR pod(s):\n  "
+                    + "\n  ".join(unknown_status_pods)
+                )
             if not_ready_pods:
                 parts.append(
                     f"FAR operator has unhealthy pods in {self.FAR_NAMESPACE} namespace:\n  "
                     + "\n  ".join(not_ready_pods)
                 )
             return RuleResult.failed("\n\n".join(parts))
+
+        return RuleResult.passed()
+
+
+class VerifyFARControllerReplicas(OrchestratorRule):
+    """Verify FAR controller manager has correct number of replicas.
+
+    FAR (Fence Agents Remediation) uses 2 replicas for high availability.
+    When one pod fails, the other takes over to ensure continuous operation.
+
+    This rule checks:
+    - Deployment has 2 replicas configured (spec.replicas)
+    - All 2 replicas are ready (status.readyReplicas)
+
+    Skipped on Single Node OpenShift (SNO) - SNO only supports 1 replica.
+    """
+
+    objective_hosts = [Objectives.ORCHESTRATOR]
+    unique_name = "verify_far_controller_replicas"
+    title = "Verify FAR controller manager has correct number of replicas"
+    supported_profiles = {"telco-base"}
+    links = [
+        "https://github.com/RedHatInsights/incluster-checks/wiki/"
+        "K8s-%E2%80%90-Verify-FAR-controller-manager-has-correct-number-of-replicas"
+    ]
+
+    FAR_NAMESPACE = "openshift-workload-availability"
+    FAR_DEPLOYMENT_NAME = "fence-agents-remediation-controller-manager"
+    EXPECTED_REPLICAS = 2
+
+    def is_prerequisite_fulfilled(self):
+        """Check if FAR deployment exists."""
+        deployments = self.oc_api.get_all_deployments(
+            namespace=self.FAR_NAMESPACE, timeout=30
+        )
+
+        for deployment in deployments:
+            deployment_name = deployment.as_dict()["metadata"]["name"]
+            if deployment_name == self.FAR_DEPLOYMENT_NAME:
+                return PrerequisiteResult.met()
+
+        return PrerequisiteResult.not_met(
+            f"FAR deployment '{self.FAR_DEPLOYMENT_NAME}' not found in '{self.FAR_NAMESPACE}' namespace. "
+            "FAR operator may not be installed."
+        )
+
+    def run_rule(self):
+        """Check FAR controller manager has correct number of replicas."""
+        # Step 1: Check if this is a Single Node OpenShift cluster
+        infrastructure = self.oc_api.select_resources(
+            "infrastructure/cluster", single=True, timeout=30
+        )
+        if infrastructure:
+            infra_dict = infrastructure.as_dict()
+            topology = infra_dict.get("status", {}).get("controlPlaneTopology", "")
+            if topology == "SingleReplica":
+                return RuleResult.skip(
+                    "SNO (Single Node OpenShift) cluster detected. Skipping replica check."
+                )
+
+        # Step 2: Get FAR deployment
+        deployments = self.oc_api.get_all_deployments(
+            namespace=self.FAR_NAMESPACE, timeout=30
+        )
+        far_deployment = None
+
+        for deployment in deployments:
+            deployment_name = deployment.as_dict()["metadata"]["name"]
+            if deployment_name == self.FAR_DEPLOYMENT_NAME:
+                far_deployment = deployment
+                break
+
+        if not far_deployment:
+            return RuleResult.failed(
+                f"FAR deployment '{self.FAR_DEPLOYMENT_NAME}' not found"
+            )
+
+        # Step 3: Get replica counts from deployment
+        deployment_dict = far_deployment.as_dict()
+        spec_replicas = deployment_dict.get("spec", {}).get("replicas")
+        ready_replicas = deployment_dict.get("status", {}).get("readyReplicas", 0)
+
+        # Step 4: Check if replicas match expected value
+        if spec_replicas != self.EXPECTED_REPLICAS:
+            return RuleResult.failed(
+                f"Expected {self.EXPECTED_REPLICAS} replicas in deployment spec, but found {spec_replicas}"
+            )
+
+        if ready_replicas != self.EXPECTED_REPLICAS:
+            return RuleResult.failed(
+                f"Expected {self.EXPECTED_REPLICAS} ready replicas, but only {ready_replicas} are ready"
+            )
 
         return RuleResult.passed()
 
@@ -1445,7 +1656,9 @@ class VerifyFarContainerNonRoot(SubscriptionOperatorRule):
 
     def run_rule(self):
         """Check if FAR pods run as non-root user with proper security context."""
-        pod_objects = self.oc_api.get_pods(labels={self.FAR_POD_LABEL_KEY: self.FAR_POD_LABEL_VALUE})
+        pod_objects = self.oc_api.get_pods(
+            labels={self.FAR_POD_LABEL_KEY: self.FAR_POD_LABEL_VALUE}
+        )
 
         if not pod_objects:
             return RuleResult.failed(
@@ -1458,10 +1671,14 @@ class VerifyFarContainerNonRoot(SubscriptionOperatorRule):
             pod_name = pod.name()
             spec = pod.as_dict().get("spec", {})
 
-            error_messages.extend(self._check_pod_security_context(pod_name, spec.get("securityContext")))
+            error_messages.extend(
+                self._check_pod_security_context(pod_name, spec.get("securityContext"))
+            )
 
             all_containers = spec.get("containers", []) + spec.get("initContainers", [])
-            error_messages.extend(self._check_containers_non_root(pod_name, all_containers))
+            error_messages.extend(
+                self._check_containers_non_root(pod_name, all_containers)
+            )
 
         if error_messages:
             message = "FAR operator pods doesn't have proper security context:\n"

--- a/src/in_cluster_checks/rules/k8s/k8s_validations.py
+++ b/src/in_cluster_checks/rules/k8s/k8s_validations.py
@@ -25,9 +25,7 @@ class AllPodsReadyAndRunning(OrchestratorRule):
         ready_pods, not_running_pods = self._get_pods_lists()
 
         if len(ready_pods) == 0:
-            return RuleResult.failed(
-                "Did not get any pods from 'oc get pods --all-namespaces'"
-            )
+            return RuleResult.failed("Did not get any pods from 'oc get pods --all-namespaces'")
 
         if not_running_pods:
             message = "Not all pods are running\n"
@@ -39,9 +37,7 @@ class AllPodsReadyAndRunning(OrchestratorRule):
                 pod_name = pod_info["name"]
                 status = pod_info["status"]
                 ready = pod_info["ready"]
-                message += (
-                    f"  {namespace}/{pod_name} - Ready: {ready}, Status: {status}\n"
-                )
+                message += f"  {namespace}/{pod_name} - Ready: {ready}, Status: {status}\n"
 
             return RuleResult.failed(message)
 
@@ -82,9 +78,7 @@ class AllPodsReadyAndRunning(OrchestratorRule):
 
             # Calculate ready containers
             total_containers = len(container_statuses)
-            ready_containers = sum(
-                1 for c in container_statuses if c.get("ready", False)
-            )
+            ready_containers = sum(1 for c in container_statuses if c.get("ready", False))
             ready_str = f"{ready_containers}/{total_containers}"
 
             pod_info = {
@@ -122,14 +116,11 @@ class NodesAreReady(OrchestratorRule):
         error_messages = []
 
         if not_ready_list:
-            error_messages.append(
-                "The following nodes are not ready:\n  " + "\n  ".join(not_ready_list)
-            )
+            error_messages.append("The following nodes are not ready:\n  " + "\n  ".join(not_ready_list))
 
         if warned_list:
             error_messages.append(
-                "The following nodes are ready but having some issues:\n  "
-                + "\n  ".join(warned_list)
+                "The following nodes are ready but having some issues:\n  " + "\n  ".join(warned_list)
             )
 
         if error_messages:
@@ -196,9 +187,7 @@ class NodesAreReady(OrchestratorRule):
                         warning_conditions.append(condition_type)
 
                 if warning_conditions:
-                    warned_list.append(
-                        f"{node_name} - Ready,{','.join(warning_conditions)}"
-                    )
+                    warned_list.append(f"{node_name} - Ready,{','.join(warning_conditions)}")
                 else:
                     ready_list.append(node_name)
             else:
@@ -220,16 +209,12 @@ class NodesCpuAndMemoryStatus(OrchestratorRule):
     def run_rule(self):
         """Check CPU and memory usage for all nodes."""
         try:
-            _, nodes_info, _ = self.oc_api.run_oc_command(
-                "adm", ["top", "nodes", "--no-headers"], timeout=45
-            )
+            _, nodes_info, _ = self.oc_api.run_oc_command("adm", ["top", "nodes", "--no-headers"], timeout=45)
         except UnExpectedSystemOutput:
             return RuleResult.failed("Failed to get nodes CPU and memory information")
 
         if not nodes_info or not nodes_info.strip():
-            return RuleResult.failed(
-                "No node metrics available from 'oc adm top nodes'"
-            )
+            return RuleResult.failed("No node metrics available from 'oc adm top nodes'")
 
         nodes_with_high_cpu = []
         nodes_with_high_memory = []
@@ -315,8 +300,7 @@ class NodesCpuAndMemoryStatus(OrchestratorRule):
 
         if is_critical:
             return RuleResult.failed(
-                message
-                + f"\n\nCRITICAL: At least one node exceeds {self.THRESHOLD_CRITICAL}% threshold"
+                message + f"\n\nCRITICAL: At least one node exceeds {self.THRESHOLD_CRITICAL}% threshold"
             )
 
         return RuleResult.failed(message)
@@ -365,9 +349,7 @@ class ValidateAllDaemonsetsScheduled(OrchestratorRule):
     def run_rule(self):
         """Check if all daemonsets have desired number of available copies."""
         try:
-            _, out, _ = self.oc_api.run_oc_command(
-                "get", ["daemonsets", "--all-namespaces", "-o", "json"], timeout=45
-            )
+            _, out, _ = self.oc_api.run_oc_command("get", ["daemonsets", "--all-namespaces", "-o", "json"], timeout=45)
         except UnExpectedSystemOutput:
             return RuleResult.failed("Failed to get daemonsets")
 
@@ -406,9 +388,7 @@ class ValidateAllDaemonsetsScheduled(OrchestratorRule):
             # Only flag as problematic if there are pods explicitly marked as unavailable
             # This indicates a real issue rather than just initialization delay
             elif number_unavailable > 0:
-                problematic_daemonsets.append(
-                    f"{namespace}/{name} - {number_unavailable} pod(s) unavailable"
-                )
+                problematic_daemonsets.append(f"{namespace}/{name} - {number_unavailable} pod(s) unavailable")
 
         if problematic_daemonsets:
             message = "Following daemonsets have scheduling or availability issues:\n  "
@@ -425,9 +405,7 @@ class AllDeploymentsAvailable(OrchestratorRule):
     unique_name = "all_deployments_available"
     title = "Verify all deployments are available"
     supported_profiles = {"telco-base"}
-    links = [
-        "https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-deployments-availability"
-    ]
+    links = ["https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-deployments-availability"]
 
     def run_rule(self):
         """Check if all deployments have Available condition set to True."""
@@ -456,9 +434,7 @@ class AllDeploymentsAvailable(OrchestratorRule):
 
             # If no Available condition found or it's not True, deployment is unavailable
             if not available_condition:
-                unavailable_deployments.append(
-                    f"{namespace}/{name} - No Available condition found"
-                )
+                unavailable_deployments.append(f"{namespace}/{name} - No Available condition found")
             elif available_condition.get("status") != "True":
                 reason = available_condition.get("reason", "Unknown")
                 message = available_condition.get("message", "No message")
@@ -482,9 +458,7 @@ class CheckDeploymentsReplicaStatus(OrchestratorRule):
     unique_name = "check_deployments_replica_status"
     title = "Verify deployment replica counts"
     supported_profiles = {"telco-base"}
-    links = [
-        "https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Check-deployment-replicas-status"
-    ]
+    links = ["https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Check-deployment-replicas-status"]
 
     def run_rule(self):
         """Check if all deployments have desired number of replicas ready."""
@@ -543,9 +517,7 @@ class AllStatefulsetsReady(OrchestratorRule):
     unique_name = "all_statefulsets_ready"
     title = "Verify all statefulsets are ready"
     supported_profiles = {"telco-base"}
-    links = [
-        "https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-statefulsets-readiness"
-    ]
+    links = ["https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-statefulsets-readiness"]
 
     def run_rule(self):
         """Check if all statefulsets have ready replicas matching desired replicas."""
@@ -649,13 +621,11 @@ class OpenshiftOperatorStatus(OrchestratorRule):
             error_messages = []
             if unavailable_operators:
                 error_messages.append(
-                    "The following operators are not available:\n  "
-                    + "\n  ".join(unavailable_operators)
+                    "The following operators are not available:\n  " + "\n  ".join(unavailable_operators)
                 )
             if progressing_operators:
                 error_messages.append(
-                    "The following operators are in progress:\n  "
-                    + "\n  ".join(progressing_operators)
+                    "The following operators are in progress:\n  " + "\n  ".join(progressing_operators)
                 )
 
             # Return with dedicated table fields
@@ -682,9 +652,7 @@ class ValidateAllPoliciesCompliant(OrchestratorRule):
     unique_name = "validate_all_policies_compliant"
     title = "Verify all policies are in compliant state"
     supported_profiles = {"telco-base"}
-    links = [
-        "https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-policies-compliance"
-    ]
+    links = ["https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-policies-compliance"]
 
     _POLICIES_RESOURCE = "policies.policy.open-cluster-management.io"
 
@@ -750,14 +718,10 @@ class ValidateAllPoliciesCompliant(OrchestratorRule):
             status = policy.get("status", {})
             compliance_state = status.get("compliant", "Unknown")
             if compliance_state != "Compliant":
-                non_compliant_policies.append(
-                    f"{namespace}/{name} - {compliance_state}"
-                )
+                non_compliant_policies.append(f"{namespace}/{name} - {compliance_state}")
 
         if non_compliant_policies:
-            message = (
-                f"There are {len(non_compliant_policies)} non-compliant policies:\n  "
-            )
+            message = f"There are {len(non_compliant_policies)} non-compliant policies:\n  "
             message += "\n  ".join(non_compliant_policies)
             return RuleResult.failed(message)
 
@@ -772,9 +736,7 @@ class VerifyInternalRegistry(OrchestratorRule):
     unique_name = "verify_internal_registry"
     title = "Verify internal image registry is configured and available"
     supported_profiles = {"telco-base"}
-    links = [
-        "https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-internal-image-registry"
-    ]
+    links = ["https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-internal-image-registry"]
 
     def is_prerequisite_fulfilled(self) -> PrerequisiteResult:
         """
@@ -790,24 +752,18 @@ class VerifyInternalRegistry(OrchestratorRule):
                 timeout=45,
             )
         except UnExpectedSystemOutput:
-            return PrerequisiteResult.not_met(
-                "Failed to get image registry configuration"
-            )
+            return PrerequisiteResult.not_met("Failed to get image registry configuration")
 
         try:
             registry_config = json.loads(registry_config_output)
         except json.JSONDecodeError as e:
-            return PrerequisiteResult.not_met(
-                f"Failed to parse image registry configuration: {e}"
-            )
+            return PrerequisiteResult.not_met(f"Failed to parse image registry configuration: {e}")
 
         spec = registry_config.get("spec", {})
         management_state = spec.get("managementState", "Unknown")
 
         if management_state != "Managed":
-            return PrerequisiteResult.not_met(
-                f"Image registry management state is '{management_state}', not 'Managed'"
-            )
+            return PrerequisiteResult.not_met(f"Image registry management state is '{management_state}', not 'Managed'")
 
         return PrerequisiteResult.met()
 
@@ -863,9 +819,7 @@ class VerifyClusterOperatorsAvailable(OrchestratorRule):
     def run_rule(self):
         """Check cluster operator conditions: Available, Degraded, Progressing, Upgradeable."""
         try:
-            _, operators_output, _ = self.oc_api.run_oc_command(
-                "get", ["clusteroperators", "-o", "json"], timeout=45
-            )
+            _, operators_output, _ = self.oc_api.run_oc_command("get", ["clusteroperators", "-o", "json"], timeout=45)
         except UnExpectedSystemOutput:
             return RuleResult.failed("Failed to get cluster operators")
 
@@ -905,59 +859,45 @@ class VerifyClusterOperatorsAvailable(OrchestratorRule):
                 if available_condition:
                     reason = available_condition.get("reason", "Unknown")
                     message = available_condition.get("message", "")
-                unavailable_operators.append(
-                    f"{name} - Reason: {reason}, Message: {message}"
-                )
+                unavailable_operators.append(f"{name} - Reason: {reason}, Message: {message}")
 
             if degraded_condition and degraded_condition.get("status") == "True":
                 reason = degraded_condition.get("reason", "Unknown")
                 message = degraded_condition.get("message", "")
-                degraded_operators.append(
-                    f"{name} - Reason: {reason}, Message: {message}"
-                )
+                degraded_operators.append(f"{name} - Reason: {reason}, Message: {message}")
 
             if progressing_condition and progressing_condition.get("status") == "True":
                 reason = progressing_condition.get("reason", "Unknown")
                 message = progressing_condition.get("message", "")
-                progressing_operators.append(
-                    f"{name} - Reason: {reason}, Message: {message}"
-                )
+                progressing_operators.append(f"{name} - Reason: {reason}, Message: {message}")
 
             if upgradeable_condition and upgradeable_condition.get("status") == "False":
                 reason = upgradeable_condition.get("reason", "Unknown")
                 message = upgradeable_condition.get("message", "")
-                not_upgradeable_operators.append(
-                    f"{name} - Reason: {reason}, Message: {message}"
-                )
+                not_upgradeable_operators.append(f"{name} - Reason: {reason}, Message: {message}")
 
         error_messages = []
         warning_messages = []
 
         if unavailable_operators:
             error_messages.append(
-                "Following cluster operators are not available:\n  "
-                + "\n  ".join(unavailable_operators)
+                "Following cluster operators are not available:\n  " + "\n  ".join(unavailable_operators)
             )
 
         if degraded_operators:
-            error_messages.append(
-                "Following cluster operators are degraded:\n  "
-                + "\n  ".join(degraded_operators)
-            )
+            error_messages.append("Following cluster operators are degraded:\n  " + "\n  ".join(degraded_operators))
 
         if error_messages:
             return RuleResult.failed("\n\n".join(error_messages))
 
         if progressing_operators:
             warning_messages.append(
-                "Following cluster operators are progressing:\n  "
-                + "\n  ".join(progressing_operators)
+                "Following cluster operators are progressing:\n  " + "\n  ".join(progressing_operators)
             )
 
         if not_upgradeable_operators:
             warning_messages.append(
-                "Following cluster operators are not upgradeable:\n  "
-                + "\n  ".join(not_upgradeable_operators)
+                "Following cluster operators are not upgradeable:\n  " + "\n  ".join(not_upgradeable_operators)
             )
 
         if warning_messages:
@@ -1004,16 +944,12 @@ class VerifyWebConsoleDisabled(OrchestratorRule):
                 timeout=45,
             )
         except UnExpectedSystemOutput:
-            return PrerequisiteResult.not_met(
-                "Failed to get console operator configuration"
-            )
+            return PrerequisiteResult.not_met("Failed to get console operator configuration")
 
         try:
             console_config = json.loads(console_config_output)
         except json.JSONDecodeError as e:
-            return PrerequisiteResult.not_met(
-                f"Failed to parse console operator configuration: {e}"
-            )
+            return PrerequisiteResult.not_met(f"Failed to parse console operator configuration: {e}")
 
         spec = console_config.get("spec", {})
         management_state = spec.get("managementState", "Unknown")
@@ -1076,9 +1012,7 @@ class SubscriptionOperatorRule(OrchestratorRule):
             f"{self.operator_display_name} operator is not installed on this cluster"
         )
 
-    def _check_pod_security_context(
-        self, pod_name: str, security_context: dict[str, object] | None
-    ) -> list[str]:
+    def _check_pod_security_context(self, pod_name: str, security_context: dict[str, object] | None) -> list[str]:
         """Validate pod-level security context has runAsNonRoot set to true.
 
         Args:
@@ -1100,9 +1034,7 @@ class SubscriptionOperatorRule(OrchestratorRule):
             )
         return errors
 
-    def _check_containers_non_root(
-        self, pod_name: str, all_containers: list[dict[str, object]]
-    ) -> list[str]:
+    def _check_containers_non_root(self, pod_name: str, all_containers: list[dict[str, object]]) -> list[str]:
         """Validate no container runs as root (runAsUser != 0).
 
         Args:
@@ -1127,9 +1059,7 @@ class SubscriptionOperatorRule(OrchestratorRule):
                             f"Container '{container_name}' in pod {pod_name} has invalid runAsUser: {run_as_user}"
                         )
                     elif run_as_user == 0:
-                        errors.append(
-                            f"Container '{container_name}' in pod {pod_name} runs as root (runAsUser=0)"
-                        )
+                        errors.append(f"Container '{container_name}' in pod {pod_name} runs as root (runAsUser=0)")
         return errors
 
 
@@ -1179,10 +1109,7 @@ class VerifyNfdOperatorHealth(SubscriptionOperatorRule):
                 not_ready_pods.append(pod_status["status_message"])
 
         if unknown_status_pods:
-            return RuleResult.failed(
-                "Failed to evaluate status for NFD pod(s):\n  "
-                + "\n  ".join(unknown_status_pods)
-            )
+            return RuleResult.failed("Failed to evaluate status for NFD pod(s):\n  " + "\n  ".join(unknown_status_pods))
 
         if not_ready_pods:
             message = f"NFD operator has unhealthy pods in {self.NFD_NAMESPACE} namespace:\n  "
@@ -1224,16 +1151,12 @@ class VerifyNetworkDiagnosticsDisabled(OrchestratorRule):
                 timeout=45,
             )
         except UnExpectedSystemOutput:
-            return PrerequisiteResult.not_met(
-                "Failed to get network operator configuration"
-            )
+            return PrerequisiteResult.not_met("Failed to get network operator configuration")
 
         try:
             network_config = json.loads(network_config_output)
         except json.JSONDecodeError as e:
-            return PrerequisiteResult.not_met(
-                f"Failed to parse network operator configuration: {e}"
-            )
+            return PrerequisiteResult.not_met(f"Failed to parse network operator configuration: {e}")
 
         spec = network_config.get("spec", {})
         disable_diagnostics = spec.get("disableNetworkDiagnostics")
@@ -1248,9 +1171,7 @@ class VerifyNetworkDiagnosticsDisabled(OrchestratorRule):
 
     def run_rule(self):
         """Verify no pods exist in the openshift-network-diagnostics namespace."""
-        pod_objects = self.oc_api.get_all_pods(
-            namespace="openshift-network-diagnostics"
-        )
+        pod_objects = self.oc_api.get_all_pods(namespace="openshift-network-diagnostics")
 
         if pod_objects:
             pod_names = []
@@ -1327,9 +1248,7 @@ class VerifyAcmOperatorHealth(SubscriptionOperatorRule):
         installed_csv_name = self._get_installed_csv_name()
         if installed_csv_name:
             acm_csvs = [
-                csv
-                for csv in csv_data.get("items", [])
-                if csv.get("metadata", {}).get("name") == installed_csv_name
+                csv for csv in csv_data.get("items", []) if csv.get("metadata", {}).get("name") == installed_csv_name
             ]
         else:
             acm_csvs = [
@@ -1351,15 +1270,10 @@ class VerifyAcmOperatorHealth(SubscriptionOperatorRule):
             if phase != "Succeeded":
                 reason = csv.get("status", {}).get("reason", "Unknown")
                 message = csv.get("status", {}).get("message", "")
-                not_succeeded.append(
-                    f"{name} - Phase: {phase}, Reason: {reason}, Message: {message}"
-                )
+                not_succeeded.append(f"{name} - Phase: {phase}, Reason: {reason}, Message: {message}")
 
         if not_succeeded:
-            return (
-                "ACM ClusterServiceVersion is not in Succeeded phase:\n  "
-                + "\n  ".join(not_succeeded)
-            )
+            return "ACM ClusterServiceVersion is not in Succeeded phase:\n  " + "\n  ".join(not_succeeded)
 
         return None
 
@@ -1401,10 +1315,7 @@ class VerifyAcmOperatorHealth(SubscriptionOperatorRule):
         if unknown_status_pods or not_ready_pods:
             parts = []
             if unknown_status_pods:
-                parts.append(
-                    "Failed to evaluate status for ACM pod(s):\n  "
-                    + "\n  ".join(unknown_status_pods)
-                )
+                parts.append("Failed to evaluate status for ACM pod(s):\n  " + "\n  ".join(unknown_status_pods))
             if not_ready_pods:
                 parts.append(
                     f"ACM operator has unhealthy pods in {self.ACM_NAMESPACE} namespace:\n  "
@@ -1464,10 +1375,7 @@ class VerifyNmoOperatorHealth(SubscriptionOperatorRule):
         if unknown_status_pods or not_ready_pods:
             parts = []
             if unknown_status_pods:
-                parts.append(
-                    "Failed to evaluate status for NMO pod(s):\n  "
-                    + "\n  ".join(unknown_status_pods)
-                )
+                parts.append("Failed to evaluate status for NMO pod(s):\n  " + "\n  ".join(unknown_status_pods))
             if not_ready_pods:
                 parts.append(
                     f"NMO operator has unhealthy pods in {self.NMO_NAMESPACE} namespace:\n  "
@@ -1525,10 +1433,7 @@ class VerifyFarOperatorHealth(SubscriptionOperatorRule):
         if unknown_status_pods or not_ready_pods:
             parts = []
             if unknown_status_pods:
-                parts.append(
-                    "Failed to evaluate status for FAR pod(s):\n  "
-                    + "\n  ".join(unknown_status_pods)
-                )
+                parts.append("Failed to evaluate status for FAR pod(s):\n  " + "\n  ".join(unknown_status_pods))
             if not_ready_pods:
                 parts.append(
                     f"FAR operator has unhealthy pods in {self.FAR_NAMESPACE} namespace:\n  "
@@ -1567,9 +1472,7 @@ class VerifyFARControllerReplicas(OrchestratorRule):
 
     def is_prerequisite_fulfilled(self):
         """Check if FAR deployment exists."""
-        deployments = self.oc_api.get_all_deployments(
-            namespace=self.FAR_NAMESPACE, timeout=30
-        )
+        deployments = self.oc_api.get_all_deployments(namespace=self.FAR_NAMESPACE, timeout=30)
 
         for deployment in deployments:
             deployment_name = deployment.as_dict()["metadata"]["name"]
@@ -1584,21 +1487,15 @@ class VerifyFARControllerReplicas(OrchestratorRule):
     def run_rule(self):
         """Check FAR controller manager has correct number of replicas."""
         # Step 1: Check if this is a Single Node OpenShift cluster
-        infrastructure = self.oc_api.select_resources(
-            "infrastructure/cluster", single=True, timeout=30
-        )
+        infrastructure = self.oc_api.select_resources("infrastructure/cluster", single=True, timeout=30)
         if infrastructure:
             infra_dict = infrastructure.as_dict()
             topology = infra_dict.get("status", {}).get("controlPlaneTopology", "")
             if topology == "SingleReplica":
-                return RuleResult.skip(
-                    "SNO (Single Node OpenShift) cluster detected. Skipping replica check."
-                )
+                return RuleResult.skip("SNO (Single Node OpenShift) cluster detected. Skipping replica check.")
 
         # Step 2: Get FAR deployment
-        deployments = self.oc_api.get_all_deployments(
-            namespace=self.FAR_NAMESPACE, timeout=30
-        )
+        deployments = self.oc_api.get_all_deployments(namespace=self.FAR_NAMESPACE, timeout=30)
         far_deployment = None
 
         for deployment in deployments:
@@ -1608,9 +1505,7 @@ class VerifyFARControllerReplicas(OrchestratorRule):
                 break
 
         if not far_deployment:
-            return RuleResult.failed(
-                f"FAR deployment '{self.FAR_DEPLOYMENT_NAME}' not found"
-            )
+            return RuleResult.failed(f"FAR deployment '{self.FAR_DEPLOYMENT_NAME}' not found")
 
         # Step 3: Get replica counts from deployment
         deployment_dict = far_deployment.as_dict()
@@ -1656,9 +1551,7 @@ class VerifyFarContainerNonRoot(SubscriptionOperatorRule):
 
     def run_rule(self):
         """Check if FAR pods run as non-root user with proper security context."""
-        pod_objects = self.oc_api.get_pods(
-            labels={self.FAR_POD_LABEL_KEY: self.FAR_POD_LABEL_VALUE}
-        )
+        pod_objects = self.oc_api.get_pods(labels={self.FAR_POD_LABEL_KEY: self.FAR_POD_LABEL_VALUE})
 
         if not pod_objects:
             return RuleResult.failed(
@@ -1671,14 +1564,10 @@ class VerifyFarContainerNonRoot(SubscriptionOperatorRule):
             pod_name = pod.name()
             spec = pod.as_dict().get("spec", {})
 
-            error_messages.extend(
-                self._check_pod_security_context(pod_name, spec.get("securityContext"))
-            )
+            error_messages.extend(self._check_pod_security_context(pod_name, spec.get("securityContext")))
 
             all_containers = spec.get("containers", []) + spec.get("initContainers", [])
-            error_messages.extend(
-                self._check_containers_non_root(pod_name, all_containers)
-            )
+            error_messages.extend(self._check_containers_non_root(pod_name, all_containers))
 
         if error_messages:
             message = "FAR operator pods doesn't have proper security context:\n"

--- a/tests/domains/test_k8s_domain.py
+++ b/tests/domains/test_k8s_domain.py
@@ -7,11 +7,12 @@ from in_cluster_checks.rules.k8s.k8s_validations import (
     NodesCpuAndMemoryStatus,
     OpenshiftOperatorStatus,
     ValidateAllDaemonsetsScheduled,
-    ValidateNamespaceStatus,
     ValidateAllPoliciesCompliant,
+    ValidateNamespaceStatus,
     VerifyAcmOperatorHealth,
     VerifyClusterOperatorsAvailable,
     VerifyFarContainerNonRoot,
+    VerifyFARControllerReplicas,
     VerifyFarOperatorHealth,
     VerifyInternalRegistry,
     VerifyNetworkDiagnosticsDisabled,
@@ -32,7 +33,7 @@ def test_k8s_domain_rules():
     domain = K8sValidationDomain()
     rules = domain.get_rule_classes()
 
-    assert len(rules) == 19
+    assert len(rules) == 20
     assert AllPodsReadyAndRunning in rules
     assert NodesAreReady in rules
     assert NodesCpuAndMemoryStatus in rules
@@ -42,6 +43,7 @@ def test_k8s_domain_rules():
     assert ValidateAllPoliciesCompliant in rules
     assert VerifyClusterOperatorsAvailable in rules
     assert VerifyFarContainerNonRoot in rules
+    assert VerifyFARControllerReplicas in rules
     assert VerifyInternalRegistry in rules
     assert VerifyWebConsoleDisabled in rules
     assert VerifyNetworkDiagnosticsDisabled in rules

--- a/tests/rules/k8s/test_k8s_validations.py
+++ b/tests/rules/k8s/test_k8s_validations.py
@@ -39,9 +39,7 @@ from tests.pytest_tools.test_rule_base import RuleScenarioParams, RuleTestBase
 def create_mock_pod(namespace, name, phase, ready_containers, total_containers):
     """Create a mock pod object."""
     mock_pod = Mock()
-    container_statuses = [
-        {"ready": i < ready_containers} for i in range(total_containers)
-    ]
+    container_statuses = [{"ready": i < ready_containers} for i in range(total_containers)]
     mock_pod.as_dict.return_value = {
         "metadata": {"namespace": namespace, "name": name},
         "status": {
@@ -241,9 +239,7 @@ class TestNodesCpuAndMemoryStatus:
 
     def test_critical_threshold_exceeded(self, tested_object):
         """Test when critical threshold is exceeded."""
-        tested_object.oc_api.run_oc_command = Mock(
-            return_value=(0, "node1    10000m  95%    2000Mi   10%", "")
-        )
+        tested_object.oc_api.run_oc_command = Mock(return_value=(0, "node1    10000m  95%    2000Mi   10%", ""))
 
         result = tested_object.run_rule()
         assert result.status == Status.FAILED
@@ -388,9 +384,7 @@ class TestValidateAllDaemonsetsScheduled:
                 },
             ]
         }
-        tested_object.oc_api.run_oc_command = Mock(
-            return_value=(0, json.dumps(daemonsets_data), "")
-        )
+        tested_object.oc_api.run_oc_command = Mock(return_value=(0, json.dumps(daemonsets_data), ""))
 
         result = tested_object.run_rule()
         assert result.status == Status.PASSED
@@ -417,9 +411,7 @@ class TestValidateAllDaemonsetsScheduled:
                 },
             ]
         }
-        tested_object.oc_api.run_oc_command = Mock(
-            return_value=(0, json.dumps(daemonsets_data), "")
-        )
+        tested_object.oc_api.run_oc_command = Mock(return_value=(0, json.dumps(daemonsets_data), ""))
 
         result = tested_object.run_rule()
         assert result.status == Status.FAILED
@@ -454,9 +446,7 @@ class TestValidateAllDaemonsetsScheduled:
                 },
             ]
         }
-        tested_object.oc_api.run_oc_command = Mock(
-            return_value=(0, json.dumps(daemonsets_data), "")
-        )
+        tested_object.oc_api.run_oc_command = Mock(return_value=(0, json.dumps(daemonsets_data), ""))
 
         result = tested_object.run_rule()
         assert result.status == Status.PASSED
@@ -478,9 +468,7 @@ class TestValidateAllDaemonsetsScheduled:
                 },
             ]
         }
-        tested_object.oc_api.run_oc_command = Mock(
-            return_value=(0, json.dumps(daemonsets_data), "")
-        )
+        tested_object.oc_api.run_oc_command = Mock(return_value=(0, json.dumps(daemonsets_data), ""))
 
         result = tested_object.run_rule()
         assert result.status == Status.PASSED
@@ -499,9 +487,7 @@ class TestValidateAllDaemonsetsScheduled:
                 },
             ]
         }
-        tested_object.oc_api.run_oc_command = Mock(
-            return_value=(0, json.dumps(daemonsets_data), "")
-        )
+        tested_object.oc_api.run_oc_command = Mock(return_value=(0, json.dumps(daemonsets_data), ""))
 
         result = tested_object.run_rule()
         assert result.status == Status.FAILED
@@ -525,9 +511,7 @@ baremetal                                  4.15.29    True        False         
 cloud-controller-manager                   4.15.29    True        False         False      14d
 cluster-autoscaler                         4.15.29    True        False         False      14d"""
 
-        tested_object.oc_api.run_oc_command = Mock(
-            return_value=(0, operator_output, "")
-        )
+        tested_object.oc_api.run_oc_command = Mock(return_value=(0, operator_output, ""))
 
         result = tested_object.run_rule()
         assert result.status == Status.INFO
@@ -551,9 +535,7 @@ cluster-autoscaler                         4.15.29    True        False         
 baremetal                                  4.15.29    False       False         False      14d     Operator is degraded
 cloud-controller-manager                   4.15.29    True        False         False      14d"""
 
-        tested_object.oc_api.run_oc_command = Mock(
-            return_value=(0, operator_output, "")
-        )
+        tested_object.oc_api.run_oc_command = Mock(return_value=(0, operator_output, ""))
 
         result = tested_object.run_rule()
         assert result.status == Status.FAILED
@@ -568,9 +550,7 @@ cloud-controller-manager                   4.15.29    True        False         
 baremetal                                  4.15.29    True        True          False      14d     Rolling out new pods
 cloud-controller-manager                   4.15.29    True        False         False      14d"""
 
-        tested_object.oc_api.run_oc_command = Mock(
-            return_value=(0, operator_output, "")
-        )
+        tested_object.oc_api.run_oc_command = Mock(return_value=(0, operator_output, ""))
 
         result = tested_object.run_rule()
         assert result.status == Status.FAILED
@@ -585,9 +565,7 @@ cloud-controller-manager                   4.15.29    True        False         
 baremetal                                  4.15.29    True        True          False      14d     Rolling out
 cloud-controller-manager                   4.15.29    True        False         False      14d"""
 
-        tested_object.oc_api.run_oc_command = Mock(
-            return_value=(0, operator_output, "")
-        )
+        tested_object.oc_api.run_oc_command = Mock(return_value=(0, operator_output, ""))
 
         result = tested_object.run_rule()
         assert result.status == Status.FAILED
@@ -613,9 +591,7 @@ bad-operator                               4.15.29    False       False         
 progressing-operator                       4.15.29    True        True          False      14d     Working
 another-good-operator                      4.15.29    True        False         False      14d"""
 
-        tested_object.oc_api.run_oc_command = Mock(
-            return_value=(0, operator_output, "")
-        )
+        tested_object.oc_api.run_oc_command = Mock(return_value=(0, operator_output, ""))
 
         result = tested_object.run_rule()
         assert result.status == Status.FAILED
@@ -728,9 +704,7 @@ class TestAllDeploymentsAvailable(RuleTestBase):
         ),
         RuleScenarioParams(
             "no deployments found in cluster",
-            tested_object_mock_dict={
-                "oc_api.get_all_deployments": Mock(return_value=[])
-            },
+            tested_object_mock_dict={"oc_api.get_all_deployments": Mock(return_value=[])},
             failed_msg="No deployments found in cluster",
         ),
         RuleScenarioParams(
@@ -968,9 +942,7 @@ class TestCheckDeploymentsReplicaStatus(RuleTestBase):
         ),
         RuleScenarioParams(
             "no deployments found in cluster",
-            tested_object_mock_dict={
-                "oc_api.get_all_deployments": Mock(return_value=[])
-            },
+            tested_object_mock_dict={"oc_api.get_all_deployments": Mock(return_value=[])},
             failed_msg="No deployments found in cluster",
         ),
     ]
@@ -1034,8 +1006,7 @@ class TestAllStatefulsetsReady(RuleTestBase):
                     ]
                 )
             },
-            failed_msg="Following statefulsets are not ready:\n"
-            "  kube-system/statefulset2 - Desired: 3, Ready: 1",
+            failed_msg="Following statefulsets are not ready:\n" "  kube-system/statefulset2 - Desired: 3, Ready: 1",
         ),
         RuleScenarioParams(
             "statefulset has zero ready replicas",
@@ -1051,8 +1022,7 @@ class TestAllStatefulsetsReady(RuleTestBase):
                     ]
                 )
             },
-            failed_msg="Following statefulsets are not ready:\n"
-            "  default/statefulset1 - Desired: 3, Ready: 0",
+            failed_msg="Following statefulsets are not ready:\n" "  default/statefulset1 - Desired: 3, Ready: 0",
         ),
         RuleScenarioParams(
             "statefulsets in mixed states",
@@ -1089,9 +1059,7 @@ class TestAllStatefulsetsReady(RuleTestBase):
     scenario_warning = [
         RuleScenarioParams(
             "no statefulsets found in cluster",
-            tested_object_mock_dict={
-                "oc_api.get_all_statefulsets": Mock(return_value=[])
-            },
+            tested_object_mock_dict={"oc_api.get_all_statefulsets": Mock(return_value=[])},
             failed_msg="No statefulsets found in cluster",
         ),
     ]
@@ -1196,9 +1164,7 @@ class TestValidateAllPoliciesCompliant(RuleTestBase):
 
     @pytest.mark.parametrize("scenario_params", scenario_prerequisite_not_fulfilled)
     def test_prerequisite_not_fulfilled(self, scenario_params, tested_object):
-        RuleTestBase.test_prerequisite_not_fulfilled(
-            self, scenario_params, tested_object
-        )
+        RuleTestBase.test_prerequisite_not_fulfilled(self, scenario_params, tested_object)
 
 
 def create_mock_registry_pod(name, namespace, phase, all_containers_ready=True):
@@ -1252,9 +1218,7 @@ class TestVerifyInternalRegistry(RuleTestBase):
         RuleScenarioParams(
             "registry is managed and pods are running",
             tested_object_mock_dict={
-                "oc_api.run_oc_command": Mock(
-                    return_value=(0, json.dumps(registry_config_managed), "")
-                ),
+                "oc_api.run_oc_command": Mock(return_value=(0, json.dumps(registry_config_managed), "")),
                 "oc_api.get_all_pods": Mock(
                     return_value=[
                         create_mock_registry_pod(
@@ -1276,9 +1240,7 @@ class TestVerifyInternalRegistry(RuleTestBase):
         RuleScenarioParams(
             "registry is managed with one running pod",
             tested_object_mock_dict={
-                "oc_api.run_oc_command": Mock(
-                    return_value=(0, json.dumps(registry_config_managed), "")
-                ),
+                "oc_api.run_oc_command": Mock(return_value=(0, json.dumps(registry_config_managed), "")),
                 "oc_api.get_all_pods": Mock(
                     return_value=[
                         create_mock_registry_pod(
@@ -1297,17 +1259,13 @@ class TestVerifyInternalRegistry(RuleTestBase):
         RuleScenarioParams(
             "registry is not in Managed state (Removed)",
             tested_object_mock_dict={
-                "oc_api.run_oc_command": Mock(
-                    return_value=(0, json.dumps(registry_config_removed), "")
-                ),
+                "oc_api.run_oc_command": Mock(return_value=(0, json.dumps(registry_config_removed), "")),
             },
         ),
         RuleScenarioParams(
             "registry is not in Managed state (Unmanaged)",
             tested_object_mock_dict={
-                "oc_api.run_oc_command": Mock(
-                    return_value=(0, json.dumps(registry_config_unmanaged), "")
-                ),
+                "oc_api.run_oc_command": Mock(return_value=(0, json.dumps(registry_config_unmanaged), "")),
             },
         ),
     ]
@@ -1316,9 +1274,7 @@ class TestVerifyInternalRegistry(RuleTestBase):
         RuleScenarioParams(
             "registry is managed but no pods found",
             tested_object_mock_dict={
-                "oc_api.run_oc_command": Mock(
-                    return_value=(0, json.dumps(registry_config_managed), "")
-                ),
+                "oc_api.run_oc_command": Mock(return_value=(0, json.dumps(registry_config_managed), "")),
                 "oc_api.get_all_pods": Mock(return_value=[]),
             },
             failed_msg="Image registry is Managed but no registry pods found in openshift-image-registry namespace.\n",
@@ -1326,9 +1282,7 @@ class TestVerifyInternalRegistry(RuleTestBase):
         RuleScenarioParams(
             "registry is managed but pods are not running",
             tested_object_mock_dict={
-                "oc_api.run_oc_command": Mock(
-                    return_value=(0, json.dumps(registry_config_managed), "")
-                ),
+                "oc_api.run_oc_command": Mock(return_value=(0, json.dumps(registry_config_managed), "")),
                 "oc_api.get_all_pods": Mock(
                     return_value=[
                         create_mock_registry_pod(
@@ -1346,9 +1300,7 @@ class TestVerifyInternalRegistry(RuleTestBase):
         RuleScenarioParams(
             "registry is managed but pods running with containers not ready",
             tested_object_mock_dict={
-                "oc_api.run_oc_command": Mock(
-                    return_value=(0, json.dumps(registry_config_managed), "")
-                ),
+                "oc_api.run_oc_command": Mock(return_value=(0, json.dumps(registry_config_managed), "")),
                 "oc_api.get_all_pods": Mock(
                     return_value=[
                         create_mock_registry_pod(
@@ -1367,9 +1319,7 @@ class TestVerifyInternalRegistry(RuleTestBase):
 
     @pytest.mark.parametrize("scenario_params", scenario_prerequisite_not_fulfilled)
     def test_prerequisite_not_fulfilled(self, scenario_params, tested_object):
-        RuleTestBase.test_prerequisite_not_fulfilled(
-            self, scenario_params, tested_object
-        )
+        RuleTestBase.test_prerequisite_not_fulfilled(self, scenario_params, tested_object)
 
     @pytest.mark.parametrize("scenario_params", scenario_passed)
     def test_scenario_passed(self, scenario_params, tested_object):
@@ -1562,9 +1512,7 @@ class TestVerifyClusterOperatorsAvailable(RuleTestBase):
         RuleScenarioParams(
             "no cluster operators found in cluster",
             oc_cmd_output_dict={
-                ("get", ("clusteroperators", "-o", "json")): CmdOutput(
-                    json.dumps({"items": []})
-                ),
+                ("get", ("clusteroperators", "-o", "json")): CmdOutput(json.dumps({"items": []})),
             },
             failed_msg="No cluster operators found in cluster",
         ),
@@ -1681,18 +1629,14 @@ class TestVerifyWebConsoleDisabled(RuleTestBase):
         RuleScenarioParams(
             "console is disabled (Removed) and no pods in openshift-console namespace",
             tested_object_mock_dict={
-                "oc_api.run_oc_command": Mock(
-                    return_value=(0, json.dumps(_console_config("Removed")), "")
-                ),
+                "oc_api.run_oc_command": Mock(return_value=(0, json.dumps(_console_config("Removed")), "")),
                 "oc_api.get_all_pods": Mock(return_value=[]),
             },
         ),
         RuleScenarioParams(
             "console is disabled (Unmanaged) and no pods in openshift-console namespace",
             tested_object_mock_dict={
-                "oc_api.run_oc_command": Mock(
-                    return_value=(0, json.dumps(_console_config("Unmanaged")), "")
-                ),
+                "oc_api.run_oc_command": Mock(return_value=(0, json.dumps(_console_config("Unmanaged")), "")),
                 "oc_api.get_all_pods": Mock(return_value=[]),
             },
         ),
@@ -1702,17 +1646,13 @@ class TestVerifyWebConsoleDisabled(RuleTestBase):
         RuleScenarioParams(
             "console operator is Managed (web console enabled)",
             tested_object_mock_dict={
-                "oc_api.run_oc_command": Mock(
-                    return_value=(0, json.dumps(_console_config("Managed")), "")
-                ),
+                "oc_api.run_oc_command": Mock(return_value=(0, json.dumps(_console_config("Managed")), "")),
             },
         ),
         RuleScenarioParams(
             "console operator managementState is missing",
             tested_object_mock_dict={
-                "oc_api.run_oc_command": Mock(
-                    return_value=(0, json.dumps(_console_config()), "")
-                ),
+                "oc_api.run_oc_command": Mock(return_value=(0, json.dumps(_console_config()), "")),
             },
         ),
     ]
@@ -1721,9 +1661,7 @@ class TestVerifyWebConsoleDisabled(RuleTestBase):
         RuleScenarioParams(
             "console is disabled but pods still exist in openshift-console namespace",
             tested_object_mock_dict={
-                "oc_api.run_oc_command": Mock(
-                    return_value=(0, json.dumps(_console_config("Removed")), "")
-                ),
+                "oc_api.run_oc_command": Mock(return_value=(0, json.dumps(_console_config("Removed")), "")),
                 "oc_api.get_all_pods": Mock(
                     return_value=[
                         create_mock_console_pod("console-7b4f8c6d9-abc12"),
@@ -1740,9 +1678,7 @@ class TestVerifyWebConsoleDisabled(RuleTestBase):
 
     @pytest.mark.parametrize("scenario_params", scenario_prerequisite_not_fulfilled)
     def test_prerequisite_not_fulfilled(self, scenario_params, tested_object):
-        RuleTestBase.test_prerequisite_not_fulfilled(
-            self, scenario_params, tested_object
-        )
+        RuleTestBase.test_prerequisite_not_fulfilled(self, scenario_params, tested_object)
 
     @pytest.mark.parametrize("scenario_params", scenario_passed)
     def test_scenario_passed(self, scenario_params, tested_object):
@@ -1768,11 +1704,7 @@ def create_mock_network_diagnostics_pod(name):
 
 def _network_config(disable_diagnostics=None):
     """Build a network operator config with the given disableNetworkDiagnostics value."""
-    spec = (
-        {"disableNetworkDiagnostics": disable_diagnostics}
-        if disable_diagnostics is not None
-        else {}
-    )
+    spec = {"disableNetworkDiagnostics": disable_diagnostics} if disable_diagnostics is not None else {}
     return {"spec": spec, "status": {}}
 
 
@@ -1823,12 +1755,8 @@ class TestVerifyNetworkDiagnosticsDisabled(RuleTestBase):
             tested_object_mock_dict={
                 "oc_api.get_all_pods": Mock(
                     return_value=[
-                        create_mock_network_diagnostics_pod(
-                            "network-check-source-7b4f8c6d9-abc12"
-                        ),
-                        create_mock_network_diagnostics_pod(
-                            "network-check-target-xyz34"
-                        ),
+                        create_mock_network_diagnostics_pod("network-check-source-7b4f8c6d9-abc12"),
+                        create_mock_network_diagnostics_pod("network-check-target-xyz34"),
                     ]
                 ),
             },
@@ -1848,9 +1776,7 @@ class TestVerifyNetworkDiagnosticsDisabled(RuleTestBase):
     @pytest.mark.parametrize("scenario_params", scenario_prerequisite_not_fulfilled)
     def test_prerequisite_not_fulfilled(self, scenario_params, tested_object):
         """Test prerequisite not fulfilled scenarios."""
-        RuleTestBase.test_prerequisite_not_fulfilled(
-            self, scenario_params, tested_object
-        )
+        RuleTestBase.test_prerequisite_not_fulfilled(self, scenario_params, tested_object)
 
     @pytest.mark.parametrize("scenario_params", scenario_passed)
     def test_scenario_passed(self, scenario_params, tested_object):
@@ -1909,9 +1835,7 @@ class TestVerifyNfdOperatorHealth(RuleTestBase):
             tested_object_mock_dict={
                 "oc_api.get_all_pods": Mock(
                     return_value=[
-                        create_mock_nfd_pod(
-                            "nfd-controller-manager-abc123", "Running", True
-                        ),
+                        create_mock_nfd_pod("nfd-controller-manager-abc123", "Running", True),
                         create_mock_nfd_pod("nfd-worker-xyz789", "Running", True),
                     ]
                 ),
@@ -1985,9 +1909,7 @@ class TestVerifyNfdOperatorHealth(RuleTestBase):
             tested_object_mock_dict={
                 "oc_api.get_all_pods": Mock(
                     return_value=[
-                        create_mock_nfd_pod(
-                            "nfd-controller-manager-abc123", "Running", True
-                        ),
+                        create_mock_nfd_pod("nfd-controller-manager-abc123", "Running", True),
                         create_mock_nfd_pod("nfd-worker-xyz789", "Pending", True),
                     ]
                 ),
@@ -2011,9 +1933,7 @@ class TestVerifyNfdOperatorHealth(RuleTestBase):
             tested_object_mock_dict={
                 "oc_api.get_all_pods": Mock(
                     return_value=[
-                        create_mock_nfd_pod(
-                            "nfd-controller-manager-abc123", "Running", False
-                        ),
+                        create_mock_nfd_pod("nfd-controller-manager-abc123", "Running", False),
                     ]
                 ),
             },
@@ -2036,9 +1956,7 @@ class TestVerifyNfdOperatorHealth(RuleTestBase):
             tested_object_mock_dict={
                 "oc_api.get_all_pods": Mock(
                     return_value=[
-                        create_mock_nfd_pod(
-                            "nfd-controller-manager-abc123", "Succeeded", True
-                        ),
+                        create_mock_nfd_pod("nfd-controller-manager-abc123", "Succeeded", True),
                     ]
                 ),
             },
@@ -2060,9 +1978,7 @@ class TestVerifyNfdOperatorHealth(RuleTestBase):
     @pytest.mark.parametrize("scenario_params", scenario_prerequisite_not_fulfilled)
     def test_prerequisite_not_fulfilled(self, scenario_params, tested_object):
         """Test that prerequisite is not met when NFD operator is not installed."""
-        RuleTestBase.test_prerequisite_not_fulfilled(
-            self, scenario_params, tested_object
-        )
+        RuleTestBase.test_prerequisite_not_fulfilled(self, scenario_params, tested_object)
 
     @pytest.mark.parametrize("scenario_params", scenario_passed)
     def test_scenario_passed(self, scenario_params, tested_object):
@@ -2091,9 +2007,7 @@ def create_mock_acm_pod(name, phase, all_containers_ready=True):
     return mock_pod
 
 
-def _acm_subscriptions(
-    include_acm=True, installed_csv="advanced-cluster-management.v2.12.0"
-):
+def _acm_subscriptions(include_acm=True, installed_csv="advanced-cluster-management.v2.12.0"):
     """Build a subscriptions response, optionally including the ACM subscription."""
     items = []
     if include_acm:
@@ -2121,11 +2035,7 @@ def _acm_csv_response(include_csv=True, phase="Succeeded"):
     items = []
     if include_csv:
         reason = "InstallSucceeded" if phase == "Succeeded" else "InstallFailed"
-        message = (
-            "install strategy completed with no errors"
-            if phase == "Succeeded"
-            else "install failed"
-        )
+        message = "install strategy completed with no errors" if phase == "Succeeded" else "install failed"
         items.append(
             {
                 "metadata": {
@@ -2158,9 +2068,7 @@ class TestVerifyAcmOperatorHealth(RuleTestBase):
         RuleScenarioParams(
             "ACM operator subscription found",
             oc_cmd_output_dict={
-                _ACM_SUB_CMD: CmdOutput(
-                    json.dumps(_acm_subscriptions(include_acm=True))
-                ),
+                _ACM_SUB_CMD: CmdOutput(json.dumps(_acm_subscriptions(include_acm=True))),
             },
         ),
     ]
@@ -2171,17 +2079,13 @@ class TestVerifyAcmOperatorHealth(RuleTestBase):
             tested_object_mock_dict={
                 "oc_api.get_all_pods": Mock(
                     return_value=[
-                        create_mock_acm_pod(
-                            "multiclusterhub-operator-abc123", "Running", True
-                        ),
+                        create_mock_acm_pod("multiclusterhub-operator-abc123", "Running", True),
                         create_mock_acm_pod("cluster-manager-xyz789", "Running", True),
                     ]
                 ),
             },
             oc_cmd_output_dict={
-                _ACM_SUB_CMD: CmdOutput(
-                    json.dumps(_acm_subscriptions(include_acm=True))
-                ),
+                _ACM_SUB_CMD: CmdOutput(json.dumps(_acm_subscriptions(include_acm=True))),
                 _ACM_CSV_CMD: CmdOutput(json.dumps(_acm_csv_response())),
             },
         ),
@@ -2190,16 +2094,12 @@ class TestVerifyAcmOperatorHealth(RuleTestBase):
             tested_object_mock_dict={
                 "oc_api.get_all_pods": Mock(
                     return_value=[
-                        create_mock_acm_pod(
-                            "multiclusterhub-operator-abc123", "Running", True
-                        ),
+                        create_mock_acm_pod("multiclusterhub-operator-abc123", "Running", True),
                     ]
                 ),
             },
             oc_cmd_output_dict={
-                _ACM_SUB_CMD: CmdOutput(
-                    json.dumps(_acm_subscriptions(include_acm=True, installed_csv=None))
-                ),
+                _ACM_SUB_CMD: CmdOutput(json.dumps(_acm_subscriptions(include_acm=True, installed_csv=None))),
                 _ACM_CSV_CMD: CmdOutput(json.dumps(_acm_csv_response())),
             },
         ),
@@ -2209,9 +2109,7 @@ class TestVerifyAcmOperatorHealth(RuleTestBase):
         RuleScenarioParams(
             "ACM operator subscription not found",
             oc_cmd_output_dict={
-                _ACM_SUB_CMD: CmdOutput(
-                    json.dumps(_acm_subscriptions(include_acm=False))
-                ),
+                _ACM_SUB_CMD: CmdOutput(json.dumps(_acm_subscriptions(include_acm=False))),
             },
         ),
         RuleScenarioParams(
@@ -2228,19 +2126,13 @@ class TestVerifyAcmOperatorHealth(RuleTestBase):
             tested_object_mock_dict={
                 "oc_api.get_all_pods": Mock(
                     return_value=[
-                        create_mock_acm_pod(
-                            "multiclusterhub-operator-abc123", "Running", True
-                        ),
+                        create_mock_acm_pod("multiclusterhub-operator-abc123", "Running", True),
                     ]
                 ),
             },
             oc_cmd_output_dict={
-                _ACM_SUB_CMD: CmdOutput(
-                    json.dumps(_acm_subscriptions(include_acm=True))
-                ),
-                _ACM_CSV_CMD: CmdOutput(
-                    json.dumps(_acm_csv_response(include_csv=False))
-                ),
+                _ACM_SUB_CMD: CmdOutput(json.dumps(_acm_subscriptions(include_acm=True))),
+                _ACM_CSV_CMD: CmdOutput(json.dumps(_acm_csv_response(include_csv=False))),
             },
             failed_msg=(
                 "No ClusterServiceVersion matching 'advanced-cluster-management' "
@@ -2252,16 +2144,12 @@ class TestVerifyAcmOperatorHealth(RuleTestBase):
             tested_object_mock_dict={
                 "oc_api.get_all_pods": Mock(
                     return_value=[
-                        create_mock_acm_pod(
-                            "multiclusterhub-operator-abc123", "Running", True
-                        ),
+                        create_mock_acm_pod("multiclusterhub-operator-abc123", "Running", True),
                     ]
                 ),
             },
             oc_cmd_output_dict={
-                _ACM_SUB_CMD: CmdOutput(
-                    json.dumps(_acm_subscriptions(include_acm=True))
-                ),
+                _ACM_SUB_CMD: CmdOutput(json.dumps(_acm_subscriptions(include_acm=True))),
                 _ACM_CSV_CMD: CmdOutput(json.dumps(_acm_csv_response(phase="Failed"))),
             },
             failed_msg=(
@@ -2275,9 +2163,7 @@ class TestVerifyAcmOperatorHealth(RuleTestBase):
                 "oc_api.get_all_pods": Mock(return_value=[]),
             },
             oc_cmd_output_dict={
-                _ACM_SUB_CMD: CmdOutput(
-                    json.dumps(_acm_subscriptions(include_acm=True))
-                ),
+                _ACM_SUB_CMD: CmdOutput(json.dumps(_acm_subscriptions(include_acm=True))),
                 _ACM_CSV_CMD: CmdOutput(json.dumps(_acm_csv_response())),
             },
             failed_msg="No pods found in open-cluster-management namespace. ACM operator may not be fully deployed.",
@@ -2287,17 +2173,13 @@ class TestVerifyAcmOperatorHealth(RuleTestBase):
             tested_object_mock_dict={
                 "oc_api.get_all_pods": Mock(
                     return_value=[
-                        create_mock_acm_pod(
-                            "multiclusterhub-operator-abc123", "Running", True
-                        ),
+                        create_mock_acm_pod("multiclusterhub-operator-abc123", "Running", True),
                         create_mock_acm_pod("cluster-manager-xyz789", "Pending", True),
                     ]
                 ),
             },
             oc_cmd_output_dict={
-                _ACM_SUB_CMD: CmdOutput(
-                    json.dumps(_acm_subscriptions(include_acm=True))
-                ),
+                _ACM_SUB_CMD: CmdOutput(json.dumps(_acm_subscriptions(include_acm=True))),
                 _ACM_CSV_CMD: CmdOutput(json.dumps(_acm_csv_response())),
             },
             failed_msg=(
@@ -2310,16 +2192,12 @@ class TestVerifyAcmOperatorHealth(RuleTestBase):
             tested_object_mock_dict={
                 "oc_api.get_all_pods": Mock(
                     return_value=[
-                        create_mock_acm_pod(
-                            "multiclusterhub-operator-abc123", "Running", False
-                        ),
+                        create_mock_acm_pod("multiclusterhub-operator-abc123", "Running", False),
                     ]
                 ),
             },
             oc_cmd_output_dict={
-                _ACM_SUB_CMD: CmdOutput(
-                    json.dumps(_acm_subscriptions(include_acm=True))
-                ),
+                _ACM_SUB_CMD: CmdOutput(json.dumps(_acm_subscriptions(include_acm=True))),
                 _ACM_CSV_CMD: CmdOutput(json.dumps(_acm_csv_response())),
             },
             failed_msg=(
@@ -2332,16 +2210,12 @@ class TestVerifyAcmOperatorHealth(RuleTestBase):
             tested_object_mock_dict={
                 "oc_api.get_all_pods": Mock(
                     return_value=[
-                        create_mock_acm_pod(
-                            "multiclusterhub-operator-abc123", "Succeeded", True
-                        ),
+                        create_mock_acm_pod("multiclusterhub-operator-abc123", "Succeeded", True),
                     ]
                 ),
             },
             oc_cmd_output_dict={
-                _ACM_SUB_CMD: CmdOutput(
-                    json.dumps(_acm_subscriptions(include_acm=True))
-                ),
+                _ACM_SUB_CMD: CmdOutput(json.dumps(_acm_subscriptions(include_acm=True))),
                 _ACM_CSV_CMD: CmdOutput(json.dumps(_acm_csv_response())),
             },
             failed_msg="Failed to evaluate status for ACM pod(s):\n  multiclusterhub-operator-abc123",
@@ -2357,9 +2231,7 @@ class TestVerifyAcmOperatorHealth(RuleTestBase):
                 ),
             },
             oc_cmd_output_dict={
-                _ACM_SUB_CMD: CmdOutput(
-                    json.dumps(_acm_subscriptions(include_acm=True))
-                ),
+                _ACM_SUB_CMD: CmdOutput(json.dumps(_acm_subscriptions(include_acm=True))),
                 _ACM_CSV_CMD: CmdOutput(json.dumps(_acm_csv_response())),
             },
             failed_msg=(
@@ -2374,16 +2246,12 @@ class TestVerifyAcmOperatorHealth(RuleTestBase):
             tested_object_mock_dict={
                 "oc_api.get_all_pods": Mock(
                     return_value=[
-                        create_mock_acm_pod(
-                            "multiclusterhub-operator-abc123", "Pending", True
-                        ),
+                        create_mock_acm_pod("multiclusterhub-operator-abc123", "Pending", True),
                     ]
                 ),
             },
             oc_cmd_output_dict={
-                _ACM_SUB_CMD: CmdOutput(
-                    json.dumps(_acm_subscriptions(include_acm=True))
-                ),
+                _ACM_SUB_CMD: CmdOutput(json.dumps(_acm_subscriptions(include_acm=True))),
                 _ACM_CSV_CMD: CmdOutput(json.dumps(_acm_csv_response(phase="Failed"))),
             },
             failed_msg=(
@@ -2404,9 +2272,7 @@ class TestVerifyAcmOperatorHealth(RuleTestBase):
     @pytest.mark.parametrize("scenario_params", scenario_prerequisite_not_fulfilled)
     def test_prerequisite_not_fulfilled(self, scenario_params, tested_object):
         """Test that prerequisite is not met when ACM operator is not installed."""
-        RuleTestBase.test_prerequisite_not_fulfilled(
-            self, scenario_params, tested_object
-        )
+        RuleTestBase.test_prerequisite_not_fulfilled(self, scenario_params, tested_object)
 
     @pytest.mark.parametrize("scenario_params", scenario_passed)
     def test_scenario_passed(self, scenario_params, tested_object):
@@ -2487,9 +2353,7 @@ class TestVerifyFarOperatorHealth(RuleTestBase):
                             "Running",
                             True,
                         ),
-                        create_mock_far_pod(
-                            "fence-agents-remediation-worker-xyz789", "Running", True
-                        ),
+                        create_mock_far_pod("fence-agents-remediation-worker-xyz789", "Running", True),
                     ]
                 ),
             },
@@ -2568,9 +2432,7 @@ class TestVerifyFarOperatorHealth(RuleTestBase):
                             "Running",
                             True,
                         ),
-                        create_mock_far_pod(
-                            "fence-agents-remediation-worker-xyz789", "Pending", True
-                        ),
+                        create_mock_far_pod("fence-agents-remediation-worker-xyz789", "Pending", True),
                     ]
                 ),
             },
@@ -2652,9 +2514,7 @@ class TestVerifyFarOperatorHealth(RuleTestBase):
                             "Succeeded",
                             True,
                         ),
-                        create_mock_far_pod(
-                            "fence-agents-remediation-worker-xyz789", "Running", False
-                        ),
+                        create_mock_far_pod("fence-agents-remediation-worker-xyz789", "Running", False),
                     ]
                 ),
             },
@@ -2684,9 +2544,7 @@ class TestVerifyFarOperatorHealth(RuleTestBase):
     @pytest.mark.parametrize("scenario_params", scenario_prerequisite_not_fulfilled)
     def test_prerequisite_not_fulfilled(self, scenario_params, tested_object):
         """Test that prerequisite is not met when FAR operator is not installed."""
-        RuleTestBase.test_prerequisite_not_fulfilled(
-            self, scenario_params, tested_object
-        )
+        RuleTestBase.test_prerequisite_not_fulfilled(self, scenario_params, tested_object)
 
     @pytest.mark.parametrize("scenario_params", scenario_passed)
     def test_scenario_passed(self, scenario_params, tested_object):
@@ -2827,9 +2685,7 @@ class TestVerifyFARControllerReplicas(RuleTestBase):
             tested_object_mock_dict={
                 "oc_api.get_all_deployments": Mock(
                     return_value=[
-                        create_mock_deployment(
-                            "fence-agents-remediation-controller-manager", 2, 2
-                        ),
+                        create_mock_deployment("fence-agents-remediation-controller-manager", 2, 2),
                     ]
                 ),
             },
@@ -2847,9 +2703,7 @@ class TestVerifyFARControllerReplicas(RuleTestBase):
         RuleScenarioParams(
             "SNO cluster - prerequisite not fulfilled",
             tested_object_mock_dict={
-                "oc_api.select_resources": Mock(
-                    return_value=create_mock_infrastructure("SingleReplica")
-                ),
+                "oc_api.select_resources": Mock(return_value=create_mock_infrastructure("SingleReplica")),
                 "oc_api.get_all_deployments": Mock(return_value=[]),
             },
         ),
@@ -2863,16 +2717,12 @@ class TestVerifyFARControllerReplicas(RuleTestBase):
                 "oc_api.select_resources": Mock(
                     side_effect=[
                         create_mock_infrastructure("HighlyAvailable"),  # Not SNO
-                        create_mock_deployment(
-                            "fence-agents-remediation-controller-manager", 2, 2
-                        ),
+                        create_mock_deployment("fence-agents-remediation-controller-manager", 2, 2),
                     ]
                 ),
                 "oc_api.get_all_deployments": Mock(
                     return_value=[
-                        create_mock_deployment(
-                            "fence-agents-remediation-controller-manager", 2, 2
-                        ),
+                        create_mock_deployment("fence-agents-remediation-controller-manager", 2, 2),
                     ]
                 ),
             },
@@ -2887,16 +2737,12 @@ class TestVerifyFARControllerReplicas(RuleTestBase):
                 "oc_api.select_resources": Mock(
                     side_effect=[
                         create_mock_infrastructure("HighlyAvailable"),
-                        create_mock_deployment(
-                            "fence-agents-remediation-controller-manager", 1, 1
-                        ),
+                        create_mock_deployment("fence-agents-remediation-controller-manager", 1, 1),
                     ]
                 ),
                 "oc_api.get_all_deployments": Mock(
                     return_value=[
-                        create_mock_deployment(
-                            "fence-agents-remediation-controller-manager", 1, 1
-                        ),
+                        create_mock_deployment("fence-agents-remediation-controller-manager", 1, 1),
                     ]
                 ),
             },
@@ -2908,16 +2754,12 @@ class TestVerifyFARControllerReplicas(RuleTestBase):
                 "oc_api.select_resources": Mock(
                     side_effect=[
                         create_mock_infrastructure("HighlyAvailable"),
-                        create_mock_deployment(
-                            "fence-agents-remediation-controller-manager", 2, 1
-                        ),
+                        create_mock_deployment("fence-agents-remediation-controller-manager", 2, 1),
                     ]
                 ),
                 "oc_api.get_all_deployments": Mock(
                     return_value=[
-                        create_mock_deployment(
-                            "fence-agents-remediation-controller-manager", 2, 1
-                        ),
+                        create_mock_deployment("fence-agents-remediation-controller-manager", 2, 1),
                     ]
                 ),
             },
@@ -2933,9 +2775,7 @@ class TestVerifyFARControllerReplicas(RuleTestBase):
     @pytest.mark.parametrize("scenario_params", scenario_prerequisite_not_fulfilled)
     def test_prerequisite_not_fulfilled(self, scenario_params, tested_object):
         """Test that prerequisite is not met when FAR deployment does not exist."""
-        RuleTestBase.test_prerequisite_not_fulfilled(
-            self, scenario_params, tested_object
-        )
+        RuleTestBase.test_prerequisite_not_fulfilled(self, scenario_params, tested_object)
 
     @pytest.mark.parametrize("scenario_params", scenario_passed)
     def test_scenario_passed(self, scenario_params, tested_object):
@@ -3282,9 +3122,7 @@ class TestVerifyFarContainerNonRoot(RuleTestBase):
 
     @pytest.mark.parametrize("scenario_params", scenario_prerequisite_not_fulfilled)
     def test_prerequisite_not_fulfilled(self, scenario_params, tested_object):
-        RuleTestBase.test_prerequisite_not_fulfilled(
-            self, scenario_params, tested_object
-        )
+        RuleTestBase.test_prerequisite_not_fulfilled(self, scenario_params, tested_object)
 
     @pytest.mark.parametrize("scenario_params", scenario_prerequisite_fulfilled)
     def test_prerequisite_fulfilled(self, scenario_params, tested_object):
@@ -3445,9 +3283,7 @@ class TestVerifyNmoOperatorHealth(RuleTestBase):
                             "Running",
                             True,
                         ),
-                        create_mock_nmo_pod(
-                            "node-maintenance-operator-worker-xyz789", "Pending", True
-                        ),
+                        create_mock_nmo_pod("node-maintenance-operator-worker-xyz789", "Pending", True),
                     ]
                 ),
             },
@@ -3529,9 +3365,7 @@ class TestVerifyNmoOperatorHealth(RuleTestBase):
                             "Succeeded",
                             True,
                         ),
-                        create_mock_nmo_pod(
-                            "node-maintenance-operator-worker-xyz789", "Running", False
-                        ),
+                        create_mock_nmo_pod("node-maintenance-operator-worker-xyz789", "Running", False),
                     ]
                 ),
             },
@@ -3561,9 +3395,7 @@ class TestVerifyNmoOperatorHealth(RuleTestBase):
     @pytest.mark.parametrize("scenario_params", scenario_prerequisite_not_fulfilled)
     def test_prerequisite_not_fulfilled(self, scenario_params, tested_object):
         """Test that prerequisite is not met when NMO operator is not installed."""
-        RuleTestBase.test_prerequisite_not_fulfilled(
-            self, scenario_params, tested_object
-        )
+        RuleTestBase.test_prerequisite_not_fulfilled(self, scenario_params, tested_object)
 
     @pytest.mark.parametrize("scenario_params", scenario_passed)
     def test_scenario_passed(self, scenario_params, tested_object):

--- a/tests/rules/k8s/test_k8s_validations.py
+++ b/tests/rules/k8s/test_k8s_validations.py
@@ -5,9 +5,9 @@ Adapted from HealthChecks test patterns for AllPodsReadyAndRunning.
 """
 
 import json
+from unittest.mock import Mock
 
 import pytest
-from unittest.mock import Mock
 
 from in_cluster_checks.rules.k8s.k8s_validations import (
     AllDeploymentsAvailable,
@@ -23,6 +23,7 @@ from in_cluster_checks.rules.k8s.k8s_validations import (
     VerifyAcmOperatorHealth,
     VerifyClusterOperatorsAvailable,
     VerifyFarContainerNonRoot,
+    VerifyFARControllerReplicas,
     VerifyFarOperatorHealth,
     VerifyInternalRegistry,
     VerifyNetworkDiagnosticsDisabled,
@@ -38,7 +39,9 @@ from tests.pytest_tools.test_rule_base import RuleScenarioParams, RuleTestBase
 def create_mock_pod(namespace, name, phase, ready_containers, total_containers):
     """Create a mock pod object."""
     mock_pod = Mock()
-    container_statuses = [{"ready": i < ready_containers} for i in range(total_containers)]
+    container_statuses = [
+        {"ready": i < ready_containers} for i in range(total_containers)
+    ]
     mock_pod.as_dict.return_value = {
         "metadata": {"namespace": namespace, "name": name},
         "status": {
@@ -194,7 +197,11 @@ class TestNodesCpuAndMemoryStatus:
     def test_all_nodes_normal_usage(self, tested_object):
         """Test when all nodes have normal CPU/memory usage."""
         tested_object.oc_api.run_oc_command = Mock(
-            return_value=(0, "node1    100m    5%     2000Mi   10%\nnode2    200m    10%    3000Mi   15%", "")
+            return_value=(
+                0,
+                "node1    100m    5%     2000Mi   10%\nnode2    200m    10%    3000Mi   15%",
+                "",
+            )
         )
 
         result = tested_object.run_rule()
@@ -203,7 +210,11 @@ class TestNodesCpuAndMemoryStatus:
     def test_high_cpu_usage(self, tested_object):
         """Test when some nodes have high CPU usage."""
         tested_object.oc_api.run_oc_command = Mock(
-            return_value=(0, "node1    10000m  85%    2000Mi   10%\nnode2    200m    10%    3000Mi   15%", "")
+            return_value=(
+                0,
+                "node1    10000m  85%    2000Mi   10%\nnode2    200m    10%    3000Mi   15%",
+                "",
+            )
         )
 
         result = tested_object.run_rule()
@@ -215,7 +226,11 @@ class TestNodesCpuAndMemoryStatus:
     def test_high_memory_usage(self, tested_object):
         """Test when some nodes have high memory usage."""
         tested_object.oc_api.run_oc_command = Mock(
-            return_value=(0, "node1    100m    5%     50000Mi  90%\nnode2    200m    10%    3000Mi   15%", "")
+            return_value=(
+                0,
+                "node1    100m    5%     50000Mi  90%\nnode2    200m    10%    3000Mi   15%",
+                "",
+            )
         )
 
         result = tested_object.run_rule()
@@ -226,7 +241,9 @@ class TestNodesCpuAndMemoryStatus:
 
     def test_critical_threshold_exceeded(self, tested_object):
         """Test when critical threshold is exceeded."""
-        tested_object.oc_api.run_oc_command = Mock(return_value=(0, "node1    10000m  95%    2000Mi   10%", ""))
+        tested_object.oc_api.run_oc_command = Mock(
+            return_value=(0, "node1    10000m  95%    2000Mi   10%", "")
+        )
 
         result = tested_object.run_rule()
         assert result.status == Status.FAILED
@@ -371,7 +388,9 @@ class TestValidateAllDaemonsetsScheduled:
                 },
             ]
         }
-        tested_object.oc_api.run_oc_command = Mock(return_value=(0, json.dumps(daemonsets_data), ""))
+        tested_object.oc_api.run_oc_command = Mock(
+            return_value=(0, json.dumps(daemonsets_data), "")
+        )
 
         result = tested_object.run_rule()
         assert result.status == Status.PASSED
@@ -398,7 +417,9 @@ class TestValidateAllDaemonsetsScheduled:
                 },
             ]
         }
-        tested_object.oc_api.run_oc_command = Mock(return_value=(0, json.dumps(daemonsets_data), ""))
+        tested_object.oc_api.run_oc_command = Mock(
+            return_value=(0, json.dumps(daemonsets_data), "")
+        )
 
         result = tested_object.run_rule()
         assert result.status == Status.FAILED
@@ -413,7 +434,10 @@ class TestValidateAllDaemonsetsScheduled:
         daemonsets_data = {
             "items": [
                 {
-                    "metadata": {"name": "vg-manager", "namespace": "openshift-storage"},
+                    "metadata": {
+                        "name": "vg-manager",
+                        "namespace": "openshift-storage",
+                    },
                     "status": {
                         "desiredNumberScheduled": 0,
                         "currentNumberScheduled": 0,
@@ -430,7 +454,9 @@ class TestValidateAllDaemonsetsScheduled:
                 },
             ]
         }
-        tested_object.oc_api.run_oc_command = Mock(return_value=(0, json.dumps(daemonsets_data), ""))
+        tested_object.oc_api.run_oc_command = Mock(
+            return_value=(0, json.dumps(daemonsets_data), "")
+        )
 
         result = tested_object.run_rule()
         assert result.status == Status.PASSED
@@ -440,7 +466,10 @@ class TestValidateAllDaemonsetsScheduled:
         daemonsets_data = {
             "items": [
                 {
-                    "metadata": {"name": "vg-manager", "namespace": "openshift-storage"},
+                    "metadata": {
+                        "name": "vg-manager",
+                        "namespace": "openshift-storage",
+                    },
                     "status": {
                         "desiredNumberScheduled": 1,
                         "currentNumberScheduled": 1,
@@ -449,7 +478,9 @@ class TestValidateAllDaemonsetsScheduled:
                 },
             ]
         }
-        tested_object.oc_api.run_oc_command = Mock(return_value=(0, json.dumps(daemonsets_data), ""))
+        tested_object.oc_api.run_oc_command = Mock(
+            return_value=(0, json.dumps(daemonsets_data), "")
+        )
 
         result = tested_object.run_rule()
         assert result.status == Status.PASSED
@@ -468,7 +499,9 @@ class TestValidateAllDaemonsetsScheduled:
                 },
             ]
         }
-        tested_object.oc_api.run_oc_command = Mock(return_value=(0, json.dumps(daemonsets_data), ""))
+        tested_object.oc_api.run_oc_command = Mock(
+            return_value=(0, json.dumps(daemonsets_data), "")
+        )
 
         result = tested_object.run_rule()
         assert result.status == Status.FAILED
@@ -492,7 +525,9 @@ baremetal                                  4.15.29    True        False         
 cloud-controller-manager                   4.15.29    True        False         False      14d
 cluster-autoscaler                         4.15.29    True        False         False      14d"""
 
-        tested_object.oc_api.run_oc_command = Mock(return_value=(0, operator_output, ""))
+        tested_object.oc_api.run_oc_command = Mock(
+            return_value=(0, operator_output, "")
+        )
 
         result = tested_object.run_rule()
         assert result.status == Status.INFO
@@ -516,7 +551,9 @@ cluster-autoscaler                         4.15.29    True        False         
 baremetal                                  4.15.29    False       False         False      14d     Operator is degraded
 cloud-controller-manager                   4.15.29    True        False         False      14d"""
 
-        tested_object.oc_api.run_oc_command = Mock(return_value=(0, operator_output, ""))
+        tested_object.oc_api.run_oc_command = Mock(
+            return_value=(0, operator_output, "")
+        )
 
         result = tested_object.run_rule()
         assert result.status == Status.FAILED
@@ -531,7 +568,9 @@ cloud-controller-manager                   4.15.29    True        False         
 baremetal                                  4.15.29    True        True          False      14d     Rolling out new pods
 cloud-controller-manager                   4.15.29    True        False         False      14d"""
 
-        tested_object.oc_api.run_oc_command = Mock(return_value=(0, operator_output, ""))
+        tested_object.oc_api.run_oc_command = Mock(
+            return_value=(0, operator_output, "")
+        )
 
         result = tested_object.run_rule()
         assert result.status == Status.FAILED
@@ -546,7 +585,9 @@ cloud-controller-manager                   4.15.29    True        False         
 baremetal                                  4.15.29    True        True          False      14d     Rolling out
 cloud-controller-manager                   4.15.29    True        False         False      14d"""
 
-        tested_object.oc_api.run_oc_command = Mock(return_value=(0, operator_output, ""))
+        tested_object.oc_api.run_oc_command = Mock(
+            return_value=(0, operator_output, "")
+        )
 
         result = tested_object.run_rule()
         assert result.status == Status.FAILED
@@ -572,7 +613,9 @@ bad-operator                               4.15.29    False       False         
 progressing-operator                       4.15.29    True        True          False      14d     Working
 another-good-operator                      4.15.29    True        False         False      14d"""
 
-        tested_object.oc_api.run_oc_command = Mock(return_value=(0, operator_output, ""))
+        tested_object.oc_api.run_oc_command = Mock(
+            return_value=(0, operator_output, "")
+        )
 
         result = tested_object.run_rule()
         assert result.status == Status.FAILED
@@ -685,7 +728,9 @@ class TestAllDeploymentsAvailable(RuleTestBase):
         ),
         RuleScenarioParams(
             "no deployments found in cluster",
-            tested_object_mock_dict={"oc_api.get_all_deployments": Mock(return_value=[])},
+            tested_object_mock_dict={
+                "oc_api.get_all_deployments": Mock(return_value=[])
+            },
             failed_msg="No deployments found in cluster",
         ),
         RuleScenarioParams(
@@ -923,7 +968,9 @@ class TestCheckDeploymentsReplicaStatus(RuleTestBase):
         ),
         RuleScenarioParams(
             "no deployments found in cluster",
-            tested_object_mock_dict={"oc_api.get_all_deployments": Mock(return_value=[])},
+            tested_object_mock_dict={
+                "oc_api.get_all_deployments": Mock(return_value=[])
+            },
             failed_msg="No deployments found in cluster",
         ),
     ]
@@ -987,7 +1034,8 @@ class TestAllStatefulsetsReady(RuleTestBase):
                     ]
                 )
             },
-            failed_msg="Following statefulsets are not ready:\n" "  kube-system/statefulset2 - Desired: 3, Ready: 1",
+            failed_msg="Following statefulsets are not ready:\n"
+            "  kube-system/statefulset2 - Desired: 3, Ready: 1",
         ),
         RuleScenarioParams(
             "statefulset has zero ready replicas",
@@ -1003,7 +1051,8 @@ class TestAllStatefulsetsReady(RuleTestBase):
                     ]
                 )
             },
-            failed_msg="Following statefulsets are not ready:\n" "  default/statefulset1 - Desired: 3, Ready: 0",
+            failed_msg="Following statefulsets are not ready:\n"
+            "  default/statefulset1 - Desired: 3, Ready: 0",
         ),
         RuleScenarioParams(
             "statefulsets in mixed states",
@@ -1040,7 +1089,9 @@ class TestAllStatefulsetsReady(RuleTestBase):
     scenario_warning = [
         RuleScenarioParams(
             "no statefulsets found in cluster",
-            tested_object_mock_dict={"oc_api.get_all_statefulsets": Mock(return_value=[])},
+            tested_object_mock_dict={
+                "oc_api.get_all_statefulsets": Mock(return_value=[])
+            },
             failed_msg="No statefulsets found in cluster",
         ),
     ]
@@ -1063,7 +1114,15 @@ class TestValidateAllPoliciesCompliant(RuleTestBase):
 
     tested_type = ValidateAllPoliciesCompliant
 
-    _POLICIES_CMD_KEY = ("get", ("policies.policy.open-cluster-management.io", "--all-namespaces", "-o", "json"))
+    _POLICIES_CMD_KEY = (
+        "get",
+        (
+            "policies.policy.open-cluster-management.io",
+            "--all-namespaces",
+            "-o",
+            "json",
+        ),
+    )
 
     all_compliant_policies = {
         "items": [
@@ -1137,7 +1196,9 @@ class TestValidateAllPoliciesCompliant(RuleTestBase):
 
     @pytest.mark.parametrize("scenario_params", scenario_prerequisite_not_fulfilled)
     def test_prerequisite_not_fulfilled(self, scenario_params, tested_object):
-        RuleTestBase.test_prerequisite_not_fulfilled(self, scenario_params, tested_object)
+        RuleTestBase.test_prerequisite_not_fulfilled(
+            self, scenario_params, tested_object
+        )
 
 
 def create_mock_registry_pod(name, namespace, phase, all_containers_ready=True):
@@ -1191,11 +1252,23 @@ class TestVerifyInternalRegistry(RuleTestBase):
         RuleScenarioParams(
             "registry is managed and pods are running",
             tested_object_mock_dict={
-                "oc_api.run_oc_command": Mock(return_value=(0, json.dumps(registry_config_managed), "")),
+                "oc_api.run_oc_command": Mock(
+                    return_value=(0, json.dumps(registry_config_managed), "")
+                ),
                 "oc_api.get_all_pods": Mock(
                     return_value=[
-                        create_mock_registry_pod("image-registry-1", "openshift-image-registry", "Running", True),
-                        create_mock_registry_pod("image-registry-2", "openshift-image-registry", "Running", True),
+                        create_mock_registry_pod(
+                            "image-registry-1",
+                            "openshift-image-registry",
+                            "Running",
+                            True,
+                        ),
+                        create_mock_registry_pod(
+                            "image-registry-2",
+                            "openshift-image-registry",
+                            "Running",
+                            True,
+                        ),
                     ]
                 ),
             },
@@ -1203,10 +1276,17 @@ class TestVerifyInternalRegistry(RuleTestBase):
         RuleScenarioParams(
             "registry is managed with one running pod",
             tested_object_mock_dict={
-                "oc_api.run_oc_command": Mock(return_value=(0, json.dumps(registry_config_managed), "")),
+                "oc_api.run_oc_command": Mock(
+                    return_value=(0, json.dumps(registry_config_managed), "")
+                ),
                 "oc_api.get_all_pods": Mock(
                     return_value=[
-                        create_mock_registry_pod("image-registry-1", "openshift-image-registry", "Running", True),
+                        create_mock_registry_pod(
+                            "image-registry-1",
+                            "openshift-image-registry",
+                            "Running",
+                            True,
+                        ),
                     ]
                 ),
             },
@@ -1217,13 +1297,17 @@ class TestVerifyInternalRegistry(RuleTestBase):
         RuleScenarioParams(
             "registry is not in Managed state (Removed)",
             tested_object_mock_dict={
-                "oc_api.run_oc_command": Mock(return_value=(0, json.dumps(registry_config_removed), "")),
+                "oc_api.run_oc_command": Mock(
+                    return_value=(0, json.dumps(registry_config_removed), "")
+                ),
             },
         ),
         RuleScenarioParams(
             "registry is not in Managed state (Unmanaged)",
             tested_object_mock_dict={
-                "oc_api.run_oc_command": Mock(return_value=(0, json.dumps(registry_config_unmanaged), "")),
+                "oc_api.run_oc_command": Mock(
+                    return_value=(0, json.dumps(registry_config_unmanaged), "")
+                ),
             },
         ),
     ]
@@ -1232,7 +1316,9 @@ class TestVerifyInternalRegistry(RuleTestBase):
         RuleScenarioParams(
             "registry is managed but no pods found",
             tested_object_mock_dict={
-                "oc_api.run_oc_command": Mock(return_value=(0, json.dumps(registry_config_managed), "")),
+                "oc_api.run_oc_command": Mock(
+                    return_value=(0, json.dumps(registry_config_managed), "")
+                ),
                 "oc_api.get_all_pods": Mock(return_value=[]),
             },
             failed_msg="Image registry is Managed but no registry pods found in openshift-image-registry namespace.\n",
@@ -1240,10 +1326,17 @@ class TestVerifyInternalRegistry(RuleTestBase):
         RuleScenarioParams(
             "registry is managed but pods are not running",
             tested_object_mock_dict={
-                "oc_api.run_oc_command": Mock(return_value=(0, json.dumps(registry_config_managed), "")),
+                "oc_api.run_oc_command": Mock(
+                    return_value=(0, json.dumps(registry_config_managed), "")
+                ),
                 "oc_api.get_all_pods": Mock(
                     return_value=[
-                        create_mock_registry_pod("image-registry-1", "openshift-image-registry", "Pending", True),
+                        create_mock_registry_pod(
+                            "image-registry-1",
+                            "openshift-image-registry",
+                            "Pending",
+                            True,
+                        ),
                     ]
                 ),
             },
@@ -1253,10 +1346,17 @@ class TestVerifyInternalRegistry(RuleTestBase):
         RuleScenarioParams(
             "registry is managed but pods running with containers not ready",
             tested_object_mock_dict={
-                "oc_api.run_oc_command": Mock(return_value=(0, json.dumps(registry_config_managed), "")),
+                "oc_api.run_oc_command": Mock(
+                    return_value=(0, json.dumps(registry_config_managed), "")
+                ),
                 "oc_api.get_all_pods": Mock(
                     return_value=[
-                        create_mock_registry_pod("image-registry-1", "openshift-image-registry", "Running", False),
+                        create_mock_registry_pod(
+                            "image-registry-1",
+                            "openshift-image-registry",
+                            "Running",
+                            False,
+                        ),
                     ]
                 ),
             },
@@ -1267,7 +1367,9 @@ class TestVerifyInternalRegistry(RuleTestBase):
 
     @pytest.mark.parametrize("scenario_params", scenario_prerequisite_not_fulfilled)
     def test_prerequisite_not_fulfilled(self, scenario_params, tested_object):
-        RuleTestBase.test_prerequisite_not_fulfilled(self, scenario_params, tested_object)
+        RuleTestBase.test_prerequisite_not_fulfilled(
+            self, scenario_params, tested_object
+        )
 
     @pytest.mark.parametrize("scenario_params", scenario_passed)
     def test_scenario_passed(self, scenario_params, tested_object):
@@ -1460,7 +1562,9 @@ class TestVerifyClusterOperatorsAvailable(RuleTestBase):
         RuleScenarioParams(
             "no cluster operators found in cluster",
             oc_cmd_output_dict={
-                ("get", ("clusteroperators", "-o", "json")): CmdOutput(json.dumps({"items": []})),
+                ("get", ("clusteroperators", "-o", "json")): CmdOutput(
+                    json.dumps({"items": []})
+                ),
             },
             failed_msg="No cluster operators found in cluster",
         ),
@@ -1577,14 +1681,18 @@ class TestVerifyWebConsoleDisabled(RuleTestBase):
         RuleScenarioParams(
             "console is disabled (Removed) and no pods in openshift-console namespace",
             tested_object_mock_dict={
-                "oc_api.run_oc_command": Mock(return_value=(0, json.dumps(_console_config("Removed")), "")),
+                "oc_api.run_oc_command": Mock(
+                    return_value=(0, json.dumps(_console_config("Removed")), "")
+                ),
                 "oc_api.get_all_pods": Mock(return_value=[]),
             },
         ),
         RuleScenarioParams(
             "console is disabled (Unmanaged) and no pods in openshift-console namespace",
             tested_object_mock_dict={
-                "oc_api.run_oc_command": Mock(return_value=(0, json.dumps(_console_config("Unmanaged")), "")),
+                "oc_api.run_oc_command": Mock(
+                    return_value=(0, json.dumps(_console_config("Unmanaged")), "")
+                ),
                 "oc_api.get_all_pods": Mock(return_value=[]),
             },
         ),
@@ -1594,13 +1702,17 @@ class TestVerifyWebConsoleDisabled(RuleTestBase):
         RuleScenarioParams(
             "console operator is Managed (web console enabled)",
             tested_object_mock_dict={
-                "oc_api.run_oc_command": Mock(return_value=(0, json.dumps(_console_config("Managed")), "")),
+                "oc_api.run_oc_command": Mock(
+                    return_value=(0, json.dumps(_console_config("Managed")), "")
+                ),
             },
         ),
         RuleScenarioParams(
             "console operator managementState is missing",
             tested_object_mock_dict={
-                "oc_api.run_oc_command": Mock(return_value=(0, json.dumps(_console_config()), "")),
+                "oc_api.run_oc_command": Mock(
+                    return_value=(0, json.dumps(_console_config()), "")
+                ),
             },
         ),
     ]
@@ -1609,7 +1721,9 @@ class TestVerifyWebConsoleDisabled(RuleTestBase):
         RuleScenarioParams(
             "console is disabled but pods still exist in openshift-console namespace",
             tested_object_mock_dict={
-                "oc_api.run_oc_command": Mock(return_value=(0, json.dumps(_console_config("Removed")), "")),
+                "oc_api.run_oc_command": Mock(
+                    return_value=(0, json.dumps(_console_config("Removed")), "")
+                ),
                 "oc_api.get_all_pods": Mock(
                     return_value=[
                         create_mock_console_pod("console-7b4f8c6d9-abc12"),
@@ -1626,7 +1740,9 @@ class TestVerifyWebConsoleDisabled(RuleTestBase):
 
     @pytest.mark.parametrize("scenario_params", scenario_prerequisite_not_fulfilled)
     def test_prerequisite_not_fulfilled(self, scenario_params, tested_object):
-        RuleTestBase.test_prerequisite_not_fulfilled(self, scenario_params, tested_object)
+        RuleTestBase.test_prerequisite_not_fulfilled(
+            self, scenario_params, tested_object
+        )
 
     @pytest.mark.parametrize("scenario_params", scenario_passed)
     def test_scenario_passed(self, scenario_params, tested_object):
@@ -1652,7 +1768,11 @@ def create_mock_network_diagnostics_pod(name):
 
 def _network_config(disable_diagnostics=None):
     """Build a network operator config with the given disableNetworkDiagnostics value."""
-    spec = {"disableNetworkDiagnostics": disable_diagnostics} if disable_diagnostics is not None else {}
+    spec = (
+        {"disableNetworkDiagnostics": disable_diagnostics}
+        if disable_diagnostics is not None
+        else {}
+    )
     return {"spec": spec, "status": {}}
 
 
@@ -1668,9 +1788,10 @@ class TestVerifyNetworkDiagnosticsDisabled(RuleTestBase):
                 "oc_api.get_all_pods": Mock(return_value=[]),
             },
             oc_cmd_output_dict={
-                ("get", ("network.operator.openshift.io", "cluster", "-o", "json")): CmdOutput(
-                    json.dumps(_network_config(True))
-                ),
+                (
+                    "get",
+                    ("network.operator.openshift.io", "cluster", "-o", "json"),
+                ): CmdOutput(json.dumps(_network_config(True))),
             },
         ),
     ]
@@ -1679,17 +1800,19 @@ class TestVerifyNetworkDiagnosticsDisabled(RuleTestBase):
         RuleScenarioParams(
             "network diagnostics is not disabled (disableNetworkDiagnostics is false)",
             oc_cmd_output_dict={
-                ("get", ("network.operator.openshift.io", "cluster", "-o", "json")): CmdOutput(
-                    json.dumps(_network_config(False))
-                ),
+                (
+                    "get",
+                    ("network.operator.openshift.io", "cluster", "-o", "json"),
+                ): CmdOutput(json.dumps(_network_config(False))),
             },
         ),
         RuleScenarioParams(
             "network operator disableNetworkDiagnostics is missing",
             oc_cmd_output_dict={
-                ("get", ("network.operator.openshift.io", "cluster", "-o", "json")): CmdOutput(
-                    json.dumps(_network_config())
-                ),
+                (
+                    "get",
+                    ("network.operator.openshift.io", "cluster", "-o", "json"),
+                ): CmdOutput(json.dumps(_network_config())),
             },
         ),
     ]
@@ -1700,15 +1823,20 @@ class TestVerifyNetworkDiagnosticsDisabled(RuleTestBase):
             tested_object_mock_dict={
                 "oc_api.get_all_pods": Mock(
                     return_value=[
-                        create_mock_network_diagnostics_pod("network-check-source-7b4f8c6d9-abc12"),
-                        create_mock_network_diagnostics_pod("network-check-target-xyz34"),
+                        create_mock_network_diagnostics_pod(
+                            "network-check-source-7b4f8c6d9-abc12"
+                        ),
+                        create_mock_network_diagnostics_pod(
+                            "network-check-target-xyz34"
+                        ),
                     ]
                 ),
             },
             oc_cmd_output_dict={
-                ("get", ("network.operator.openshift.io", "cluster", "-o", "json")): CmdOutput(
-                    json.dumps(_network_config(True))
-                ),
+                (
+                    "get",
+                    ("network.operator.openshift.io", "cluster", "-o", "json"),
+                ): CmdOutput(json.dumps(_network_config(True))),
             },
             failed_msg="Found 2 pod(s) in openshift-network-diagnostics namespace "
             "but network diagnostics should be disabled:\n"
@@ -1720,7 +1848,9 @@ class TestVerifyNetworkDiagnosticsDisabled(RuleTestBase):
     @pytest.mark.parametrize("scenario_params", scenario_prerequisite_not_fulfilled)
     def test_prerequisite_not_fulfilled(self, scenario_params, tested_object):
         """Test prerequisite not fulfilled scenarios."""
-        RuleTestBase.test_prerequisite_not_fulfilled(self, scenario_params, tested_object)
+        RuleTestBase.test_prerequisite_not_fulfilled(
+            self, scenario_params, tested_object
+        )
 
     @pytest.mark.parametrize("scenario_params", scenario_passed)
     def test_scenario_passed(self, scenario_params, tested_object):
@@ -1779,15 +1909,23 @@ class TestVerifyNfdOperatorHealth(RuleTestBase):
             tested_object_mock_dict={
                 "oc_api.get_all_pods": Mock(
                     return_value=[
-                        create_mock_nfd_pod("nfd-controller-manager-abc123", "Running", True),
+                        create_mock_nfd_pod(
+                            "nfd-controller-manager-abc123", "Running", True
+                        ),
                         create_mock_nfd_pod("nfd-worker-xyz789", "Running", True),
                     ]
                 ),
             },
             oc_cmd_output_dict={
-                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
-                    json.dumps(_nfd_subscriptions(include_nfd=True))
-                ),
+                (
+                    "get",
+                    (
+                        "subscriptions.operators.coreos.com",
+                        "--all-namespaces",
+                        "-o",
+                        "json",
+                    ),
+                ): CmdOutput(json.dumps(_nfd_subscriptions(include_nfd=True))),
             },
         ),
     ]
@@ -1796,17 +1934,29 @@ class TestVerifyNfdOperatorHealth(RuleTestBase):
         RuleScenarioParams(
             "NFD operator subscription not found",
             oc_cmd_output_dict={
-                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
-                    json.dumps(_nfd_subscriptions(include_nfd=False))
-                ),
+                (
+                    "get",
+                    (
+                        "subscriptions.operators.coreos.com",
+                        "--all-namespaces",
+                        "-o",
+                        "json",
+                    ),
+                ): CmdOutput(json.dumps(_nfd_subscriptions(include_nfd=False))),
             },
         ),
         RuleScenarioParams(
             "no subscriptions exist in cluster",
             oc_cmd_output_dict={
-                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
-                    json.dumps({"items": []})
-                ),
+                (
+                    "get",
+                    (
+                        "subscriptions.operators.coreos.com",
+                        "--all-namespaces",
+                        "-o",
+                        "json",
+                    ),
+                ): CmdOutput(json.dumps({"items": []})),
             },
         ),
     ]
@@ -1818,9 +1968,15 @@ class TestVerifyNfdOperatorHealth(RuleTestBase):
                 "oc_api.get_all_pods": Mock(return_value=[]),
             },
             oc_cmd_output_dict={
-                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
-                    json.dumps(_nfd_subscriptions(include_nfd=True))
-                ),
+                (
+                    "get",
+                    (
+                        "subscriptions.operators.coreos.com",
+                        "--all-namespaces",
+                        "-o",
+                        "json",
+                    ),
+                ): CmdOutput(json.dumps(_nfd_subscriptions(include_nfd=True))),
             },
             failed_msg="No pods found in openshift-nfd namespace. NFD operator may not be fully deployed.",
         ),
@@ -1829,15 +1985,23 @@ class TestVerifyNfdOperatorHealth(RuleTestBase):
             tested_object_mock_dict={
                 "oc_api.get_all_pods": Mock(
                     return_value=[
-                        create_mock_nfd_pod("nfd-controller-manager-abc123", "Running", True),
+                        create_mock_nfd_pod(
+                            "nfd-controller-manager-abc123", "Running", True
+                        ),
                         create_mock_nfd_pod("nfd-worker-xyz789", "Pending", True),
                     ]
                 ),
             },
             oc_cmd_output_dict={
-                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
-                    json.dumps(_nfd_subscriptions(include_nfd=True))
-                ),
+                (
+                    "get",
+                    (
+                        "subscriptions.operators.coreos.com",
+                        "--all-namespaces",
+                        "-o",
+                        "json",
+                    ),
+                ): CmdOutput(json.dumps(_nfd_subscriptions(include_nfd=True))),
             },
             failed_msg="NFD operator has unhealthy pods in openshift-nfd namespace:\n"
             "  nfd-worker-xyz789 - Phase: Pending",
@@ -1847,14 +2011,22 @@ class TestVerifyNfdOperatorHealth(RuleTestBase):
             tested_object_mock_dict={
                 "oc_api.get_all_pods": Mock(
                     return_value=[
-                        create_mock_nfd_pod("nfd-controller-manager-abc123", "Running", False),
+                        create_mock_nfd_pod(
+                            "nfd-controller-manager-abc123", "Running", False
+                        ),
                     ]
                 ),
             },
             oc_cmd_output_dict={
-                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
-                    json.dumps(_nfd_subscriptions(include_nfd=True))
-                ),
+                (
+                    "get",
+                    (
+                        "subscriptions.operators.coreos.com",
+                        "--all-namespaces",
+                        "-o",
+                        "json",
+                    ),
+                ): CmdOutput(json.dumps(_nfd_subscriptions(include_nfd=True))),
             },
             failed_msg="NFD operator has unhealthy pods in openshift-nfd namespace:\n"
             "  nfd-controller-manager-abc123 - Running, Not all containers ready",
@@ -1864,14 +2036,22 @@ class TestVerifyNfdOperatorHealth(RuleTestBase):
             tested_object_mock_dict={
                 "oc_api.get_all_pods": Mock(
                     return_value=[
-                        create_mock_nfd_pod("nfd-controller-manager-abc123", "Succeeded", True),
+                        create_mock_nfd_pod(
+                            "nfd-controller-manager-abc123", "Succeeded", True
+                        ),
                     ]
                 ),
             },
             oc_cmd_output_dict={
-                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
-                    json.dumps(_nfd_subscriptions(include_nfd=True))
-                ),
+                (
+                    "get",
+                    (
+                        "subscriptions.operators.coreos.com",
+                        "--all-namespaces",
+                        "-o",
+                        "json",
+                    ),
+                ): CmdOutput(json.dumps(_nfd_subscriptions(include_nfd=True))),
             },
             failed_msg="Failed to evaluate status for NFD pod(s):\n  nfd-controller-manager-abc123",
         ),
@@ -1880,7 +2060,9 @@ class TestVerifyNfdOperatorHealth(RuleTestBase):
     @pytest.mark.parametrize("scenario_params", scenario_prerequisite_not_fulfilled)
     def test_prerequisite_not_fulfilled(self, scenario_params, tested_object):
         """Test that prerequisite is not met when NFD operator is not installed."""
-        RuleTestBase.test_prerequisite_not_fulfilled(self, scenario_params, tested_object)
+        RuleTestBase.test_prerequisite_not_fulfilled(
+            self, scenario_params, tested_object
+        )
 
     @pytest.mark.parametrize("scenario_params", scenario_passed)
     def test_scenario_passed(self, scenario_params, tested_object):
@@ -1909,13 +2091,18 @@ def create_mock_acm_pod(name, phase, all_containers_ready=True):
     return mock_pod
 
 
-def _acm_subscriptions(include_acm=True, installed_csv="advanced-cluster-management.v2.12.0"):
+def _acm_subscriptions(
+    include_acm=True, installed_csv="advanced-cluster-management.v2.12.0"
+):
     """Build a subscriptions response, optionally including the ACM subscription."""
     items = []
     if include_acm:
         sub = {
             "metadata": {"name": "acm-sub", "namespace": "open-cluster-management"},
-            "spec": {"name": "advanced-cluster-management", "source": "redhat-operators"},
+            "spec": {
+                "name": "advanced-cluster-management",
+                "source": "redhat-operators",
+            },
         }
         if installed_csv:
             sub["status"] = {"installedCSV": installed_csv}
@@ -1934,7 +2121,11 @@ def _acm_csv_response(include_csv=True, phase="Succeeded"):
     items = []
     if include_csv:
         reason = "InstallSucceeded" if phase == "Succeeded" else "InstallFailed"
-        message = "install strategy completed with no errors" if phase == "Succeeded" else "install failed"
+        message = (
+            "install strategy completed with no errors"
+            if phase == "Succeeded"
+            else "install failed"
+        )
         items.append(
             {
                 "metadata": {
@@ -1951,7 +2142,10 @@ def _acm_csv_response(include_csv=True, phase="Succeeded"):
     return {"items": items}
 
 
-_ACM_SUB_CMD = ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json"))
+_ACM_SUB_CMD = (
+    "get",
+    ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json"),
+)
 _ACM_CSV_CMD = ("get", ("csv", "-n", "open-cluster-management", "-o", "json"))
 
 
@@ -1964,7 +2158,9 @@ class TestVerifyAcmOperatorHealth(RuleTestBase):
         RuleScenarioParams(
             "ACM operator subscription found",
             oc_cmd_output_dict={
-                _ACM_SUB_CMD: CmdOutput(json.dumps(_acm_subscriptions(include_acm=True))),
+                _ACM_SUB_CMD: CmdOutput(
+                    json.dumps(_acm_subscriptions(include_acm=True))
+                ),
             },
         ),
     ]
@@ -1975,13 +2171,17 @@ class TestVerifyAcmOperatorHealth(RuleTestBase):
             tested_object_mock_dict={
                 "oc_api.get_all_pods": Mock(
                     return_value=[
-                        create_mock_acm_pod("multiclusterhub-operator-abc123", "Running", True),
+                        create_mock_acm_pod(
+                            "multiclusterhub-operator-abc123", "Running", True
+                        ),
                         create_mock_acm_pod("cluster-manager-xyz789", "Running", True),
                     ]
                 ),
             },
             oc_cmd_output_dict={
-                _ACM_SUB_CMD: CmdOutput(json.dumps(_acm_subscriptions(include_acm=True))),
+                _ACM_SUB_CMD: CmdOutput(
+                    json.dumps(_acm_subscriptions(include_acm=True))
+                ),
                 _ACM_CSV_CMD: CmdOutput(json.dumps(_acm_csv_response())),
             },
         ),
@@ -1990,12 +2190,16 @@ class TestVerifyAcmOperatorHealth(RuleTestBase):
             tested_object_mock_dict={
                 "oc_api.get_all_pods": Mock(
                     return_value=[
-                        create_mock_acm_pod("multiclusterhub-operator-abc123", "Running", True),
+                        create_mock_acm_pod(
+                            "multiclusterhub-operator-abc123", "Running", True
+                        ),
                     ]
                 ),
             },
             oc_cmd_output_dict={
-                _ACM_SUB_CMD: CmdOutput(json.dumps(_acm_subscriptions(include_acm=True, installed_csv=None))),
+                _ACM_SUB_CMD: CmdOutput(
+                    json.dumps(_acm_subscriptions(include_acm=True, installed_csv=None))
+                ),
                 _ACM_CSV_CMD: CmdOutput(json.dumps(_acm_csv_response())),
             },
         ),
@@ -2005,7 +2209,9 @@ class TestVerifyAcmOperatorHealth(RuleTestBase):
         RuleScenarioParams(
             "ACM operator subscription not found",
             oc_cmd_output_dict={
-                _ACM_SUB_CMD: CmdOutput(json.dumps(_acm_subscriptions(include_acm=False))),
+                _ACM_SUB_CMD: CmdOutput(
+                    json.dumps(_acm_subscriptions(include_acm=False))
+                ),
             },
         ),
         RuleScenarioParams(
@@ -2022,13 +2228,19 @@ class TestVerifyAcmOperatorHealth(RuleTestBase):
             tested_object_mock_dict={
                 "oc_api.get_all_pods": Mock(
                     return_value=[
-                        create_mock_acm_pod("multiclusterhub-operator-abc123", "Running", True),
+                        create_mock_acm_pod(
+                            "multiclusterhub-operator-abc123", "Running", True
+                        ),
                     ]
                 ),
             },
             oc_cmd_output_dict={
-                _ACM_SUB_CMD: CmdOutput(json.dumps(_acm_subscriptions(include_acm=True))),
-                _ACM_CSV_CMD: CmdOutput(json.dumps(_acm_csv_response(include_csv=False))),
+                _ACM_SUB_CMD: CmdOutput(
+                    json.dumps(_acm_subscriptions(include_acm=True))
+                ),
+                _ACM_CSV_CMD: CmdOutput(
+                    json.dumps(_acm_csv_response(include_csv=False))
+                ),
             },
             failed_msg=(
                 "No ClusterServiceVersion matching 'advanced-cluster-management' "
@@ -2040,12 +2252,16 @@ class TestVerifyAcmOperatorHealth(RuleTestBase):
             tested_object_mock_dict={
                 "oc_api.get_all_pods": Mock(
                     return_value=[
-                        create_mock_acm_pod("multiclusterhub-operator-abc123", "Running", True),
+                        create_mock_acm_pod(
+                            "multiclusterhub-operator-abc123", "Running", True
+                        ),
                     ]
                 ),
             },
             oc_cmd_output_dict={
-                _ACM_SUB_CMD: CmdOutput(json.dumps(_acm_subscriptions(include_acm=True))),
+                _ACM_SUB_CMD: CmdOutput(
+                    json.dumps(_acm_subscriptions(include_acm=True))
+                ),
                 _ACM_CSV_CMD: CmdOutput(json.dumps(_acm_csv_response(phase="Failed"))),
             },
             failed_msg=(
@@ -2059,7 +2275,9 @@ class TestVerifyAcmOperatorHealth(RuleTestBase):
                 "oc_api.get_all_pods": Mock(return_value=[]),
             },
             oc_cmd_output_dict={
-                _ACM_SUB_CMD: CmdOutput(json.dumps(_acm_subscriptions(include_acm=True))),
+                _ACM_SUB_CMD: CmdOutput(
+                    json.dumps(_acm_subscriptions(include_acm=True))
+                ),
                 _ACM_CSV_CMD: CmdOutput(json.dumps(_acm_csv_response())),
             },
             failed_msg="No pods found in open-cluster-management namespace. ACM operator may not be fully deployed.",
@@ -2069,13 +2287,17 @@ class TestVerifyAcmOperatorHealth(RuleTestBase):
             tested_object_mock_dict={
                 "oc_api.get_all_pods": Mock(
                     return_value=[
-                        create_mock_acm_pod("multiclusterhub-operator-abc123", "Running", True),
+                        create_mock_acm_pod(
+                            "multiclusterhub-operator-abc123", "Running", True
+                        ),
                         create_mock_acm_pod("cluster-manager-xyz789", "Pending", True),
                     ]
                 ),
             },
             oc_cmd_output_dict={
-                _ACM_SUB_CMD: CmdOutput(json.dumps(_acm_subscriptions(include_acm=True))),
+                _ACM_SUB_CMD: CmdOutput(
+                    json.dumps(_acm_subscriptions(include_acm=True))
+                ),
                 _ACM_CSV_CMD: CmdOutput(json.dumps(_acm_csv_response())),
             },
             failed_msg=(
@@ -2088,12 +2310,16 @@ class TestVerifyAcmOperatorHealth(RuleTestBase):
             tested_object_mock_dict={
                 "oc_api.get_all_pods": Mock(
                     return_value=[
-                        create_mock_acm_pod("multiclusterhub-operator-abc123", "Running", False),
+                        create_mock_acm_pod(
+                            "multiclusterhub-operator-abc123", "Running", False
+                        ),
                     ]
                 ),
             },
             oc_cmd_output_dict={
-                _ACM_SUB_CMD: CmdOutput(json.dumps(_acm_subscriptions(include_acm=True))),
+                _ACM_SUB_CMD: CmdOutput(
+                    json.dumps(_acm_subscriptions(include_acm=True))
+                ),
                 _ACM_CSV_CMD: CmdOutput(json.dumps(_acm_csv_response())),
             },
             failed_msg=(
@@ -2106,12 +2332,16 @@ class TestVerifyAcmOperatorHealth(RuleTestBase):
             tested_object_mock_dict={
                 "oc_api.get_all_pods": Mock(
                     return_value=[
-                        create_mock_acm_pod("multiclusterhub-operator-abc123", "Succeeded", True),
+                        create_mock_acm_pod(
+                            "multiclusterhub-operator-abc123", "Succeeded", True
+                        ),
                     ]
                 ),
             },
             oc_cmd_output_dict={
-                _ACM_SUB_CMD: CmdOutput(json.dumps(_acm_subscriptions(include_acm=True))),
+                _ACM_SUB_CMD: CmdOutput(
+                    json.dumps(_acm_subscriptions(include_acm=True))
+                ),
                 _ACM_CSV_CMD: CmdOutput(json.dumps(_acm_csv_response())),
             },
             failed_msg="Failed to evaluate status for ACM pod(s):\n  multiclusterhub-operator-abc123",
@@ -2127,7 +2357,9 @@ class TestVerifyAcmOperatorHealth(RuleTestBase):
                 ),
             },
             oc_cmd_output_dict={
-                _ACM_SUB_CMD: CmdOutput(json.dumps(_acm_subscriptions(include_acm=True))),
+                _ACM_SUB_CMD: CmdOutput(
+                    json.dumps(_acm_subscriptions(include_acm=True))
+                ),
                 _ACM_CSV_CMD: CmdOutput(json.dumps(_acm_csv_response())),
             },
             failed_msg=(
@@ -2142,12 +2374,16 @@ class TestVerifyAcmOperatorHealth(RuleTestBase):
             tested_object_mock_dict={
                 "oc_api.get_all_pods": Mock(
                     return_value=[
-                        create_mock_acm_pod("multiclusterhub-operator-abc123", "Pending", True),
+                        create_mock_acm_pod(
+                            "multiclusterhub-operator-abc123", "Pending", True
+                        ),
                     ]
                 ),
             },
             oc_cmd_output_dict={
-                _ACM_SUB_CMD: CmdOutput(json.dumps(_acm_subscriptions(include_acm=True))),
+                _ACM_SUB_CMD: CmdOutput(
+                    json.dumps(_acm_subscriptions(include_acm=True))
+                ),
                 _ACM_CSV_CMD: CmdOutput(json.dumps(_acm_csv_response(phase="Failed"))),
             },
             failed_msg=(
@@ -2168,7 +2404,9 @@ class TestVerifyAcmOperatorHealth(RuleTestBase):
     @pytest.mark.parametrize("scenario_params", scenario_prerequisite_not_fulfilled)
     def test_prerequisite_not_fulfilled(self, scenario_params, tested_object):
         """Test that prerequisite is not met when ACM operator is not installed."""
-        RuleTestBase.test_prerequisite_not_fulfilled(self, scenario_params, tested_object)
+        RuleTestBase.test_prerequisite_not_fulfilled(
+            self, scenario_params, tested_object
+        )
 
     @pytest.mark.parametrize("scenario_params", scenario_passed)
     def test_scenario_passed(self, scenario_params, tested_object):
@@ -2203,8 +2441,14 @@ def _far_subscriptions(include_far=True):
     if include_far:
         items.append(
             {
-                "metadata": {"name": "far-sub", "namespace": "openshift-workload-availability"},
-                "spec": {"name": "fence-agents-remediation", "source": "redhat-operators"},
+                "metadata": {
+                    "name": "far-sub",
+                    "namespace": "openshift-workload-availability",
+                },
+                "spec": {
+                    "name": "fence-agents-remediation",
+                    "source": "redhat-operators",
+                },
             }
         )
     return {"items": items}
@@ -2219,9 +2463,15 @@ class TestVerifyFarOperatorHealth(RuleTestBase):
         RuleScenarioParams(
             "FAR operator subscription found",
             oc_cmd_output_dict={
-                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
-                    json.dumps(_far_subscriptions(include_far=True))
-                ),
+                (
+                    "get",
+                    (
+                        "subscriptions.operators.coreos.com",
+                        "--all-namespaces",
+                        "-o",
+                        "json",
+                    ),
+                ): CmdOutput(json.dumps(_far_subscriptions(include_far=True))),
             },
         ),
     ]
@@ -2232,15 +2482,27 @@ class TestVerifyFarOperatorHealth(RuleTestBase):
             tested_object_mock_dict={
                 "oc_api.get_all_pods": Mock(
                     return_value=[
-                        create_mock_far_pod("fence-agents-remediation-controller-manager-abc123", "Running", True),
-                        create_mock_far_pod("fence-agents-remediation-worker-xyz789", "Running", True),
+                        create_mock_far_pod(
+                            "fence-agents-remediation-controller-manager-abc123",
+                            "Running",
+                            True,
+                        ),
+                        create_mock_far_pod(
+                            "fence-agents-remediation-worker-xyz789", "Running", True
+                        ),
                     ]
                 ),
             },
             oc_cmd_output_dict={
-                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
-                    json.dumps(_far_subscriptions(include_far=True))
-                ),
+                (
+                    "get",
+                    (
+                        "subscriptions.operators.coreos.com",
+                        "--all-namespaces",
+                        "-o",
+                        "json",
+                    ),
+                ): CmdOutput(json.dumps(_far_subscriptions(include_far=True))),
             },
         ),
     ]
@@ -2249,17 +2511,29 @@ class TestVerifyFarOperatorHealth(RuleTestBase):
         RuleScenarioParams(
             "FAR operator subscription not found",
             oc_cmd_output_dict={
-                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
-                    json.dumps(_far_subscriptions(include_far=False))
-                ),
+                (
+                    "get",
+                    (
+                        "subscriptions.operators.coreos.com",
+                        "--all-namespaces",
+                        "-o",
+                        "json",
+                    ),
+                ): CmdOutput(json.dumps(_far_subscriptions(include_far=False))),
             },
         ),
         RuleScenarioParams(
             "no subscriptions exist in cluster",
             oc_cmd_output_dict={
-                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
-                    json.dumps({"items": []})
-                ),
+                (
+                    "get",
+                    (
+                        "subscriptions.operators.coreos.com",
+                        "--all-namespaces",
+                        "-o",
+                        "json",
+                    ),
+                ): CmdOutput(json.dumps({"items": []})),
             },
         ),
     ]
@@ -2271,9 +2545,15 @@ class TestVerifyFarOperatorHealth(RuleTestBase):
                 "oc_api.get_all_pods": Mock(return_value=[]),
             },
             oc_cmd_output_dict={
-                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
-                    json.dumps(_far_subscriptions(include_far=True))
-                ),
+                (
+                    "get",
+                    (
+                        "subscriptions.operators.coreos.com",
+                        "--all-namespaces",
+                        "-o",
+                        "json",
+                    ),
+                ): CmdOutput(json.dumps(_far_subscriptions(include_far=True))),
             },
             failed_msg="No pods found in openshift-workload-availability namespace."
             " FAR operator may not be fully deployed.",
@@ -2283,15 +2563,27 @@ class TestVerifyFarOperatorHealth(RuleTestBase):
             tested_object_mock_dict={
                 "oc_api.get_all_pods": Mock(
                     return_value=[
-                        create_mock_far_pod("fence-agents-remediation-controller-manager-abc123", "Running", True),
-                        create_mock_far_pod("fence-agents-remediation-worker-xyz789", "Pending", True),
+                        create_mock_far_pod(
+                            "fence-agents-remediation-controller-manager-abc123",
+                            "Running",
+                            True,
+                        ),
+                        create_mock_far_pod(
+                            "fence-agents-remediation-worker-xyz789", "Pending", True
+                        ),
                     ]
                 ),
             },
             oc_cmd_output_dict={
-                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
-                    json.dumps(_far_subscriptions(include_far=True))
-                ),
+                (
+                    "get",
+                    (
+                        "subscriptions.operators.coreos.com",
+                        "--all-namespaces",
+                        "-o",
+                        "json",
+                    ),
+                ): CmdOutput(json.dumps(_far_subscriptions(include_far=True))),
             },
             failed_msg="FAR operator has unhealthy pods in openshift-workload-availability namespace:\n"
             "  fence-agents-remediation-worker-xyz789 - Phase: Pending",
@@ -2301,14 +2593,24 @@ class TestVerifyFarOperatorHealth(RuleTestBase):
             tested_object_mock_dict={
                 "oc_api.get_all_pods": Mock(
                     return_value=[
-                        create_mock_far_pod("fence-agents-remediation-controller-manager-abc123", "Running", False),
+                        create_mock_far_pod(
+                            "fence-agents-remediation-controller-manager-abc123",
+                            "Running",
+                            False,
+                        ),
                     ]
                 ),
             },
             oc_cmd_output_dict={
-                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
-                    json.dumps(_far_subscriptions(include_far=True))
-                ),
+                (
+                    "get",
+                    (
+                        "subscriptions.operators.coreos.com",
+                        "--all-namespaces",
+                        "-o",
+                        "json",
+                    ),
+                ): CmdOutput(json.dumps(_far_subscriptions(include_far=True))),
             },
             failed_msg="FAR operator has unhealthy pods in openshift-workload-availability namespace:\n"
             "  fence-agents-remediation-controller-manager-abc123 - Running, Not all containers ready",
@@ -2318,14 +2620,24 @@ class TestVerifyFarOperatorHealth(RuleTestBase):
             tested_object_mock_dict={
                 "oc_api.get_all_pods": Mock(
                     return_value=[
-                        create_mock_far_pod("fence-agents-remediation-controller-manager-abc123", "Succeeded", True),
+                        create_mock_far_pod(
+                            "fence-agents-remediation-controller-manager-abc123",
+                            "Succeeded",
+                            True,
+                        ),
                     ]
                 ),
             },
             oc_cmd_output_dict={
-                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
-                    json.dumps(_far_subscriptions(include_far=True))
-                ),
+                (
+                    "get",
+                    (
+                        "subscriptions.operators.coreos.com",
+                        "--all-namespaces",
+                        "-o",
+                        "json",
+                    ),
+                ): CmdOutput(json.dumps(_far_subscriptions(include_far=True))),
             },
             failed_msg="Failed to evaluate status for FAR pod(s):\n"
             "  fence-agents-remediation-controller-manager-abc123",
@@ -2335,15 +2647,27 @@ class TestVerifyFarOperatorHealth(RuleTestBase):
             tested_object_mock_dict={
                 "oc_api.get_all_pods": Mock(
                     return_value=[
-                        create_mock_far_pod("fence-agents-remediation-controller-manager-abc123", "Succeeded", True),
-                        create_mock_far_pod("fence-agents-remediation-worker-xyz789", "Running", False),
+                        create_mock_far_pod(
+                            "fence-agents-remediation-controller-manager-abc123",
+                            "Succeeded",
+                            True,
+                        ),
+                        create_mock_far_pod(
+                            "fence-agents-remediation-worker-xyz789", "Running", False
+                        ),
                     ]
                 ),
             },
             oc_cmd_output_dict={
-                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
-                    json.dumps(_far_subscriptions(include_far=True))
-                ),
+                (
+                    "get",
+                    (
+                        "subscriptions.operators.coreos.com",
+                        "--all-namespaces",
+                        "-o",
+                        "json",
+                    ),
+                ): CmdOutput(json.dumps(_far_subscriptions(include_far=True))),
             },
             failed_msg="Failed to evaluate status for FAR pod(s):\n"
             "  fence-agents-remediation-controller-manager-abc123\n\n"
@@ -2360,7 +2684,9 @@ class TestVerifyFarOperatorHealth(RuleTestBase):
     @pytest.mark.parametrize("scenario_params", scenario_prerequisite_not_fulfilled)
     def test_prerequisite_not_fulfilled(self, scenario_params, tested_object):
         """Test that prerequisite is not met when FAR operator is not installed."""
-        RuleTestBase.test_prerequisite_not_fulfilled(self, scenario_params, tested_object)
+        RuleTestBase.test_prerequisite_not_fulfilled(
+            self, scenario_params, tested_object
+        )
 
     @pytest.mark.parametrize("scenario_params", scenario_passed)
     def test_scenario_passed(self, scenario_params, tested_object):
@@ -2379,7 +2705,10 @@ def _far_subscription_response(has_far=True):
     if has_far:
         items.append(
             {
-                "metadata": {"name": "fence-agents-remediation", "namespace": "openshift-workload-availability"},
+                "metadata": {
+                    "name": "fence-agents-remediation",
+                    "namespace": "openshift-workload-availability",
+                },
                 "spec": {"name": "fence-agents-remediation"},
             }
         )
@@ -2391,7 +2720,10 @@ def _far_subscription_response_custom_name():
     return {
         "items": [
             {
-                "metadata": {"name": "my-custom-far-sub", "namespace": "openshift-workload-availability"},
+                "metadata": {
+                    "name": "my-custom-far-sub",
+                    "namespace": "openshift-workload-availability",
+                },
                 "spec": {"name": "fence-agents-remediation"},
             }
         ]
@@ -2463,6 +2795,159 @@ def _create_far_pod(
     return mock_pod
 
 
+def create_mock_deployment(name, spec_replicas, ready_replicas):
+    """Create a simple mock deployment object."""
+    mock_deployment = Mock()
+    mock_deployment.as_dict.return_value = {
+        "metadata": {"name": name},
+        "spec": {"replicas": spec_replicas},
+        "status": {"readyReplicas": ready_replicas},
+    }
+    return mock_deployment
+
+
+def create_mock_infrastructure(topology):
+    """Create a simple mock infrastructure object."""
+    mock_infra = Mock()
+    mock_infra.as_dict.return_value = {
+        "status": {"controlPlaneTopology": topology},
+    }
+    return mock_infra
+
+
+class TestVerifyFARControllerReplicas(RuleTestBase):
+    """Tests for VerifyFARControllerReplicas rule."""
+
+    tested_type = VerifyFARControllerReplicas
+
+    # Test: Prerequisite fulfilled - FAR deployment exists
+    scenario_prerequisite_fulfilled = [
+        RuleScenarioParams(
+            "FAR deployment exists",
+            tested_object_mock_dict={
+                "oc_api.get_all_deployments": Mock(
+                    return_value=[
+                        create_mock_deployment(
+                            "fence-agents-remediation-controller-manager", 2, 2
+                        ),
+                    ]
+                ),
+            },
+        ),
+    ]
+
+    # Test: Prerequisite not fulfilled - FAR deployment does not exist
+    scenario_prerequisite_not_fulfilled = [
+        RuleScenarioParams(
+            "FAR deployment does not exist",
+            tested_object_mock_dict={
+                "oc_api.get_all_deployments": Mock(return_value=[]),
+            },
+        ),
+        RuleScenarioParams(
+            "SNO cluster - prerequisite not fulfilled",
+            tested_object_mock_dict={
+                "oc_api.select_resources": Mock(
+                    return_value=create_mock_infrastructure("SingleReplica")
+                ),
+                "oc_api.get_all_deployments": Mock(return_value=[]),
+            },
+        ),
+    ]
+
+    # Test: Rule passed - Deployment has 2 replicas and 2 ready
+    scenario_passed = [
+        RuleScenarioParams(
+            "FAR deployment has 2 replicas and all are ready",
+            tested_object_mock_dict={
+                "oc_api.select_resources": Mock(
+                    side_effect=[
+                        create_mock_infrastructure("HighlyAvailable"),  # Not SNO
+                        create_mock_deployment(
+                            "fence-agents-remediation-controller-manager", 2, 2
+                        ),
+                    ]
+                ),
+                "oc_api.get_all_deployments": Mock(
+                    return_value=[
+                        create_mock_deployment(
+                            "fence-agents-remediation-controller-manager", 2, 2
+                        ),
+                    ]
+                ),
+            },
+        ),
+    ]
+
+    # Test: Rule failed - Wrong replica count
+    scenario_failed = [
+        RuleScenarioParams(
+            "FAR deployment has wrong spec replicas",
+            tested_object_mock_dict={
+                "oc_api.select_resources": Mock(
+                    side_effect=[
+                        create_mock_infrastructure("HighlyAvailable"),
+                        create_mock_deployment(
+                            "fence-agents-remediation-controller-manager", 1, 1
+                        ),
+                    ]
+                ),
+                "oc_api.get_all_deployments": Mock(
+                    return_value=[
+                        create_mock_deployment(
+                            "fence-agents-remediation-controller-manager", 1, 1
+                        ),
+                    ]
+                ),
+            },
+            failed_msg="Expected 2 replicas in deployment spec, but found 1",
+        ),
+        RuleScenarioParams(
+            "FAR deployment has correct spec but not all replicas ready",
+            tested_object_mock_dict={
+                "oc_api.select_resources": Mock(
+                    side_effect=[
+                        create_mock_infrastructure("HighlyAvailable"),
+                        create_mock_deployment(
+                            "fence-agents-remediation-controller-manager", 2, 1
+                        ),
+                    ]
+                ),
+                "oc_api.get_all_deployments": Mock(
+                    return_value=[
+                        create_mock_deployment(
+                            "fence-agents-remediation-controller-manager", 2, 1
+                        ),
+                    ]
+                ),
+            },
+            failed_msg="Expected 2 ready replicas, but only 1 are ready",
+        ),
+    ]
+
+    @pytest.mark.parametrize("scenario_params", scenario_prerequisite_fulfilled)
+    def test_prerequisite_fulfilled(self, scenario_params, tested_object):
+        """Test that prerequisite is met when FAR deployment exists."""
+        RuleTestBase.test_prerequisite_fulfilled(self, scenario_params, tested_object)
+
+    @pytest.mark.parametrize("scenario_params", scenario_prerequisite_not_fulfilled)
+    def test_prerequisite_not_fulfilled(self, scenario_params, tested_object):
+        """Test that prerequisite is not met when FAR deployment does not exist."""
+        RuleTestBase.test_prerequisite_not_fulfilled(
+            self, scenario_params, tested_object
+        )
+
+    @pytest.mark.parametrize("scenario_params", scenario_passed)
+    def test_scenario_passed(self, scenario_params, tested_object):
+        """Test that rule passes when deployment has correct replicas."""
+        RuleTestBase.test_scenario_passed(self, scenario_params, tested_object)
+
+    @pytest.mark.parametrize("scenario_params", scenario_failed)
+    def test_scenario_failed(self, scenario_params, tested_object):
+        """Test that rule fails when replica count is wrong."""
+        RuleTestBase.test_scenario_failed(self, scenario_params, tested_object)
+
+
 class TestVerifyFarContainerNonRoot(RuleTestBase):
     """Test VerifyFarContainerNonRoot rule."""
 
@@ -2472,15 +2957,23 @@ class TestVerifyFarContainerNonRoot(RuleTestBase):
         RuleScenarioParams(
             "FAR pod runs as non-root with proper security context",
             oc_cmd_output_dict={
-                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
-                    json.dumps(_far_subscription_response(has_far=True))
-                ),
+                (
+                    "get",
+                    (
+                        "subscriptions.operators.coreos.com",
+                        "--all-namespaces",
+                        "-o",
+                        "json",
+                    ),
+                ): CmdOutput(json.dumps(_far_subscription_response(has_far=True))),
             },
             tested_object_mock_dict={
                 "oc_api.get_pods": Mock(
                     return_value=[
                         _create_far_pod(
-                            "far-controller-manager-abc123", run_as_non_root=True, containers_run_as_user=[1000]
+                            "far-controller-manager-abc123",
+                            run_as_non_root=True,
+                            containers_run_as_user=[1000],
                         ),
                     ]
                 ),
@@ -2489,18 +2982,28 @@ class TestVerifyFarContainerNonRoot(RuleTestBase):
         RuleScenarioParams(
             "multiple FAR pods all run as non-root",
             oc_cmd_output_dict={
-                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
-                    json.dumps(_far_subscription_response(has_far=True))
-                ),
+                (
+                    "get",
+                    (
+                        "subscriptions.operators.coreos.com",
+                        "--all-namespaces",
+                        "-o",
+                        "json",
+                    ),
+                ): CmdOutput(json.dumps(_far_subscription_response(has_far=True))),
             },
             tested_object_mock_dict={
                 "oc_api.get_pods": Mock(
                     return_value=[
                         _create_far_pod(
-                            "far-controller-manager-abc123", run_as_non_root=True, containers_run_as_user=[1000]
+                            "far-controller-manager-abc123",
+                            run_as_non_root=True,
+                            containers_run_as_user=[1000],
                         ),
                         _create_far_pod(
-                            "far-controller-manager-def456", run_as_non_root=True, containers_run_as_user=[1000, 65534]
+                            "far-controller-manager-def456",
+                            run_as_non_root=True,
+                            containers_run_as_user=[1000, 65534],
                         ),
                     ]
                 ),
@@ -2512,9 +3015,15 @@ class TestVerifyFarContainerNonRoot(RuleTestBase):
         RuleScenarioParams(
             "FAR operator subscription not found",
             oc_cmd_output_dict={
-                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
-                    json.dumps(_far_subscription_response(has_far=False))
-                ),
+                (
+                    "get",
+                    (
+                        "subscriptions.operators.coreos.com",
+                        "--all-namespaces",
+                        "-o",
+                        "json",
+                    ),
+                ): CmdOutput(json.dumps(_far_subscription_response(has_far=False))),
             },
         ),
     ]
@@ -2523,17 +3032,29 @@ class TestVerifyFarContainerNonRoot(RuleTestBase):
         RuleScenarioParams(
             "FAR operator subscription exists",
             oc_cmd_output_dict={
-                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
-                    json.dumps(_far_subscription_response(has_far=True))
-                ),
+                (
+                    "get",
+                    (
+                        "subscriptions.operators.coreos.com",
+                        "--all-namespaces",
+                        "-o",
+                        "json",
+                    ),
+                ): CmdOutput(json.dumps(_far_subscription_response(has_far=True))),
             },
         ),
         RuleScenarioParams(
             "FAR subscription with custom metadata.name but correct spec.name",
             oc_cmd_output_dict={
-                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
-                    json.dumps(_far_subscription_response_custom_name())
-                ),
+                (
+                    "get",
+                    (
+                        "subscriptions.operators.coreos.com",
+                        "--all-namespaces",
+                        "-o",
+                        "json",
+                    ),
+                ): CmdOutput(json.dumps(_far_subscription_response_custom_name())),
             },
         ),
     ]
@@ -2542,9 +3063,15 @@ class TestVerifyFarContainerNonRoot(RuleTestBase):
         RuleScenarioParams(
             "no FAR pods found",
             oc_cmd_output_dict={
-                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
-                    json.dumps(_far_subscription_response(has_far=True))
-                ),
+                (
+                    "get",
+                    (
+                        "subscriptions.operators.coreos.com",
+                        "--all-namespaces",
+                        "-o",
+                        "json",
+                    ),
+                ): CmdOutput(json.dumps(_far_subscription_response(has_far=True))),
             },
             tested_object_mock_dict={
                 "oc_api.get_pods": Mock(return_value=[]),
@@ -2554,9 +3081,15 @@ class TestVerifyFarContainerNonRoot(RuleTestBase):
         RuleScenarioParams(
             "FAR pod has nil SecurityContext",
             oc_cmd_output_dict={
-                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
-                    json.dumps(_far_subscription_response(has_far=True))
-                ),
+                (
+                    "get",
+                    (
+                        "subscriptions.operators.coreos.com",
+                        "--all-namespaces",
+                        "-o",
+                        "json",
+                    ),
+                ): CmdOutput(json.dumps(_far_subscription_response(has_far=True))),
             },
             tested_object_mock_dict={
                 "oc_api.get_pods": Mock(
@@ -2570,9 +3103,15 @@ class TestVerifyFarContainerNonRoot(RuleTestBase):
         RuleScenarioParams(
             "FAR pod has nil runAsNonRoot",
             oc_cmd_output_dict={
-                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
-                    json.dumps(_far_subscription_response(has_far=True))
-                ),
+                (
+                    "get",
+                    (
+                        "subscriptions.operators.coreos.com",
+                        "--all-namespaces",
+                        "-o",
+                        "json",
+                    ),
+                ): CmdOutput(json.dumps(_far_subscription_response(has_far=True))),
             },
             tested_object_mock_dict={
                 "oc_api.get_pods": Mock(
@@ -2586,9 +3125,15 @@ class TestVerifyFarContainerNonRoot(RuleTestBase):
         RuleScenarioParams(
             "FAR pod has runAsNonRoot set to false",
             oc_cmd_output_dict={
-                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
-                    json.dumps(_far_subscription_response(has_far=True))
-                ),
+                (
+                    "get",
+                    (
+                        "subscriptions.operators.coreos.com",
+                        "--all-namespaces",
+                        "-o",
+                        "json",
+                    ),
+                ): CmdOutput(json.dumps(_far_subscription_response(has_far=True))),
             },
             tested_object_mock_dict={
                 "oc_api.get_pods": Mock(
@@ -2603,9 +3148,15 @@ class TestVerifyFarContainerNonRoot(RuleTestBase):
         RuleScenarioParams(
             "FAR pod has no containers",
             oc_cmd_output_dict={
-                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
-                    json.dumps(_far_subscription_response(has_far=True))
-                ),
+                (
+                    "get",
+                    (
+                        "subscriptions.operators.coreos.com",
+                        "--all-namespaces",
+                        "-o",
+                        "json",
+                    ),
+                ): CmdOutput(json.dumps(_far_subscription_response(has_far=True))),
             },
             tested_object_mock_dict={
                 "oc_api.get_pods": Mock(
@@ -2619,14 +3170,24 @@ class TestVerifyFarContainerNonRoot(RuleTestBase):
         RuleScenarioParams(
             "FAR container runs as root (runAsUser=0)",
             oc_cmd_output_dict={
-                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
-                    json.dumps(_far_subscription_response(has_far=True))
-                ),
+                (
+                    "get",
+                    (
+                        "subscriptions.operators.coreos.com",
+                        "--all-namespaces",
+                        "-o",
+                        "json",
+                    ),
+                ): CmdOutput(json.dumps(_far_subscription_response(has_far=True))),
             },
             tested_object_mock_dict={
                 "oc_api.get_pods": Mock(
                     return_value=[
-                        _create_far_pod("far-pod-1", run_as_non_root=True, containers_run_as_user=[0]),
+                        _create_far_pod(
+                            "far-pod-1",
+                            run_as_non_root=True,
+                            containers_run_as_user=[0],
+                        ),
                     ]
                 ),
             },
@@ -2636,9 +3197,15 @@ class TestVerifyFarContainerNonRoot(RuleTestBase):
         RuleScenarioParams(
             "FAR init container runs as root (runAsUser=0)",
             oc_cmd_output_dict={
-                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
-                    json.dumps(_far_subscription_response(has_far=True))
-                ),
+                (
+                    "get",
+                    (
+                        "subscriptions.operators.coreos.com",
+                        "--all-namespaces",
+                        "-o",
+                        "json",
+                    ),
+                ): CmdOutput(json.dumps(_far_subscription_response(has_far=True))),
             },
             tested_object_mock_dict={
                 "oc_api.get_pods": Mock(
@@ -2658,15 +3225,25 @@ class TestVerifyFarContainerNonRoot(RuleTestBase):
         RuleScenarioParams(
             "mixed failures - nil SecurityContext and root container",
             oc_cmd_output_dict={
-                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
-                    json.dumps(_far_subscription_response(has_far=True))
-                ),
+                (
+                    "get",
+                    (
+                        "subscriptions.operators.coreos.com",
+                        "--all-namespaces",
+                        "-o",
+                        "json",
+                    ),
+                ): CmdOutput(json.dumps(_far_subscription_response(has_far=True))),
             },
             tested_object_mock_dict={
                 "oc_api.get_pods": Mock(
                     return_value=[
                         _create_far_pod("far-pod-1", has_security_context=False),
-                        _create_far_pod("far-pod-2", run_as_non_root=True, containers_run_as_user=[0, 1000]),
+                        _create_far_pod(
+                            "far-pod-2",
+                            run_as_non_root=True,
+                            containers_run_as_user=[0, 1000],
+                        ),
                     ]
                 ),
             },
@@ -2677,14 +3254,24 @@ class TestVerifyFarContainerNonRoot(RuleTestBase):
         RuleScenarioParams(
             "FAR container has invalid runAsUser (negative value)",
             oc_cmd_output_dict={
-                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
-                    json.dumps(_far_subscription_response(has_far=True))
-                ),
+                (
+                    "get",
+                    (
+                        "subscriptions.operators.coreos.com",
+                        "--all-namespaces",
+                        "-o",
+                        "json",
+                    ),
+                ): CmdOutput(json.dumps(_far_subscription_response(has_far=True))),
             },
             tested_object_mock_dict={
                 "oc_api.get_pods": Mock(
                     return_value=[
-                        _create_far_pod("far-pod-1", run_as_non_root=True, containers_run_as_user=[-1]),
+                        _create_far_pod(
+                            "far-pod-1",
+                            run_as_non_root=True,
+                            containers_run_as_user=[-1],
+                        ),
                     ]
                 ),
             },
@@ -2695,7 +3282,9 @@ class TestVerifyFarContainerNonRoot(RuleTestBase):
 
     @pytest.mark.parametrize("scenario_params", scenario_prerequisite_not_fulfilled)
     def test_prerequisite_not_fulfilled(self, scenario_params, tested_object):
-        RuleTestBase.test_prerequisite_not_fulfilled(self, scenario_params, tested_object)
+        RuleTestBase.test_prerequisite_not_fulfilled(
+            self, scenario_params, tested_object
+        )
 
     @pytest.mark.parametrize("scenario_params", scenario_prerequisite_fulfilled)
     def test_prerequisite_fulfilled(self, scenario_params, tested_object):
@@ -2732,8 +3321,14 @@ def _nmo_subscriptions(include_nmo=True):
     if include_nmo:
         items.append(
             {
-                "metadata": {"name": "nmo-sub", "namespace": "openshift-workload-availability"},
-                "spec": {"name": "node-maintenance-operator", "source": "redhat-operators"},
+                "metadata": {
+                    "name": "nmo-sub",
+                    "namespace": "openshift-workload-availability",
+                },
+                "spec": {
+                    "name": "node-maintenance-operator",
+                    "source": "redhat-operators",
+                },
             }
         )
     return {"items": items}
@@ -2748,9 +3343,15 @@ class TestVerifyNmoOperatorHealth(RuleTestBase):
         RuleScenarioParams(
             "NMO operator subscription found",
             oc_cmd_output_dict={
-                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
-                    json.dumps(_nmo_subscriptions(include_nmo=True))
-                ),
+                (
+                    "get",
+                    (
+                        "subscriptions.operators.coreos.com",
+                        "--all-namespaces",
+                        "-o",
+                        "json",
+                    ),
+                ): CmdOutput(json.dumps(_nmo_subscriptions(include_nmo=True))),
             },
         ),
     ]
@@ -2761,14 +3362,24 @@ class TestVerifyNmoOperatorHealth(RuleTestBase):
             tested_object_mock_dict={
                 "oc_api.get_all_pods": Mock(
                     return_value=[
-                        create_mock_nmo_pod("node-maintenance-operator-controller-manager-abc123", "Running", True),
+                        create_mock_nmo_pod(
+                            "node-maintenance-operator-controller-manager-abc123",
+                            "Running",
+                            True,
+                        ),
                     ]
                 ),
             },
             oc_cmd_output_dict={
-                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
-                    json.dumps(_nmo_subscriptions(include_nmo=True))
-                ),
+                (
+                    "get",
+                    (
+                        "subscriptions.operators.coreos.com",
+                        "--all-namespaces",
+                        "-o",
+                        "json",
+                    ),
+                ): CmdOutput(json.dumps(_nmo_subscriptions(include_nmo=True))),
             },
         ),
     ]
@@ -2777,17 +3388,29 @@ class TestVerifyNmoOperatorHealth(RuleTestBase):
         RuleScenarioParams(
             "NMO operator subscription not found",
             oc_cmd_output_dict={
-                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
-                    json.dumps(_nmo_subscriptions(include_nmo=False))
-                ),
+                (
+                    "get",
+                    (
+                        "subscriptions.operators.coreos.com",
+                        "--all-namespaces",
+                        "-o",
+                        "json",
+                    ),
+                ): CmdOutput(json.dumps(_nmo_subscriptions(include_nmo=False))),
             },
         ),
         RuleScenarioParams(
             "no subscriptions exist in cluster",
             oc_cmd_output_dict={
-                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
-                    json.dumps({"items": []})
-                ),
+                (
+                    "get",
+                    (
+                        "subscriptions.operators.coreos.com",
+                        "--all-namespaces",
+                        "-o",
+                        "json",
+                    ),
+                ): CmdOutput(json.dumps({"items": []})),
             },
         ),
     ]
@@ -2799,9 +3422,15 @@ class TestVerifyNmoOperatorHealth(RuleTestBase):
                 "oc_api.get_all_pods": Mock(return_value=[]),
             },
             oc_cmd_output_dict={
-                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
-                    json.dumps(_nmo_subscriptions(include_nmo=True))
-                ),
+                (
+                    "get",
+                    (
+                        "subscriptions.operators.coreos.com",
+                        "--all-namespaces",
+                        "-o",
+                        "json",
+                    ),
+                ): CmdOutput(json.dumps(_nmo_subscriptions(include_nmo=True))),
             },
             failed_msg="No pods found in openshift-workload-availability namespace."
             " NMO operator may not be fully deployed.",
@@ -2811,15 +3440,27 @@ class TestVerifyNmoOperatorHealth(RuleTestBase):
             tested_object_mock_dict={
                 "oc_api.get_all_pods": Mock(
                     return_value=[
-                        create_mock_nmo_pod("node-maintenance-operator-controller-manager-abc123", "Running", True),
-                        create_mock_nmo_pod("node-maintenance-operator-worker-xyz789", "Pending", True),
+                        create_mock_nmo_pod(
+                            "node-maintenance-operator-controller-manager-abc123",
+                            "Running",
+                            True,
+                        ),
+                        create_mock_nmo_pod(
+                            "node-maintenance-operator-worker-xyz789", "Pending", True
+                        ),
                     ]
                 ),
             },
             oc_cmd_output_dict={
-                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
-                    json.dumps(_nmo_subscriptions(include_nmo=True))
-                ),
+                (
+                    "get",
+                    (
+                        "subscriptions.operators.coreos.com",
+                        "--all-namespaces",
+                        "-o",
+                        "json",
+                    ),
+                ): CmdOutput(json.dumps(_nmo_subscriptions(include_nmo=True))),
             },
             failed_msg="NMO operator has unhealthy pods in openshift-workload-availability namespace:\n"
             "  node-maintenance-operator-worker-xyz789 - Phase: Pending",
@@ -2829,14 +3470,24 @@ class TestVerifyNmoOperatorHealth(RuleTestBase):
             tested_object_mock_dict={
                 "oc_api.get_all_pods": Mock(
                     return_value=[
-                        create_mock_nmo_pod("node-maintenance-operator-controller-manager-abc123", "Running", False),
+                        create_mock_nmo_pod(
+                            "node-maintenance-operator-controller-manager-abc123",
+                            "Running",
+                            False,
+                        ),
                     ]
                 ),
             },
             oc_cmd_output_dict={
-                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
-                    json.dumps(_nmo_subscriptions(include_nmo=True))
-                ),
+                (
+                    "get",
+                    (
+                        "subscriptions.operators.coreos.com",
+                        "--all-namespaces",
+                        "-o",
+                        "json",
+                    ),
+                ): CmdOutput(json.dumps(_nmo_subscriptions(include_nmo=True))),
             },
             failed_msg="NMO operator has unhealthy pods in openshift-workload-availability namespace:\n"
             "  node-maintenance-operator-controller-manager-abc123 - Running, Not all containers ready",
@@ -2846,14 +3497,24 @@ class TestVerifyNmoOperatorHealth(RuleTestBase):
             tested_object_mock_dict={
                 "oc_api.get_all_pods": Mock(
                     return_value=[
-                        create_mock_nmo_pod("node-maintenance-operator-controller-manager-abc123", "Succeeded", True),
+                        create_mock_nmo_pod(
+                            "node-maintenance-operator-controller-manager-abc123",
+                            "Succeeded",
+                            True,
+                        ),
                     ]
                 ),
             },
             oc_cmd_output_dict={
-                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
-                    json.dumps(_nmo_subscriptions(include_nmo=True))
-                ),
+                (
+                    "get",
+                    (
+                        "subscriptions.operators.coreos.com",
+                        "--all-namespaces",
+                        "-o",
+                        "json",
+                    ),
+                ): CmdOutput(json.dumps(_nmo_subscriptions(include_nmo=True))),
             },
             failed_msg="Failed to evaluate status for NMO pod(s):\n"
             "  node-maintenance-operator-controller-manager-abc123",
@@ -2863,15 +3524,27 @@ class TestVerifyNmoOperatorHealth(RuleTestBase):
             tested_object_mock_dict={
                 "oc_api.get_all_pods": Mock(
                     return_value=[
-                        create_mock_nmo_pod("node-maintenance-operator-controller-manager-abc123", "Succeeded", True),
-                        create_mock_nmo_pod("node-maintenance-operator-worker-xyz789", "Running", False),
+                        create_mock_nmo_pod(
+                            "node-maintenance-operator-controller-manager-abc123",
+                            "Succeeded",
+                            True,
+                        ),
+                        create_mock_nmo_pod(
+                            "node-maintenance-operator-worker-xyz789", "Running", False
+                        ),
                     ]
                 ),
             },
             oc_cmd_output_dict={
-                ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json")): CmdOutput(
-                    json.dumps(_nmo_subscriptions(include_nmo=True))
-                ),
+                (
+                    "get",
+                    (
+                        "subscriptions.operators.coreos.com",
+                        "--all-namespaces",
+                        "-o",
+                        "json",
+                    ),
+                ): CmdOutput(json.dumps(_nmo_subscriptions(include_nmo=True))),
             },
             failed_msg="Failed to evaluate status for NMO pod(s):\n"
             "  node-maintenance-operator-controller-manager-abc123\n\n"
@@ -2888,7 +3561,9 @@ class TestVerifyNmoOperatorHealth(RuleTestBase):
     @pytest.mark.parametrize("scenario_params", scenario_prerequisite_not_fulfilled)
     def test_prerequisite_not_fulfilled(self, scenario_params, tested_object):
         """Test that prerequisite is not met when NMO operator is not installed."""
-        RuleTestBase.test_prerequisite_not_fulfilled(self, scenario_params, tested_object)
+        RuleTestBase.test_prerequisite_not_fulfilled(
+            self, scenario_params, tested_object
+        )
 
     @pytest.mark.parametrize("scenario_params", scenario_passed)
     def test_scenario_passed(self, scenario_params, tested_object):

--- a/tests/rules/k8s/test_k8s_validations.py
+++ b/tests/rules/k8s/test_k8s_validations.py
@@ -2653,19 +2653,8 @@ def _create_far_pod(
     return mock_pod
 
 
-def create_mock_deployment(name, spec_replicas, ready_replicas):
-    """Create a simple mock deployment object."""
-    mock_deployment = Mock()
-    mock_deployment.as_dict.return_value = {
-        "metadata": {"name": name},
-        "spec": {"replicas": spec_replicas},
-        "status": {"readyReplicas": ready_replicas},
-    }
-    return mock_deployment
-
-
-def create_mock_infrastructure(topology):
-    """Create a simple mock infrastructure object."""
+def create_mock_infrastructure_for_far(topology):
+    """Create a mock infrastructure object for FAR tests."""
     mock_infra = Mock()
     mock_infra.as_dict.return_value = {
         "status": {"controlPlaneTopology": topology},
@@ -2685,7 +2674,12 @@ class TestVerifyFARControllerReplicas(RuleTestBase):
             tested_object_mock_dict={
                 "oc_api.get_all_deployments": Mock(
                     return_value=[
-                        create_mock_deployment("fence-agents-remediation-controller-manager", 2, 2),
+                        create_mock_deployment(
+                            "fence-agents-remediation-controller-manager",
+                            "openshift-workload-availability",
+                            spec={"replicas": 2},
+                            status={"readyReplicas": 2},
+                        ),
                     ]
                 ),
             },
@@ -2700,13 +2694,6 @@ class TestVerifyFARControllerReplicas(RuleTestBase):
                 "oc_api.get_all_deployments": Mock(return_value=[]),
             },
         ),
-        RuleScenarioParams(
-            "SNO cluster - prerequisite not fulfilled",
-            tested_object_mock_dict={
-                "oc_api.select_resources": Mock(return_value=create_mock_infrastructure("SingleReplica")),
-                "oc_api.get_all_deployments": Mock(return_value=[]),
-            },
-        ),
     ]
 
     # Test: Rule passed - Deployment has 2 replicas and 2 ready
@@ -2714,15 +2701,15 @@ class TestVerifyFARControllerReplicas(RuleTestBase):
         RuleScenarioParams(
             "FAR deployment has 2 replicas and all are ready",
             tested_object_mock_dict={
-                "oc_api.select_resources": Mock(
-                    side_effect=[
-                        create_mock_infrastructure("HighlyAvailable"),  # Not SNO
-                        create_mock_deployment("fence-agents-remediation-controller-manager", 2, 2),
-                    ]
-                ),
+                "oc_api.select_resources": Mock(return_value=create_mock_infrastructure_for_far("HighlyAvailable")),
                 "oc_api.get_all_deployments": Mock(
                     return_value=[
-                        create_mock_deployment("fence-agents-remediation-controller-manager", 2, 2),
+                        create_mock_deployment(
+                            "fence-agents-remediation-controller-manager",
+                            "openshift-workload-availability",
+                            spec={"replicas": 2},
+                            status={"readyReplicas": 2},
+                        ),
                     ]
                 ),
             },
@@ -2734,15 +2721,15 @@ class TestVerifyFARControllerReplicas(RuleTestBase):
         RuleScenarioParams(
             "FAR deployment has wrong spec replicas",
             tested_object_mock_dict={
-                "oc_api.select_resources": Mock(
-                    side_effect=[
-                        create_mock_infrastructure("HighlyAvailable"),
-                        create_mock_deployment("fence-agents-remediation-controller-manager", 1, 1),
-                    ]
-                ),
+                "oc_api.select_resources": Mock(return_value=create_mock_infrastructure_for_far("HighlyAvailable")),
                 "oc_api.get_all_deployments": Mock(
                     return_value=[
-                        create_mock_deployment("fence-agents-remediation-controller-manager", 1, 1),
+                        create_mock_deployment(
+                            "fence-agents-remediation-controller-manager",
+                            "openshift-workload-availability",
+                            spec={"replicas": 1},
+                            status={"readyReplicas": 1},
+                        ),
                     ]
                 ),
             },
@@ -2751,15 +2738,15 @@ class TestVerifyFARControllerReplicas(RuleTestBase):
         RuleScenarioParams(
             "FAR deployment has correct spec but not all replicas ready",
             tested_object_mock_dict={
-                "oc_api.select_resources": Mock(
-                    side_effect=[
-                        create_mock_infrastructure("HighlyAvailable"),
-                        create_mock_deployment("fence-agents-remediation-controller-manager", 2, 1),
-                    ]
-                ),
+                "oc_api.select_resources": Mock(return_value=create_mock_infrastructure_for_far("HighlyAvailable")),
                 "oc_api.get_all_deployments": Mock(
                     return_value=[
-                        create_mock_deployment("fence-agents-remediation-controller-manager", 2, 1),
+                        create_mock_deployment(
+                            "fence-agents-remediation-controller-manager",
+                            "openshift-workload-availability",
+                            spec={"replicas": 2},
+                            status={"readyReplicas": 1},
+                        ),
                     ]
                 ),
             },
@@ -2786,6 +2773,24 @@ class TestVerifyFARControllerReplicas(RuleTestBase):
     def test_scenario_failed(self, scenario_params, tested_object):
         """Test that rule fails when replica count is wrong."""
         RuleTestBase.test_scenario_failed(self, scenario_params, tested_object)
+
+    def test_sno_cluster_skipped(self, tested_object):
+        """Test that rule is skipped on SNO (Single Node OpenShift) cluster."""
+        tested_object.oc_api.select_resources = Mock(return_value=create_mock_infrastructure_for_far("SingleReplica"))
+        tested_object.oc_api.get_all_deployments = Mock(
+            return_value=[
+                create_mock_deployment(
+                    "fence-agents-remediation-controller-manager",
+                    "openshift-workload-availability",
+                    spec={"replicas": 1},
+                    status={"readyReplicas": 1},
+                ),
+            ]
+        )
+
+        result = tested_object.run_rule()
+        assert result.status == Status.SKIP
+        assert "SNO" in result.message or "Single Node OpenShift" in result.message
 
 
 class TestVerifyFarContainerNonRoot(RuleTestBase):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a FAR controller-manager replica validation that checks deployment existence and expected replica/ready-replica counts; skipped on Single Node OpenShift.

* **Changes**
  * Improved health-check message formatting and JSON parsing for operator/pod health validations; refined error text for several pod-health and container validations.

* **Tests**
  * Added unit tests covering the new FAR replica validation and updated domain rule set expectations; reformatted existing test helpers and assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->