### PR TITLE
chore(PDRIVE-633): migrate rule docs from GitHub wiki to Confluence

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -82,5 +82,5 @@ See [@.claude/rules/github-mcp.md](rules/github-mcp.md) for detailed GitHub MCP 
 
 ## Additional Resources
 
-- **Project Wiki**: https://github.com/RedHatInsights/incluster-checks/wiki - Detailed knowledge sharing about rules and documentation
+- **Rule Documentation**: https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418417677/In-Cluster+Checks+Rules - Detailed knowledge sharing about rules and documentation
 - **Contributing Guide**: See [CONTRIBUTING.md](../CONTRIBUTING.md) for development setup and contribution guidelines

--- a/.claude/rules/in-cluster-check.md
+++ b/.claude/rules/in-cluster-check.md
@@ -78,26 +78,20 @@ All rules use the `Status` enum (`utils/enums.py`):
 - NEVER use `self.logger` in rules. Return error messages via `RuleResult.failed()` or `RuleResult.warning()` instead. The framework handles logging automatically.
 
 **Documentation:**
-- **REQUIRED**: Every new rule MUST have a corresponding wiki page in the GitHub wiki
+- **REQUIRED**: Every new rule MUST have a corresponding documentation page in Confluence
+- Rule documentation is hosted at: https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418417677/In-Cluster+Checks+Rules
 - When implementing a new rule:
-  1. Add wiki link to the rule's `links` field pointing to where the page will be: `links = ["https://github.com/RedHatInsights/incluster-checks/wiki/{Domain}-%E2%80%90-{Rule-Title}"]`
-  2. Create wiki page content in markdown format for the user to copy-paste into GitHub wiki
-- **Wiki URL format**: `{Domain}-%E2%80%90-{Rule-Title}` where:
-  - `{Domain}` is the domain name (e.g., "Security", "Network", "Storage")
-  - `-%E2%80%90-` is the separator (hyphen + URL-encoded Unicode hyphen U+2010 + hyphen)
-  - `{Rule-Title}` is the rule title with spaces replaced by ASCII hyphens `-`
-  - Example: "Check kubelet CA certificate expiry" in Security domain → `Security-%E2%80%90-Check-kubelet-CA-certificate-expiry`
-- **IMPORTANT**: The domain-to-title separator MUST be `-%E2%80%90-` (URL-encoded). Within domain and title text, use regular ASCII hyphens `-` for spaces.
+  1. Add the Confluence page link to the rule's `links` field: `links = ["https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/{PAGE_ID}"]`
+  2. Create the documentation page in Confluence under the appropriate domain (DPF, Hardware, K8s, Linux, Network, Resources, Security)
 
-**Creating Wiki Page Content:**
-- GitHub wikis are NOT accessible via the GitHub MCP (REST API returns 404)
-- **Workflow**: 
-  1. Use WebFetch to read existing wiki pages as templates: `WebFetch(url="https://github.com/RedHatInsights/incluster-checks/wiki/Security-%E2%80%90-TLS-certificate-expiry")`
-  2. Create the new wiki page content in **markdown format** following the standard structure
-  3. Present the markdown content in a code block for easy copy-paste by the user
+**Creating Documentation Page Content:**
+- **Workflow**:
+  1. Read an existing Confluence page as a template (e.g., [TLS certificate expiry](https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418482936))
+  2. Create the new documentation page in Confluence under the appropriate domain
+  3. Add the Confluence page URL to the rule's `links` field
 
-**Wiki Page Structure:**
-All wiki pages should follow this standard structure (in markdown format):
+**Documentation Page Structure:**
+All documentation pages should follow this standard structure:
   - **Description**: What the rule checks, why it's important, severity level, and failure thresholds
   - **Prerequisites**: Required access, tools, or conditions needed to run the check
   - **Impact**: What happens if the condition fails (specific failure scenarios and consequences)
@@ -106,8 +100,8 @@ All wiki pages should follow this standard structure (in markdown format):
   - **Solution**: Step-by-step remediation instructions with code examples
   - **Resources**: Links to official documentation, KCS articles, troubleshooting guides
 
-**Wiki Page Examples:**
-- See existing templates: [Security - TLS certificate expiry](https://github.com/RedHatInsights/incluster-checks/wiki/Security-%E2%80%90-TLS-certificate-expiry), [Security - Node certificate expiry](https://github.com/RedHatInsights/incluster-checks/wiki/Security-%E2%80%90-Node-certificate-expiry)
+**Documentation Page Examples:**
+- See existing templates: [Security - TLS certificate expiry](https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418482936), [Security - Node certificate expiry](https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418418558)
 
 ## Existing Domains
 

--- a/.claude/skills/create-wiki-page/SKILL.md
+++ b/.claude/skills/create-wiki-page/SKILL.md
@@ -1,13 +1,15 @@
 ---
 name: create-wiki-page
-description: Use when creating wiki documentation for an in-cluster-checks validation rule - follows 7-section template with proper formatting
+description: Use when creating documentation for an in-cluster-checks validation rule - follows 7-section template with proper formatting
 ---
 
-Create a wiki page for an in-cluster-checks validation rule.
+Create a Confluence documentation page for an in-cluster-checks validation rule.
 
 $ARGUMENTS
 
-Follow the 7-section wiki template and project documentation standards.
+Follow the 7-section documentation template and project documentation standards.
+
+Documentation is hosted in Confluence: https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418417677/In-Cluster+Checks+Rules
 
 ---
 

--- a/.claude/skills/implement-rule-from-jira/SKILL.md
+++ b/.claude/skills/implement-rule-from-jira/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: implement-rule-from-jira
-description: Use when user wants to create a new validation rule from a Jira ticket (Story type only) - validates ticket, scaffolds rule with tests and wiki docs
+description: Use when user wants to create a new validation rule from a Jira ticket (Story type only) - validates ticket, scaffolds rule with tests and Confluence docs
 ---
 
 Create a new in-cluster validation rule from a Jira ticket.
 
 **Args**: Jira ticket number (e.g., PDRIVE-123)
 
-**Purpose**: This skill helps external contributors implement new validation rules according to project guidelines. It validates the ticket type, scaffolds the rule, creates tests, generates wiki documentation, and handles the complete PR workflow.
+**Purpose**: This skill helps external contributors implement new validation rules according to project guidelines. It validates the ticket type, scaffolds the rule, creates tests, generates Confluence documentation, and handles the complete PR workflow.
 
 # Implement New Rule from Jira Ticket
 
@@ -91,7 +91,7 @@ Place the rule in `src/in_cluster_checks/rules/<domain>/<file>.py`:
 - Implement `run_rule()` returning `RuleResult`
 - Add `is_prerequisite_fulfilled()` if needed
 - **CRITICAL**: All commands MUST use `SafeCmdString`
-- Add wiki link to `links` field (see Step 6 for wiki URL format)
+- Add Confluence link to `links` field (see Step 6 for URL format)
 
 **Important reminders:**
 - NO use of `self.logger` - return messages via RuleResult
@@ -136,29 +136,23 @@ pytest tests/rules/<domain>/test_<file>.py -v
 
 Ensure all tests pass before proceeding.
 
-## Step 6: Create Wiki Page Content
+## Step 6: Create Confluence Documentation Page
 
-**REQUIRED**: Every new rule MUST have wiki documentation.
+**REQUIRED**: Every new rule MUST have Confluence documentation.
 
-**Reference**: @.claude/rules/in-cluster-check.md (Documentation section, lines 66-93)
+**Reference**: @.claude/rules/in-cluster-check.md (Documentation section)
 
-### 6a. Fetch Wiki Template
+### 6a. Review Existing Template
 
-Use WebFetch to read an existing wiki page as a template:
-```
-WebFetch(url="https://github.com/RedHatInsights/incluster-checks/wiki/Security-‐-TLS-certificate-expiry")
-```
+Read an existing Confluence page as a template:
+- [TLS certificate expiry](https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418482936)
+- [Node certificate expiry](https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418418558)
 
-### 6b. Generate Wiki Content
+### 6b. Generate Documentation Content
 
-Create wiki page content in **markdown format** following the standard structure:
+Create documentation page content following the standard structure:
 
-**Wiki URL Format**: `https://github.com/RedHatInsights/incluster-checks/wiki/{Domain}-‐-{Rule-Title}`
-- Use the rule's `title` field with spaces replaced by dashes
-- Use `‐` (not `-`) in URLs due to GitHub wiki encoding
-- Example: "Check kubelet CA certificate expiry" → `Security-‐-Check-kubelet-CA-certificate-expiry`
-
-**Standard Wiki Structure**:
+**Standard Structure**:
 - **Description**: What the rule checks, why it's important, severity, failure thresholds
 - **Prerequisites**: Required access, tools, or conditions
 - **Impact**: What happens if the condition fails
@@ -167,27 +161,28 @@ Create wiki page content in **markdown format** following the standard structure
 - **Solution**: Step-by-step remediation with code examples
 - **Resources**: Links to official docs, KCS articles, guides
 
-### 6c. Present Wiki Content
+### 6c. Present Documentation Content
 
-Show the complete wiki page content in a markdown code block for easy copy-paste:
+Show the complete page content in a markdown code block for easy copy-paste:
 
 ```
-Here's the wiki page content for your new rule.
+Here's the documentation page content for your new rule.
 
 **IMPORTANT - Manual Steps Required:**
 
-1. **Copy the wiki content** from the markdown code block below
-2. **Navigate to**: https://github.com/RedHatInsights/incluster-checks/wiki/{Domain}-‐-{Rule-Title}
-3. Click "Create new page"
-4. Paste the content
-5. Save the page
-6. **Verify the wiki link** in your rule's `links` field matches the created wiki page URL
+1. **Navigate to**: https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418417677/In-Cluster+Checks+Rules
+2. Open the appropriate **domain page** (e.g., Network, K8s, Security)
+3. Click **Create** to add a child page
+4. Set the title to the rule's title
+5. Paste the content from below
+6. **Publish** the page
+7. **Copy the page URL** and add it to the rule's `links` field
 
 ```markdown
-[Wiki content here]
+[Documentation content here]
 ```
 
-**Note**: GitHub wikis are not accessible via API, so this must be done manually. Make sure the wiki link in the rule code matches the actual wiki page URL after creation.
+**Note**: After creating the page, copy the Confluence URL and update the rule's `links` field to match.
 ```
 
 ## Step 7: Run All Tests
@@ -279,8 +274,8 @@ Use `mcp__plugin_github_github__create_pull_request`:
   - ✅ Pre-commit checks pass
   - ✅ Coverage maintained
   
-  ## Wiki Documentation
-  Wiki page URL: https://github.com/RedHatInsights/incluster-checks/wiki/{Domain}-‐-{Rule-Title}
+  ## Documentation
+  Confluence page: https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/{PAGE_ID}
   (Will be created after PR approval)
   ```
 
@@ -304,7 +299,7 @@ Created new validation rule: `<unique_name>`
 
 **Pull Request:** [PR #NUMBER](PR-URL)
 
-**Wiki Documentation:** [Rule Wiki Page](wiki-url)
+**Documentation:** [Rule Documentation Page](confluence-url)
 
 **Status:** Ready for review
 ```
@@ -333,10 +328,10 @@ Before marking complete, verify:
 - [ ] Tests written with passed and failed scenarios
 - [ ] All tests passing
 - [ ] Pre-commit checks passing
-- [ ] Wiki page content created and provided to user
-- [ ] User instructed to manually create wiki page and copy content
-- [ ] Wiki link added to rule's `links` field
-- [ ] User reminded to verify wiki link matches actual wiki page URL
+- [ ] Documentation page content created and provided to user
+- [ ] User instructed to create Confluence page under appropriate domain
+- [ ] Confluence link added to rule's `links` field
+- [ ] User reminded to verify Confluence link matches actual page URL
 - [ ] Committed with conventional commit format
 - [ ] Rebased on upstream/main
 - [ ] Pushed to origin
@@ -357,7 +352,7 @@ Expected flow:
 6. Create rule in src/in_cluster_checks/rules/network/
 7. Register in NetworkValidationDomain
 8. Create tests in tests/rules/network/
-9. Generate wiki page content and provide to user
+9. Generate documentation page content and provide to user
 10. Run tests → all pass ✓
 11. Commit with: feat(PDRIVE-505): add network connectivity validation
 12. Rebase on upstream/main

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -62,12 +62,11 @@ reviews:
     - Error messages must be clear and informative so the end user can understand what went wrong.
 
     **Link validation:**
-    - Verify that all links (wiki pages, documentation, external references) are valid and accessible.
-    - **For GitHub wiki links**: Fetch the page content and verify it is not empty or a placeholder.
-      The wiki page should contain meaningful documentation with at least the following sections:
+    - Verify that all links (Confluence pages, documentation, external references) are valid and accessible.
+    - **For Confluence documentation links**: The documentation page should contain meaningful content with at least the following sections:
       Description, Prerequisites, Impact, Root Cause, Diagnostics, Solution, and Resources.
     - Verify link content is relevant and specific to the rule (not generic boilerplate).
-    - Flag wiki links that return 404 or contain only stub/placeholder content.
+    - Flag links that return 404 or contain only stub/placeholder content.
 
   path_instructions:
     - path: "src/in_cluster_checks/rules/**/*.py"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,7 +120,7 @@ This skill automates the complete workflow for implementing a new validation rul
 - Scaffolds the rule class with all required fields
 - Generates comprehensive tests
 - Registers the rule in the appropriate domain
-- Creates wiki documentation content
+- Creates Confluence documentation content
 - Runs all tests and pre-commit checks
 - Commits changes with proper formatting
 - Creates a pull request
@@ -138,7 +138,7 @@ This skill automates the complete workflow for implementing a new validation rul
 
 **Important notes:**
 - The skill validates that the ticket is a "Story" type - other issue types will be rejected
-- Wiki pages must be created manually on GitHub (skill provides the content to copy-paste)
+- Confluence pages must be created manually (skill provides the content to copy-paste)
 - You'll be asked for confirmation before committing and creating the PR
 - All code follows project guidelines and passes automated checks
 
@@ -186,22 +186,22 @@ class YourNewRule(Rule):
 
 The `links` field should contain references to documentation about the rule:
 
-1. **Create a Wiki page** for the new rule at https://github.com/RedHatInsights/incluster-checks/wiki
-   - Use the [wiki template](https://github.com/RedHatInsights/incluster-checks/wiki) to create the page
+1. **Create a Confluence page** for the new rule under the [In-Cluster Checks Rules](https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418417677/In-Cluster+Checks+Rules) parent page
+   - Create a new page under the appropriate domain section
    - Document what the rule checks, why it's important, and troubleshooting steps
    - Include example output or scenarios
 
-2. **Add the Wiki URL** to the `links` field:
+2. **Add the Confluence URL** to the `links` field:
    ```python
    links = [
-       "https://github.com/RedHatInsights/incluster-checks/wiki/YourNewRule",
+       "https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/<PAGE_ID>",
    ]
    ```
 
 3. **Additional documentation URLs** can also be included (Knowledge Base articles, OpenShift docs, bug reports, etc.):
    ```python
    links = [
-       "https://github.com/RedHatInsights/incluster-checks/wiki/YourNewRule",
+       "https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/<PAGE_ID>",
        "https://access.redhat.com/solutions/12345",
    ]
    ```
@@ -686,7 +686,7 @@ Before submitting your PR, ensure:
 
 - **Bug reports or feature requests**: [Open an issue](https://github.com/RedHatInsights/incluster-checks/issues/new) on GitHub
 - **General questions**: [Open an issue](https://github.com/RedHatInsights/incluster-checks/issues/new) with your question
-- **Documentation and rule information**: Check the [project wiki](https://github.com/RedHatInsights/incluster-checks/wiki) for detailed knowledge sharing about rules
+- **Documentation and rule information**: Check the [project wiki](https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418417677/In-Cluster+Checks+Rules) for detailed knowledge sharing about rules
 - **Private matters**: Contact maintainers directly via GitHub
 
 ## License

--- a/src/in_cluster_checks/rules/hw/hw_validations.py
+++ b/src/in_cluster_checks/rules/hw/hw_validations.py
@@ -23,10 +23,7 @@ class CheckDiskUsage(Rule):
     objective_hosts = [Objectives.ALL_NODES]
     unique_name = "is_disk_space_sufficient"
     title = "Verify disk space usage on computes and storage nodes"
-    links = (
-        "https://github.com/RedHatInsights/incluster-checks/wiki/"
-        "Hardware-%E2%80%90-Verify-disk-space-usage-on-computes-and-storage-nodes",
-    )
+    links = ("https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418482712",)
     THRESHOLD_WARN = 80
     THRESHOLD_ERR = 90
 

--- a/src/in_cluster_checks/rules/k8s/k8s_validations.py
+++ b/src/in_cluster_checks/rules/k8s/k8s_validations.py
@@ -405,7 +405,7 @@ class AllDeploymentsAvailable(OrchestratorRule):
     unique_name = "all_deployments_available"
     title = "Verify all deployments are available"
     supported_profiles = {"telco-base"}
-    links = ["https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-deployments-availability"]
+    links = ["https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418516241"]
 
     def run_rule(self):
         """Check if all deployments have Available condition set to True."""
@@ -458,7 +458,7 @@ class CheckDeploymentsReplicaStatus(OrchestratorRule):
     unique_name = "check_deployments_replica_status"
     title = "Verify deployment replica counts"
     supported_profiles = {"telco-base"}
-    links = ["https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Check-deployment-replicas-status"]
+    links = ["https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418482816"]
 
     def run_rule(self):
         """Check if all deployments have desired number of replicas ready."""
@@ -517,7 +517,7 @@ class AllStatefulsetsReady(OrchestratorRule):
     unique_name = "all_statefulsets_ready"
     title = "Verify all statefulsets are ready"
     supported_profiles = {"telco-base"}
-    links = ["https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-statefulsets-readiness"]
+    links = ["https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418516203"]
 
     def run_rule(self):
         """Check if all statefulsets have ready replicas matching desired replicas."""
@@ -652,7 +652,7 @@ class ValidateAllPoliciesCompliant(OrchestratorRule):
     unique_name = "validate_all_policies_compliant"
     title = "Verify all policies are in compliant state"
     supported_profiles = {"telco-base"}
-    links = ["https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-policies-compliance"]
+    links = ["https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418418424"]
 
     _POLICIES_RESOURCE = "policies.policy.open-cluster-management.io"
 
@@ -736,7 +736,7 @@ class VerifyInternalRegistry(OrchestratorRule):
     unique_name = "verify_internal_registry"
     title = "Verify internal image registry is configured and available"
     supported_profiles = {"telco-base"}
-    links = ["https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-internal-image-registry"]
+    links = ["https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418482747"]
 
     def is_prerequisite_fulfilled(self) -> PrerequisiteResult:
         """
@@ -813,7 +813,7 @@ class VerifyClusterOperatorsAvailable(OrchestratorRule):
     title = "Verify all cluster operators are in available state"
     supported_profiles = {"telco-base"}
     links = [
-        "https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-cluster-operators-available",
+        "https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418418357",
     ]
 
     def run_rule(self):
@@ -926,7 +926,7 @@ class VerifyWebConsoleDisabled(OrchestratorRule):
     title = "Verify web console is disabled (edge/SNO clusters)"
     supported_profiles = {"telco-base"}
     links = [
-        "https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-web-console-disabled",
+        "https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418482772",
         "https://docs.openshift.com/container-platform/latest/web_console/disabling-web-console.html",
     ]
 
@@ -1077,7 +1077,7 @@ class VerifyNfdOperatorHealth(SubscriptionOperatorRule):
     title = "Verify NFD operator pods are healthy"
     supported_profiles = {"telco-base"}
     links = [
-        "https://github.com/RedHatInsights/incluster-checks/wiki/K8s%E2%80%90-Verify-NFD-operator-health",
+        "https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418482793",
         "https://docs.openshift.com/container-platform/4.18/hardware_enablement"
         "/psap-node-feature-discovery-operator.html",
     ]
@@ -1187,7 +1187,7 @@ class VerifyNetworkDiagnosticsDisabled(OrchestratorRule):
     title = "Verify no pods in network diagnostics namespace (edge/SNO clusters)"
     supported_profiles = {"telco-base"}
     links = [
-        "https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-network-diagnostics-disabled",
+        "https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418516222",
         "https://docs.redhat.com/en/documentation/openshift_container_platform"
         "/4.17/html/networking_operators/cluster-network-operator",
     ]
@@ -1260,7 +1260,7 @@ class VerifyAcmOperatorHealth(SubscriptionOperatorRule):
     title = "Verify ACM operator pods are healthy"
     supported_profiles = {"telco-base"}
     links = [
-        "https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-ACM-operator-health",
+        "https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418516286",
         "https://docs.redhat.com/en/documentation/red_hat_advanced_cluster_management_for_kubernetes"
         "/2.12/html/install/installing#installing-while-connected-online",
     ]
@@ -1455,7 +1455,7 @@ class VerifyFarOperatorHealth(SubscriptionOperatorRule):
     title = "Verify FAR operator pods are healthy"
     supported_profiles = {"telco-base"}
     links = [
-        "https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-FAR-operator-health",
+        "https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418450754",
         "https://docs.openshift.com/container-platform/4.18/nodes/nodes/eco-fence-agents-remediation-operator.html",
     ]
 
@@ -1594,7 +1594,7 @@ class VerifyFarContainerNonRoot(SubscriptionOperatorRule):
     title = "Verify FAR container runs as non-root user"
     supported_profiles = {"telco-base"}
     links = [
-        "https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-FAR-container-non%E2%80%90root",
+        "https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418450775",
         "https://docs.openshift.com/container-platform/4.18/nodes/pods/nodes-pods-configuring.html",
     ]
 

--- a/src/in_cluster_checks/rules/k8s/k8s_validations.py
+++ b/src/in_cluster_checks/rules/k8s/k8s_validations.py
@@ -1133,7 +1133,6 @@ class VerifyNfdPodRestartCount(SubscriptionOperatorRule):
     title = "Verify NFD pod restart count is zero"
     supported_profiles = {"telco-base"}
     links = [
-        "https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-NFD-pod-restart-count",
         "https://docs.openshift.com/container-platform/4.18/hardware_enablement"
         "/psap-node-feature-discovery-operator.html",
     ]
@@ -1396,7 +1395,7 @@ class VerifyNmoOperatorHealth(SubscriptionOperatorRule):
     title = "Verify NMO operator pods are healthy"
     supported_profiles = {"telco-base"}
     links = [
-        "https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-NMO-operator-health",
+        "https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418418378",
         "https://docs.redhat.com/en/documentation/workload_availability_for_red_hat_openshift"
         "/24.1/html/remediation_fencing_and_maintenance/node-maintenance-operator",
     ]
@@ -1516,10 +1515,7 @@ class VerifyFARControllerReplicas(OrchestratorRule):
     unique_name = "verify_far_controller_replicas"
     title = "Verify FAR controller manager has correct number of replicas"
     supported_profiles = {"telco-base"}
-    links = [
-        "https://github.com/RedHatInsights/incluster-checks/wiki/"
-        "K8s-%E2%80%90-Verify-FAR-controller-manager-has-correct-number-of-replicas"
-    ]
+    links = ["https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418516260"]
 
     FAR_NAMESPACE = "openshift-workload-availability"
     FAR_DEPLOYMENT_NAME = "fence-agents-remediation-controller-manager"

--- a/src/in_cluster_checks/rules/linux/linux_validations.py
+++ b/src/in_cluster_checks/rules/linux/linux_validations.py
@@ -234,7 +234,7 @@ class SelinuxMode(Rule):
     unique_name = "selinux_mode"
     title = "SELinux enforcing mode"
     links = [
-        "https://github.com/RedHatInsights/incluster-checks/wiki/Linux-%E2%80%90-SELinux-enforcing-mode",
+        "https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418418445",
         (
             "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/"
             "using_selinux/getting-started-with-selinux_using-selinux"
@@ -263,7 +263,7 @@ class AuditdBacklogLimit(Rule):
     unique_name = "auditd_backlog_limit"
     title = "Check auditd backlog limit usage"
     links = [
-        "https://github.com/RedHatInsights/incluster-checks/wiki/Linux-%E2%80%90-Check-auditd-backlog-limit-usage",
+        "https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418516309",
     ]
 
     BACKLOG = "backlog"

--- a/src/in_cluster_checks/rules/network/nmstate_validations.py
+++ b/src/in_cluster_checks/rules/network/nmstate_validations.py
@@ -29,8 +29,7 @@ class VerifyAllNNCPsAvailable(OrchestratorRule):
     supported_profiles = {"telco-base"}
     objective_hosts = [Objectives.ORCHESTRATOR]
     links = [
-        "https://github.com/RedHatInsights/incluster-checks/wiki/"
-        "Network-%E2%80%90-Verify-all-NodeNetworkConfigurationPolicies-are-Available",
+        "https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418418464",
     ]
 
     def is_prerequisite_fulfilled(self) -> PrerequisiteResult:

--- a/src/in_cluster_checks/rules/network/node_connectivity_validations.py
+++ b/src/in_cluster_checks/rules/network/node_connectivity_validations.py
@@ -201,7 +201,7 @@ class BondDnsServersComparison(OrchestratorRule):
     unique_name = "bond_dns_servers_comparison"
     title = "Compare bond DNS servers across hosts"
     links = [
-        "https://github.com/RedHatInsights/incluster-checks/wiki/Network-%E2%80%90-Bond-DNS-Servers-Comparison",
+        "https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418516384",
     ]
 
     def run_rule(self):

--- a/src/in_cluster_checks/rules/network/ovnk8s_validations.py
+++ b/src/in_cluster_checks/rules/network/ovnk8s_validations.py
@@ -255,7 +255,7 @@ class OvnRoutingHealthCheck(OvnDetectingNodeRuleBase):
     unique_name = "ovn_routing_health_check"
     title = "Verify OVN-learned routes are present"
     links = [
-        "https://github.com/RedHatInsights/incluster-checks/wiki/Network-%E2%80%90-OVN-Routing-Health-Check",
+        "https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418451085",
     ]
 
     def _run_ovn_rule(self) -> RuleResult:

--- a/src/in_cluster_checks/rules/network/ovs_validations.py
+++ b/src/in_cluster_checks/rules/network/ovs_validations.py
@@ -36,7 +36,7 @@ class VlanOvsAttachmentCheck(OvnDetectingNodeRuleBase):
     unique_name = "vlan_ovs_attachment_check"
     title = "Verify OVS-configured VLAN interfaces are attached to OVS bridge"
     links = [
-        "https://github.com/RedHatInsights/incluster-checks/wiki/Network-%E2%80%90-VLAN-OVS-Attachment-Check",
+        "https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418482888",
     ]
 
     def is_prerequisite_fulfilled(self) -> PrerequisiteResult:
@@ -227,7 +227,7 @@ class OvsInterfaceAndPortFound(OvnDetectingNodeRuleBase):
     unique_name = "ovs_interface_and_port_managed_by_network_manager"
     title = "Verify that ovs interface and port are managed by network manager"
     links = [
-        "https://github.com/RedHatInsights/incluster-checks/wiki/Network-%E2%80%90-OVS-Interface-And-Port-Found",
+        "https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418418487",
     ]
 
     def _run_ovn_rule(self):
@@ -279,7 +279,7 @@ class OvsPhysicalPortHealthCheck(OvnDetectingNodeRuleBase):
     unique_name = "ovs_physical_port_health_check"
     title = "Verify OVS physical port is UP and has no IP"
     links = [
-        "https://github.com/RedHatInsights/incluster-checks/wiki/Network-%E2%80%90-OVS-Physical-Port-Health-Check",
+        "https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418482997",
     ]
 
     def _run_ovn_rule(self) -> RuleResult:
@@ -395,7 +395,7 @@ class OvsBridgeInterfaceHealthCheck(OvnDetectingNodeRuleBase):
     unique_name = "ovs_bridge_interface_health_check"
     title = "Verify OVS bridge is UP with OVN link-local IP"
     links = [
-        "https://github.com/RedHatInsights/incluster-checks/wiki/Network-%E2%80%90-OVS-Bridge-Interface-Health-Check",
+        "https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418516353",
     ]
 
     def _run_ovn_rule(self) -> RuleResult:
@@ -649,7 +649,7 @@ class OvsProfileActivationCheck(OvnDetectingNodeRuleBase):
     unique_name = "ovs_profile_activation_check"
     title = "Verify OVS NetworkManager profiles are activated"
     links = [
-        "https://github.com/RedHatInsights/incluster-checks/wiki/Network-%E2%80%90-OVS-Profile-Activation-Check",
+        "https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418516326",
     ]
 
     def _run_ovn_rule(self) -> RuleResult:

--- a/src/in_cluster_checks/rules/resources_utilization/resources_utilization.py
+++ b/src/in_cluster_checks/rules/resources_utilization/resources_utilization.py
@@ -195,7 +195,7 @@ class ResourcesUtilization(OrchestratorRule):
     objective_hosts = [Objectives.ORCHESTRATOR]
     unique_name = "resources_utilization"
     title = "Resources Utilization"
-    links = ["https://github.com/RedHatInsights/incluster-checks/wiki/Resources-%E2%80%90-Resources-Utilization"]
+    links = ["https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418418514"]
 
     # Core resources always shown (supports regex patterns)
     CORE_RESOURCES = [

--- a/src/in_cluster_checks/rules/security/ca_certificate_validations.py
+++ b/src/in_cluster_checks/rules/security/ca_certificate_validations.py
@@ -38,8 +38,7 @@ class KubeletCaExpiryCheck(OrchestratorRule):
     unique_name = "kubelet_ca_expiry_check"
     title = "Check kubelet CA certificate expiry"
     links = [
-        "https://github.com/RedHatInsights/incluster-checks/wiki/"
-        "Security-%E2%80%90-Check-kubelet-CA-certificate-expiry",
+        "https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418482913",
     ]
 
     # Alert threshold: 30 days (CA rotation should have happened at ~73 days, ~292 days after creation)

--- a/src/in_cluster_checks/rules/security/node_certificate_validations.py
+++ b/src/in_cluster_checks/rules/security/node_certificate_validations.py
@@ -28,7 +28,7 @@ class NodeCertificateExpiry(Rule):
     unique_name = "node_certificate_expiry"
     title = "Verify node certificates are not expiring soon"
     links = [
-        "https://github.com/RedHatInsights/incluster-checks/wiki/Security-%E2%80%90-Node-certificate-expiry",
+        "https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418418558",
     ]
 
     # Days before expiry to start warning
@@ -259,7 +259,7 @@ class KubeletCsrHealthCheck(OrchestratorRule):
     unique_name = "kubelet_csr_health_check"
     title = "Check kubelet CSR health"
     links = [
-        "https://github.com/RedHatInsights/incluster-checks/wiki/Security-‐-Check-kubelet-CSR-health",
+        "https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418450824",
     ]
 
     def run_rule(self):

--- a/src/in_cluster_checks/rules/security/tls_certificate_validations.py
+++ b/src/in_cluster_checks/rules/security/tls_certificate_validations.py
@@ -28,7 +28,7 @@ class TlsCertificateExpiry(OrchestratorRule):
     unique_name = "all_tls_certs_are_valid"
     title = "Check if all TLS certificates don't expire in 14 days"
     links = [
-        "https://github.com/RedHatInsights/incluster-checks/wiki/Security-%E2%80%90-TLS-certificate-expiry",
+        "https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418482936",
     ]
 
     WARNING_DAYS = 14


### PR DESCRIPTION
## Ticket
https://redhat.atlassian.net/browse/PDRIVE-633

## Summary
- Replace all GitHub wiki URLs with Confluence page links across 12 rule source files (27 links total)
- Update documentation (CONTRIBUTING.md, CLAUDE.md, .coderabbit.yaml, skills) to reference Confluence as the single source of truth
- Rule documentation now lives at: [In-Cluster Checks Rules](https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418417677/In-Cluster+Checks+Rules)

## Changes
- **Rule source files** (12 files): All `links = [...]` fields now point to Confluence pages
- **CONTRIBUTING.md**: Updated wiki references to Confluence
- **.coderabbit.yaml**: Updated link validation instructions for Confluence
- **.claude/CLAUDE.md**: Updated project wiki link
- **.claude/rules/in-cluster-check.md**: Updated documentation guidelines for Confluence workflow
- **.claude/skills/**: Updated implement-rule-from-jira and create-wiki-page skills

## Testing
- All 771 tests pass
- Pre-commit checks pass
- Zero remaining GitHub wiki URLs in codebase (verified with grep)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated all rule documentation links from legacy GitHub wiki pages to the centralized Red Hat Atlassian Confluence space.
  * Refreshed the rule documentation workflow and templates to use Confluence (including required link fields and standardized page structure).
  * Updated contribution guidance to reflect Confluence-based rule documentation creation and verification.
* **Chores**
  * Adjusted link-validation guidance to properly account for Confluence documentation links and their expected structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->