### PR TITLE
fix(PDRIVE-640): resolve CodeQL code scanning alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
     name: Pre-commit checks

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build distribution

--- a/src/in_cluster_checks/core/executor_factory.py
+++ b/src/in_cluster_checks/core/executor_factory.py
@@ -119,11 +119,8 @@ class NodeExecutorFactory:
         roles = []
         node_labels = node_dict.get("metadata", {}).get("labels", {})
 
-        # Extract role labels from node-role.kubernetes.io/* labels
-        # Same pattern as HC
-        role_labels = [
-            key.split("node-role.kubernetes.io/")[1] for key in node_labels.keys() if "node-role.kubernetes.io/" in key
-        ]
+        role_prefix = "node-role.kubernetes.io/"
+        role_labels = [key.removeprefix(role_prefix) for key in node_labels.keys() if key.startswith(role_prefix)]
 
         # Map role labels to Objectives
         for role_label in role_labels:
@@ -149,10 +146,8 @@ class NodeExecutorFactory:
         """
         node_labels = node_dict.get("metadata", {}).get("labels", {})
 
-        # Extract role labels from node-role.kubernetes.io/* labels
-        role_labels = [
-            key.split("node-role.kubernetes.io/")[1] for key in node_labels.keys() if "node-role.kubernetes.io/" in key
-        ]
+        role_prefix = "node-role.kubernetes.io/"
+        role_labels = [key.removeprefix(role_prefix) for key in node_labels.keys() if key.startswith(role_prefix)]
 
         return ",".join(sorted(role_labels)) if role_labels else ""
 


### PR DESCRIPTION
## Summary

Resolves all 6 open [CodeQL code scanning alerts](https://github.com/RedHatInsights/incluster-checks/security/code-scanning).

**Jira**: [PDRIVE-640](https://redhat.atlassian.net/browse/PDRIVE-640)

### High Severity (2 alerts) — Incomplete URL substring sanitization

- **executor_factory.py**: Replaced `"node-role.kubernetes.io/" in key` + `split()[1]` with `key.startswith(...)` + `removeprefix()` for node role label extraction. This ensures the prefix is matched at position 0, not anywhere in the string.

### Medium Severity (4 alerts) — Workflow missing permissions

- **ci.yml**: Added top-level `permissions: contents: read` (covers all 3 jobs: pre-commit, test, lint)
- **publish.yml**: Added top-level `permissions: contents: read` (the `publish-to-pypi` job already overrides with `id-token: write`)

## Test plan

- [x] All 813 unit tests pass
- [ ] Verify CodeQL alerts are resolved after merge

[PDRIVE-640]: https://redhat.atlassian.net/browse/PDRIVE-640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security by explicitly restricting workflow token permissions in CI and deployment pipelines.

* **Bug Fixes**
  * Improved node role label detection to be more precise and strict, ensuring only valid role identifiers are processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->