### PR TITLE
feat(PDRIVE-597): include deployment conditions in CheckDeploymentsReplicaStatus error messages

### DIFF
--- a/src/in_cluster_checks/rules/k8s/k8s_validations.py
+++ b/src/in_cluster_checks/rules/k8s/k8s_validations.py
@@ -484,21 +484,25 @@ class CheckDeploymentsReplicaStatus(OrchestratorRule):
             available_replicas = int(status.get("availableReplicas", 0))
             updated_replicas = int(status.get("updatedReplicas", 0))
 
+            # Get deployment conditions for diagnostic info
+            conditions = status.get("conditions") or []
+            condition_info = self._format_failed_conditions(conditions)
+
             # Check if ready replicas match desired
             if ready_replicas != desired_replicas:
                 problematic_deployments.append(
-                    f"{namespace}/{name} - Desired: {desired_replicas}, Ready: {ready_replicas}"
+                    f"{namespace}/{name} - Desired: {desired_replicas}, Ready: {ready_replicas}{condition_info}"
                 )
             # Check if available replicas match desired
             elif available_replicas != desired_replicas:
                 problematic_deployments.append(
-                    f"{namespace}/{name} - Desired: {desired_replicas}, Available: {available_replicas}"
+                    f"{namespace}/{name} - Desired: {desired_replicas}, Available: {available_replicas}{condition_info}"
                 )
             # Check if updated replicas match desired (rollout not complete)
             elif updated_replicas != desired_replicas:
                 problematic_deployments.append(
                     f"{namespace}/{name} - Desired: {desired_replicas}, Updated: {updated_replicas} "
-                    "(rollout in progress)"
+                    f"(rollout in progress){condition_info}"
                 )
 
         if problematic_deployments:
@@ -507,6 +511,31 @@ class CheckDeploymentsReplicaStatus(OrchestratorRule):
             return RuleResult.failed(message)
 
         return RuleResult.passed()
+
+    @staticmethod
+    def _format_failed_conditions(conditions: list[dict[str, object]] | None) -> str:
+        """Format deployment conditions with status=False for inclusion in error messages.
+
+        Args:
+            conditions: List of deployment condition dictionaries, or None
+
+        Returns:
+            String with formatted conditions (e.g., " [Reason: Message]"),
+            or empty string if no failed conditions
+        """
+        if not conditions:
+            return ""
+
+        condition_parts = []
+        for condition in conditions:
+            if condition.get("status") == "False":
+                reason = condition.get("reason", "Unknown")
+                message = condition.get("message", "")
+                condition_parts.append(f"[{reason}: {message}]")
+
+        if condition_parts:
+            return " " + " ".join(condition_parts)
+        return ""
 
 
 # Checking statefulsets is important as they are used for critical components like alerts and monitoring.

--- a/tests/rules/k8s/test_k8s_validations.py
+++ b/tests/rules/k8s/test_k8s_validations.py
@@ -946,6 +946,112 @@ class TestCheckDeploymentsReplicaStatus(RuleTestBase):
             tested_object_mock_dict={"oc_api.get_all_deployments": Mock(return_value=[])},
             failed_msg="No deployments found in cluster",
         ),
+        RuleScenarioParams(
+            "deployment with failed conditions shows diagnostic info",
+            tested_object_mock_dict={
+                "oc_api.get_all_deployments": Mock(
+                    return_value=[
+                        create_mock_deployment(
+                            "assisted-chat",
+                            "assisted-chat",
+                            spec={"replicas": 1},
+                            status={
+                                "replicas": 1,
+                                "readyReplicas": 0,
+                                "availableReplicas": 0,
+                                "updatedReplicas": 1,
+                                "conditions": [
+                                    {
+                                        "type": "Available",
+                                        "status": "False",
+                                        "reason": "MinimumReplicasUnavailable",
+                                        "message": "Deployment does not have minimum availability.",
+                                    },
+                                    {
+                                        "type": "Progressing",
+                                        "status": "False",
+                                        "reason": "ProgressDeadlineExceeded",
+                                        "message": 'ReplicaSet "assisted-chat-5c78bb9bf" has timed out progressing.',
+                                    },
+                                ],
+                            },
+                        ),
+                    ]
+                )
+            },
+            failed_msg="Following deployments have replica count issues:\n"
+            "  assisted-chat/assisted-chat - Desired: 1, Ready: 0 "
+            "[MinimumReplicasUnavailable: Deployment does not have minimum availability.] "
+            "[ProgressDeadlineExceeded: ReplicaSet "
+            '"assisted-chat-5c78bb9bf" has timed out progressing.]',
+        ),
+        RuleScenarioParams(
+            "deployment with partial failure and conditions",
+            tested_object_mock_dict={
+                "oc_api.get_all_deployments": Mock(
+                    return_value=[
+                        create_mock_deployment(
+                            "partial-failure",
+                            "prod-ns",
+                            spec={"replicas": 5},
+                            status={
+                                "replicas": 5,
+                                "readyReplicas": 2,
+                                "availableReplicas": 2,
+                                "updatedReplicas": 5,
+                                "conditions": [
+                                    {
+                                        "type": "Available",
+                                        "status": "False",
+                                        "reason": "MinimumReplicasUnavailable",
+                                        "message": "Deployment does not have minimum availability.",
+                                    },
+                                ],
+                            },
+                        ),
+                    ]
+                )
+            },
+            failed_msg="Following deployments have replica count issues:\n"
+            "  prod-ns/partial-failure - Desired: 5, Ready: 2 "
+            "[MinimumReplicasUnavailable: Deployment does not have minimum availability.]",
+        ),
+        RuleScenarioParams(
+            "deployment with conditions all passing still fails on replica mismatch",
+            tested_object_mock_dict={
+                "oc_api.get_all_deployments": Mock(
+                    return_value=[
+                        create_mock_deployment(
+                            "scaling-deployment",
+                            "default",
+                            spec={"replicas": 3},
+                            status={
+                                "replicas": 3,
+                                "readyReplicas": 1,
+                                "availableReplicas": 1,
+                                "updatedReplicas": 3,
+                                "conditions": [
+                                    {
+                                        "type": "Available",
+                                        "status": "True",
+                                        "reason": "MinimumReplicasAvailable",
+                                        "message": "Deployment has minimum availability.",
+                                    },
+                                    {
+                                        "type": "Progressing",
+                                        "status": "True",
+                                        "reason": "NewReplicaSetAvailable",
+                                        "message": 'ReplicaSet "scaling-deployment-abc" has successfully progressed.',
+                                    },
+                                ],
+                            },
+                        ),
+                    ]
+                )
+            },
+            failed_msg="Following deployments have replica count issues:\n"
+            "  default/scaling-deployment - Desired: 3, Ready: 1",
+        ),
     ]
 
     @pytest.mark.parametrize("scenario_params", scenario_passed)


### PR DESCRIPTION
## Summary

Enhances the `CheckDeploymentsReplicaStatus` rule to include Kubernetes deployment conditions in error messages, providing actionable diagnostic information when replica counts don't match the desired state.

## Jira Ticket

https://redhat.atlassian.net/browse/PDRIVE-597

## Changes

- Added `_format_failed_conditions()` helper method to extract and format deployment conditions with `status=False`
- Modified error messages to include condition reason and message (e.g., `[ProgressDeadlineExceeded: ReplicaSet "..." has timed out]`)
- Added comprehensive test coverage for deployments with failed conditions

## Benefits

✅ **Faster diagnosis** - Users immediately see WHY deployments are failing  
✅ **Actionable information** - Condition messages point to specific issues (e.g., which ReplicaSet timed out)  
✅ **Better prioritization** - Distinguish transient rollouts from permanent failures  
✅ **Backward compatible** - Only adds info when conditions exist

## Example

**Before:**
```
Following deployments have replica count issues:
  assisted-chat/assisted-chat - Desired: 1, Ready: 0
```

**After:**
```
Following deployments have replica count issues:
  assisted-chat/assisted-chat - Desired: 1, Ready: 0 [MinimumReplicasUnavailable: Deployment does not have minimum availability.] [ProgressDeadlineExceeded: ReplicaSet "assisted-chat-5c78bb9bf" has timed out progressing.]
```

## Testing

- ✅ All 816 tests pass
- ✅ Coverage: 88%
- ✅ New test scenarios verify the enhancement works correctly with:
  - Deployments with multiple failed conditions
  - Deployments with partial failure and conditions
  - Deployments with passing conditions but replica mismatch (backward compatibility)

## Files Modified

- `src/in_cluster_checks/rules/k8s/k8s_validations.py` - Rule enhancement
- `tests/rules/k8s/test_k8s_validations.py` - Test coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved Kubernetes deployment replica-mismatch errors by appending a concise, condition-derived diagnostic suffix to “Desired vs Ready/Available/Updated” failures (only when relevant conditions indicate failure).

* **Tests**
  * Added coverage to confirm failure messages include specific condition details (e.g., unavailable replicas and rollout deadline issues) and that diagnostic brackets are omitted when conditions are all passing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->