### PR TITLE
Feature/verify nfd pod restart count

### DIFF
--- a/src/in_cluster_checks/domains/k8s_domain.py
+++ b/src/in_cluster_checks/domains/k8s_domain.py
@@ -26,6 +26,7 @@ from in_cluster_checks.rules.k8s.k8s_validations import (
     VerifyInternalRegistry,
     VerifyNetworkDiagnosticsDisabled,
     VerifyNfdOperatorHealth,
+    VerifyNfdPodRestartCount,
     VerifyNmoOperatorHealth,
     VerifyWebConsoleDisabled,
 )
@@ -65,6 +66,7 @@ class K8sValidationDomain(RuleDomain):
             VerifyWebConsoleDisabled,
             VerifyNetworkDiagnosticsDisabled,
             VerifyNfdOperatorHealth,
+            VerifyNfdPodRestartCount,
             VerifyAcmOperatorHealth,
             VerifyNmoOperatorHealth,
             VerifyFarOperatorHealth,

--- a/src/in_cluster_checks/rules/k8s/k8s_validations.py
+++ b/src/in_cluster_checks/rules/k8s/k8s_validations.py
@@ -1125,13 +1125,7 @@ class VerifyNfdPodRestartCount(SubscriptionOperatorRule):
 
     def run_rule(self):
         """Verify all containers in openshift-nfd pods have zero restart count."""
-        _, pods_output, _ = self.oc_api.run_oc_command(
-            "get",
-            ["pods", "-n", self.NFD_NAMESPACE, "-o", "json"],
-        )
-
-        pods_data = parse_json(pods_output, "oc get pods -n openshift-nfd -o json", "orchestrator")
-        items = pods_data.get("items", [])
+        items = self.oc_api.get_pods(namespace=self.NFD_NAMESPACE)
 
         if not items:
             return RuleResult.failed(
@@ -1141,9 +1135,10 @@ class VerifyNfdPodRestartCount(SubscriptionOperatorRule):
         pods_with_restarts = []
 
         for pod in items:
-            pod_name = pod.get("metadata", {}).get("name", "unknown")
-            container_statuses = pod.get("status", {}).get("containerStatuses", [])
-            init_container_statuses = pod.get("status", {}).get("initContainerStatuses", [])
+            pod_name = pod.name()
+            pod_dict = pod.as_dict()
+            container_statuses = pod_dict.get("status", {}).get("containerStatuses", [])
+            init_container_statuses = pod_dict.get("status", {}).get("initContainerStatuses", [])
 
             for container in container_statuses + init_container_statuses:
                 restart_count = container.get("restartCount", 0)

--- a/src/in_cluster_checks/rules/k8s/k8s_validations.py
+++ b/src/in_cluster_checks/rules/k8s/k8s_validations.py
@@ -1099,6 +1099,66 @@ class VerifyNfdOperatorHealth(SubscriptionOperatorRule):
         return RuleResult.passed()
 
 
+class VerifyNfdPodRestartCount(SubscriptionOperatorRule):
+    """Verify NFD pods have zero restart count across all containers.
+
+    A non-zero restart count indicates pod instability caused by crashes,
+    OOMKills, or configuration errors, compromising reliable node feature
+    labelling.  This rule checks that the NFD operator is installed and
+    that every container in the openshift-nfd namespace has restartCount 0.
+    """
+
+    objective_hosts = [Objectives.ORCHESTRATOR]
+    unique_name = "verify_nfd_pod_restart_count"
+    title = "Verify NFD pod restart count is zero"
+    supported_profiles = {"telco-base"}
+    links = [
+        "https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-NFD-pod-restart-count",
+        "https://docs.openshift.com/container-platform/4.18/hardware_enablement"
+        "/psap-node-feature-discovery-operator.html",
+    ]
+
+    operator_subscription_name = "nfd"
+    operator_display_name = "Node Feature Discovery"
+
+    NFD_NAMESPACE = "openshift-nfd"
+
+    def run_rule(self):
+        """Verify all containers in openshift-nfd pods have zero restart count."""
+        _, pods_output, _ = self.oc_api.run_oc_command(
+            "get",
+            ["pods", "-n", self.NFD_NAMESPACE, "-o", "json"],
+        )
+
+        pods_data = parse_json(pods_output, "oc get pods -n openshift-nfd -o json", "orchestrator")
+        items = pods_data.get("items", [])
+
+        if not items:
+            return RuleResult.failed(
+                f"No pods found in {self.NFD_NAMESPACE} namespace. NFD operator may not be fully deployed."
+            )
+
+        pods_with_restarts = []
+
+        for pod in items:
+            pod_name = pod.get("metadata", {}).get("name", "unknown")
+            container_statuses = pod.get("status", {}).get("containerStatuses", [])
+            init_container_statuses = pod.get("status", {}).get("initContainerStatuses", [])
+
+            for container in container_statuses + init_container_statuses:
+                restart_count = container.get("restartCount", 0)
+                if restart_count > 0:
+                    container_name = container.get("name", "unknown")
+                    pods_with_restarts.append(f"{pod_name}/{container_name}: restartCount={restart_count}")
+
+        if pods_with_restarts:
+            message = f"NFD pods in {self.NFD_NAMESPACE} namespace have non-zero restart counts:\n  "
+            message += "\n  ".join(pods_with_restarts)
+            return RuleResult.failed(message)
+
+        return RuleResult.passed()
+
+
 class VerifyNetworkDiagnosticsDisabled(OrchestratorRule):
     """Verify no pods exist in openshift-network-diagnostics namespace when diagnostics are disabled.
 

--- a/tests/domains/test_k8s_domain.py
+++ b/tests/domains/test_k8s_domain.py
@@ -16,6 +16,7 @@ from in_cluster_checks.rules.k8s.k8s_validations import (
     VerifyInternalRegistry,
     VerifyNetworkDiagnosticsDisabled,
     VerifyNfdOperatorHealth,
+    VerifyNfdPodRestartCount,
     VerifyNmoOperatorHealth,
     VerifyWebConsoleDisabled,
 )
@@ -32,7 +33,7 @@ def test_k8s_domain_rules():
     domain = K8sValidationDomain()
     rules = domain.get_rule_classes()
 
-    assert len(rules) == 19
+    assert len(rules) == 20
     assert AllPodsReadyAndRunning in rules
     assert NodesAreReady in rules
     assert NodesCpuAndMemoryStatus in rules
@@ -46,6 +47,7 @@ def test_k8s_domain_rules():
     assert VerifyWebConsoleDisabled in rules
     assert VerifyNetworkDiagnosticsDisabled in rules
     assert VerifyNfdOperatorHealth in rules
+    assert VerifyNfdPodRestartCount in rules
     assert VerifyAcmOperatorHealth in rules
     assert VerifyNmoOperatorHealth in rules
     assert VerifyFarOperatorHealth in rules

--- a/tests/rules/k8s/test_k8s_validations.py
+++ b/tests/rules/k8s/test_k8s_validations.py
@@ -1894,27 +1894,21 @@ class TestVerifyNfdOperatorHealth(RuleTestBase):
         RuleTestBase.test_scenario_failed(self, scenario_params, tested_object)
 
 
-def _nfd_pods_json(pods):
-    """Build a JSON response for oc get pods -n openshift-nfd -o json."""
-    return json.dumps({"items": pods})
-
-
-def _nfd_pod_item(name, container_statuses, init_container_statuses=None):
-    """Build a single pod item dict for NFD restart count tests."""
-    pod = {
-        "metadata": {"name": name, "namespace": "openshift-nfd"},
-        "status": {
-            "phase": "Running",
-            "containerStatuses": container_statuses,
-        },
-    }
+def _create_mock_nfd_restart_pod(name, container_statuses, init_container_statuses=None):
+    """Create a mock NFD pod object for restart count tests."""
+    mock_pod = Mock()
+    mock_pod.name.return_value = name
+    status = {"containerStatuses": container_statuses}
     if init_container_statuses:
-        pod["status"]["initContainerStatuses"] = init_container_statuses
-    return pod
+        status["initContainerStatuses"] = init_container_statuses
+    mock_pod.as_dict.return_value = {
+        "metadata": {"name": name, "namespace": "openshift-nfd"},
+        "status": status,
+    }
+    return mock_pod
 
 
 _NFD_RESTART_SUB_CMD = ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json"))
-_NFD_RESTART_PODS_CMD = ("get", ("pods", "-n", "openshift-nfd", "-o", "json"))
 
 
 class TestVerifyNfdPodRestartCount(RuleTestBase):
@@ -1951,23 +1945,19 @@ class TestVerifyNfdPodRestartCount(RuleTestBase):
             "NFD pods have zero restart count",
             oc_cmd_output_dict={
                 _NFD_RESTART_SUB_CMD: CmdOutput(json.dumps(_nfd_subscriptions(include_nfd=True))),
-                _NFD_RESTART_PODS_CMD: CmdOutput(
-                    _nfd_pods_json(
-                        [
-                            _nfd_pod_item(
-                                "nfd-controller-manager-abc123",
-                                [
-                                    {"name": "manager", "restartCount": 0, "ready": True},
-                                ],
-                            ),
-                            _nfd_pod_item(
-                                "nfd-worker-xyz789",
-                                [
-                                    {"name": "nfd-worker", "restartCount": 0, "ready": True},
-                                ],
-                            ),
-                        ]
-                    )
+            },
+            tested_object_mock_dict={
+                "oc_api.get_pods": Mock(
+                    return_value=[
+                        _create_mock_nfd_restart_pod(
+                            "nfd-controller-manager-abc123",
+                            [{"name": "manager", "restartCount": 0, "ready": True}],
+                        ),
+                        _create_mock_nfd_restart_pod(
+                            "nfd-worker-xyz789",
+                            [{"name": "nfd-worker", "restartCount": 0, "ready": True}],
+                        ),
+                    ]
                 ),
             },
         ),
@@ -1975,16 +1965,16 @@ class TestVerifyNfdPodRestartCount(RuleTestBase):
             "NFD pods with init containers all zero restarts",
             oc_cmd_output_dict={
                 _NFD_RESTART_SUB_CMD: CmdOutput(json.dumps(_nfd_subscriptions(include_nfd=True))),
-                _NFD_RESTART_PODS_CMD: CmdOutput(
-                    _nfd_pods_json(
-                        [
-                            _nfd_pod_item(
-                                "nfd-controller-manager-abc123",
-                                [{"name": "manager", "restartCount": 0, "ready": True}],
-                                init_container_statuses=[{"name": "init-setup", "restartCount": 0, "ready": True}],
-                            ),
-                        ]
-                    )
+            },
+            tested_object_mock_dict={
+                "oc_api.get_pods": Mock(
+                    return_value=[
+                        _create_mock_nfd_restart_pod(
+                            "nfd-controller-manager-abc123",
+                            [{"name": "manager", "restartCount": 0, "ready": True}],
+                            init_container_statuses=[{"name": "init-setup", "restartCount": 0, "ready": True}],
+                        ),
+                    ]
                 ),
             },
         ),
@@ -1995,7 +1985,9 @@ class TestVerifyNfdPodRestartCount(RuleTestBase):
             "NFD pods not found in namespace",
             oc_cmd_output_dict={
                 _NFD_RESTART_SUB_CMD: CmdOutput(json.dumps(_nfd_subscriptions(include_nfd=True))),
-                _NFD_RESTART_PODS_CMD: CmdOutput(_nfd_pods_json([])),
+            },
+            tested_object_mock_dict={
+                "oc_api.get_pods": Mock(return_value=[]),
             },
             failed_msg="No pods found in openshift-nfd namespace. NFD operator may not be fully deployed.",
         ),
@@ -2003,23 +1995,19 @@ class TestVerifyNfdPodRestartCount(RuleTestBase):
             "NFD pod has non-zero restart count",
             oc_cmd_output_dict={
                 _NFD_RESTART_SUB_CMD: CmdOutput(json.dumps(_nfd_subscriptions(include_nfd=True))),
-                _NFD_RESTART_PODS_CMD: CmdOutput(
-                    _nfd_pods_json(
-                        [
-                            _nfd_pod_item(
-                                "nfd-controller-manager-abc123",
-                                [
-                                    {"name": "manager", "restartCount": 0, "ready": True},
-                                ],
-                            ),
-                            _nfd_pod_item(
-                                "nfd-worker-xyz789",
-                                [
-                                    {"name": "nfd-worker", "restartCount": 3, "ready": True},
-                                ],
-                            ),
-                        ]
-                    )
+            },
+            tested_object_mock_dict={
+                "oc_api.get_pods": Mock(
+                    return_value=[
+                        _create_mock_nfd_restart_pod(
+                            "nfd-controller-manager-abc123",
+                            [{"name": "manager", "restartCount": 0, "ready": True}],
+                        ),
+                        _create_mock_nfd_restart_pod(
+                            "nfd-worker-xyz789",
+                            [{"name": "nfd-worker", "restartCount": 3, "ready": True}],
+                        ),
+                    ]
                 ),
             },
             failed_msg="NFD pods in openshift-nfd namespace have non-zero restart counts:\n"
@@ -2029,23 +2017,19 @@ class TestVerifyNfdPodRestartCount(RuleTestBase):
             "Multiple NFD pods with restarts across containers",
             oc_cmd_output_dict={
                 _NFD_RESTART_SUB_CMD: CmdOutput(json.dumps(_nfd_subscriptions(include_nfd=True))),
-                _NFD_RESTART_PODS_CMD: CmdOutput(
-                    _nfd_pods_json(
-                        [
-                            _nfd_pod_item(
-                                "nfd-controller-manager-abc123",
-                                [
-                                    {"name": "manager", "restartCount": 2, "ready": True},
-                                ],
-                            ),
-                            _nfd_pod_item(
-                                "nfd-worker-xyz789",
-                                [
-                                    {"name": "nfd-worker", "restartCount": 5, "ready": True},
-                                ],
-                            ),
-                        ]
-                    )
+            },
+            tested_object_mock_dict={
+                "oc_api.get_pods": Mock(
+                    return_value=[
+                        _create_mock_nfd_restart_pod(
+                            "nfd-controller-manager-abc123",
+                            [{"name": "manager", "restartCount": 2, "ready": True}],
+                        ),
+                        _create_mock_nfd_restart_pod(
+                            "nfd-worker-xyz789",
+                            [{"name": "nfd-worker", "restartCount": 5, "ready": True}],
+                        ),
+                    ]
                 ),
             },
             failed_msg="NFD pods in openshift-nfd namespace have non-zero restart counts:\n"
@@ -2056,16 +2040,16 @@ class TestVerifyNfdPodRestartCount(RuleTestBase):
             "NFD init container has non-zero restart count",
             oc_cmd_output_dict={
                 _NFD_RESTART_SUB_CMD: CmdOutput(json.dumps(_nfd_subscriptions(include_nfd=True))),
-                _NFD_RESTART_PODS_CMD: CmdOutput(
-                    _nfd_pods_json(
-                        [
-                            _nfd_pod_item(
-                                "nfd-controller-manager-abc123",
-                                [{"name": "manager", "restartCount": 0, "ready": True}],
-                                init_container_statuses=[{"name": "init-setup", "restartCount": 1, "ready": True}],
-                            ),
-                        ]
-                    )
+            },
+            tested_object_mock_dict={
+                "oc_api.get_pods": Mock(
+                    return_value=[
+                        _create_mock_nfd_restart_pod(
+                            "nfd-controller-manager-abc123",
+                            [{"name": "manager", "restartCount": 0, "ready": True}],
+                            init_container_statuses=[{"name": "init-setup", "restartCount": 1, "ready": True}],
+                        ),
+                    ]
                 ),
             },
             failed_msg="NFD pods in openshift-nfd namespace have non-zero restart counts:\n"

--- a/tests/rules/k8s/test_k8s_validations.py
+++ b/tests/rules/k8s/test_k8s_validations.py
@@ -27,6 +27,7 @@ from in_cluster_checks.rules.k8s.k8s_validations import (
     VerifyInternalRegistry,
     VerifyNetworkDiagnosticsDisabled,
     VerifyNfdOperatorHealth,
+    VerifyNfdPodRestartCount,
     VerifyNmoOperatorHealth,
     VerifyWebConsoleDisabled,
 )
@@ -1890,6 +1891,206 @@ class TestVerifyNfdOperatorHealth(RuleTestBase):
     @pytest.mark.parametrize("scenario_params", scenario_failed)
     def test_scenario_failed(self, scenario_params, tested_object):
         """Test that rule fails when NFD pods are unhealthy or missing."""
+        RuleTestBase.test_scenario_failed(self, scenario_params, tested_object)
+
+
+def _nfd_pods_json(pods):
+    """Build a JSON response for oc get pods -n openshift-nfd -o json."""
+    return json.dumps({"items": pods})
+
+
+def _nfd_pod_item(name, container_statuses, init_container_statuses=None):
+    """Build a single pod item dict for NFD restart count tests."""
+    pod = {
+        "metadata": {"name": name, "namespace": "openshift-nfd"},
+        "status": {
+            "phase": "Running",
+            "containerStatuses": container_statuses,
+        },
+    }
+    if init_container_statuses:
+        pod["status"]["initContainerStatuses"] = init_container_statuses
+    return pod
+
+
+_NFD_RESTART_SUB_CMD = ("get", ("subscriptions.operators.coreos.com", "--all-namespaces", "-o", "json"))
+_NFD_RESTART_PODS_CMD = ("get", ("pods", "-n", "openshift-nfd", "-o", "json"))
+
+
+class TestVerifyNfdPodRestartCount(RuleTestBase):
+    """Test VerifyNfdPodRestartCount rule."""
+
+    tested_type = VerifyNfdPodRestartCount
+
+    scenario_prerequisite_fulfilled = [
+        RuleScenarioParams(
+            "NFD operator subscription found",
+            oc_cmd_output_dict={
+                _NFD_RESTART_SUB_CMD: CmdOutput(json.dumps(_nfd_subscriptions(include_nfd=True))),
+            },
+        ),
+    ]
+
+    scenario_prerequisite_not_fulfilled = [
+        RuleScenarioParams(
+            "NFD operator subscription not found",
+            oc_cmd_output_dict={
+                _NFD_RESTART_SUB_CMD: CmdOutput(json.dumps(_nfd_subscriptions(include_nfd=False))),
+            },
+        ),
+        RuleScenarioParams(
+            "no subscriptions exist in cluster",
+            oc_cmd_output_dict={
+                _NFD_RESTART_SUB_CMD: CmdOutput(json.dumps({"items": []})),
+            },
+        ),
+    ]
+
+    scenario_passed = [
+        RuleScenarioParams(
+            "NFD pods have zero restart count",
+            oc_cmd_output_dict={
+                _NFD_RESTART_SUB_CMD: CmdOutput(json.dumps(_nfd_subscriptions(include_nfd=True))),
+                _NFD_RESTART_PODS_CMD: CmdOutput(
+                    _nfd_pods_json(
+                        [
+                            _nfd_pod_item(
+                                "nfd-controller-manager-abc123",
+                                [
+                                    {"name": "manager", "restartCount": 0, "ready": True},
+                                ],
+                            ),
+                            _nfd_pod_item(
+                                "nfd-worker-xyz789",
+                                [
+                                    {"name": "nfd-worker", "restartCount": 0, "ready": True},
+                                ],
+                            ),
+                        ]
+                    )
+                ),
+            },
+        ),
+        RuleScenarioParams(
+            "NFD pods with init containers all zero restarts",
+            oc_cmd_output_dict={
+                _NFD_RESTART_SUB_CMD: CmdOutput(json.dumps(_nfd_subscriptions(include_nfd=True))),
+                _NFD_RESTART_PODS_CMD: CmdOutput(
+                    _nfd_pods_json(
+                        [
+                            _nfd_pod_item(
+                                "nfd-controller-manager-abc123",
+                                [{"name": "manager", "restartCount": 0, "ready": True}],
+                                init_container_statuses=[{"name": "init-setup", "restartCount": 0, "ready": True}],
+                            ),
+                        ]
+                    )
+                ),
+            },
+        ),
+    ]
+
+    scenario_failed = [
+        RuleScenarioParams(
+            "NFD pods not found in namespace",
+            oc_cmd_output_dict={
+                _NFD_RESTART_SUB_CMD: CmdOutput(json.dumps(_nfd_subscriptions(include_nfd=True))),
+                _NFD_RESTART_PODS_CMD: CmdOutput(_nfd_pods_json([])),
+            },
+            failed_msg="No pods found in openshift-nfd namespace. NFD operator may not be fully deployed.",
+        ),
+        RuleScenarioParams(
+            "NFD pod has non-zero restart count",
+            oc_cmd_output_dict={
+                _NFD_RESTART_SUB_CMD: CmdOutput(json.dumps(_nfd_subscriptions(include_nfd=True))),
+                _NFD_RESTART_PODS_CMD: CmdOutput(
+                    _nfd_pods_json(
+                        [
+                            _nfd_pod_item(
+                                "nfd-controller-manager-abc123",
+                                [
+                                    {"name": "manager", "restartCount": 0, "ready": True},
+                                ],
+                            ),
+                            _nfd_pod_item(
+                                "nfd-worker-xyz789",
+                                [
+                                    {"name": "nfd-worker", "restartCount": 3, "ready": True},
+                                ],
+                            ),
+                        ]
+                    )
+                ),
+            },
+            failed_msg="NFD pods in openshift-nfd namespace have non-zero restart counts:\n"
+            "  nfd-worker-xyz789/nfd-worker: restartCount=3",
+        ),
+        RuleScenarioParams(
+            "Multiple NFD pods with restarts across containers",
+            oc_cmd_output_dict={
+                _NFD_RESTART_SUB_CMD: CmdOutput(json.dumps(_nfd_subscriptions(include_nfd=True))),
+                _NFD_RESTART_PODS_CMD: CmdOutput(
+                    _nfd_pods_json(
+                        [
+                            _nfd_pod_item(
+                                "nfd-controller-manager-abc123",
+                                [
+                                    {"name": "manager", "restartCount": 2, "ready": True},
+                                ],
+                            ),
+                            _nfd_pod_item(
+                                "nfd-worker-xyz789",
+                                [
+                                    {"name": "nfd-worker", "restartCount": 5, "ready": True},
+                                ],
+                            ),
+                        ]
+                    )
+                ),
+            },
+            failed_msg="NFD pods in openshift-nfd namespace have non-zero restart counts:\n"
+            "  nfd-controller-manager-abc123/manager: restartCount=2\n"
+            "  nfd-worker-xyz789/nfd-worker: restartCount=5",
+        ),
+        RuleScenarioParams(
+            "NFD init container has non-zero restart count",
+            oc_cmd_output_dict={
+                _NFD_RESTART_SUB_CMD: CmdOutput(json.dumps(_nfd_subscriptions(include_nfd=True))),
+                _NFD_RESTART_PODS_CMD: CmdOutput(
+                    _nfd_pods_json(
+                        [
+                            _nfd_pod_item(
+                                "nfd-controller-manager-abc123",
+                                [{"name": "manager", "restartCount": 0, "ready": True}],
+                                init_container_statuses=[{"name": "init-setup", "restartCount": 1, "ready": True}],
+                            ),
+                        ]
+                    )
+                ),
+            },
+            failed_msg="NFD pods in openshift-nfd namespace have non-zero restart counts:\n"
+            "  nfd-controller-manager-abc123/init-setup: restartCount=1",
+        ),
+    ]
+
+    @pytest.mark.parametrize("scenario_params", scenario_prerequisite_fulfilled)
+    def test_prerequisite_fulfilled(self, scenario_params, tested_object):
+        """Test that prerequisite is met when NFD operator is installed."""
+        RuleTestBase.test_prerequisite_fulfilled(self, scenario_params, tested_object)
+
+    @pytest.mark.parametrize("scenario_params", scenario_prerequisite_not_fulfilled)
+    def test_prerequisite_not_fulfilled(self, scenario_params, tested_object):
+        """Test that prerequisite is not met when NFD operator is not installed."""
+        RuleTestBase.test_prerequisite_not_fulfilled(self, scenario_params, tested_object)
+
+    @pytest.mark.parametrize("scenario_params", scenario_passed)
+    def test_scenario_passed(self, scenario_params, tested_object):
+        """Test that rule passes when all NFD pods have zero restart count."""
+        RuleTestBase.test_scenario_passed(self, scenario_params, tested_object)
+
+    @pytest.mark.parametrize("scenario_params", scenario_failed)
+    def test_scenario_failed(self, scenario_params, tested_object):
+        """Test that rule fails when NFD pods have non-zero restart counts."""
         RuleTestBase.test_scenario_failed(self, scenario_params, tested_object)
 
 


### PR DESCRIPTION
## Summary
- Add `VerifyNfdPodRestartCount` rule that validates all NFD pods in `openshift-nfd` namespace have zero restart count across containers and init containers
- Uses `SubscriptionOperatorRule` base class for prerequisite check (NFD operator installed via Subscription)
- Ref: Quarterly objective - NFD stability validation

## Test plan
- [x] `pre-commit run --all-files` passes
- [x] `pytest tests/rules/k8s/test_k8s_validations.py::TestVerifyNfdPodRestartCount -v` passes
- [x] `pytest tests/domains/test_k8s_domain.py -v` passes
- [x] `python3 -m black --check --line-length=120` on all changed files
- [x] Tested on real cluster: `--debug-rule verify_nfd_pod_restart_count --profile telco-base`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a health-check that monitors Node Feature Discovery (NFD) pod restart activity (including init containers) and reports any pod/container with non-zero restarts.

* **Tests**
  * Added end-to-end tests covering subscription presence, success when all restart counts are zero, and failures for missing pods or any non-zero container/init-container restart counts, asserting reported messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->