### PR TITLE
chore: bump version to 0.1.26

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "in-cluster-checks"
-version = "0.1.25"
+version = "0.1.26"
 description = "Generic framework for running health validation rules on OpenShift cluster nodes"
 readme = "README.md"
 license = "BSD-3-Clause"


### PR DESCRIPTION
Automated version bump to 0.1.26 from Pendrive release pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version number updated to 0.1.26.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->