### PR TITLE
feat: add --light-run CLI flag to exclude heavy rules

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -50,6 +50,10 @@ pre-commit run --all-files          # Code quality checks
 # Run all checks (output saved to ./cluster-checks.json)
 in-cluster-checks --output ./cluster-checks.json
 
+# Run only lightweight rules (excludes resource-intensive rules marked with include_in_light_run=False)
+# Currently excludes: hw_fw_details domain (hardware/firmware inventory collection)
+in-cluster-checks --light-run --output ./quick-check.json
+
 # Run with debug logging
 in-cluster-checks --log-level DEBUG
 
@@ -59,7 +63,8 @@ in-cluster-checks --debug-rule "is_disk_space_sufficient"
 # List available domains
 in-cluster-checks --list-domains
 
-# List all available rules
+# List all available rules 
+# Rules marked [full-run-only] are excluded from --light-run (resource-intensive rules)
 in-cluster-checks --list-rules
 ```
 

--- a/.claude/rules/in-cluster-check.md
+++ b/.claude/rules/in-cluster-check.md
@@ -74,6 +74,20 @@ All rules use the `Status` enum (`utils/enums.py`):
       # ...
   ```
 
+**Light-Run Mode:**
+- **Use `include_in_light_run`** to mark resource-intensive rules that should be excluded from quick health checks
+- Set `include_in_light_run = False` on rules that perform resource-intensive operations (e.g., hardware/firmware inventory collection)
+- Default is `True` (included in light runs) — only set to `False` for truly resource-intensive rules
+- When `--light-run` CLI flag is used, rules with `include_in_light_run = False` are automatically excluded
+- Example:
+  ```python
+  class HardwareDetailsRule(OrchestratorRule):
+      objective_hosts = [Objectives.ORCHESTRATOR]
+      unique_name = "hardware_details"
+      include_in_light_run = False  # Exclude from --light-run
+      # ...
+  ```
+
 **Logging:**
 - NEVER use `self.logger` in rules. Return error messages via `RuleResult.failed()` or `RuleResult.warning()` instead. The framework handles logging automatically.
 

--- a/examples/custom_configuration.py
+++ b/examples/custom_configuration.py
@@ -19,6 +19,8 @@ def main():
         debug_rule_name="",
         # Set maximum concurrent workers (default: 50)
         max_workers=75,
+        # Run only lightweight rules (default: False)
+        light_run=False,
     )
 
     # Define output path

--- a/src/in_cluster_checks/cli.py
+++ b/src/in_cluster_checks/cli.py
@@ -104,6 +104,9 @@ def list_rules(runner: InClusterCheckRunner) -> None:
             for rule_class in sorted(rules, key=lambda r: r.get_unique_name_classmethod() or ""):
                 rule_name = rule_class.get_unique_name_classmethod()
                 if rule_name:
+                    # Check if rule is excluded from light runs
+                    light_run_indicator = "" if rule_class.include_in_light_run else " [full-run-only]"
+
                     # Try to get title if available
                     title = "No description"
                     try:
@@ -113,7 +116,7 @@ def list_rules(runner: InClusterCheckRunner) -> None:
                     except Exception:
                         pass
 
-                    print(f"  - {rule_name}")
+                    print(f"  - {rule_name}{light_run_indicator}")
                     if title != "No description":
                         print(f"      {title}")
                     total_rules += 1
@@ -178,6 +181,12 @@ def main() -> None:
         help="List all available rules by domain and exit",
     )
 
+    parser.add_argument(
+        "--light-run",
+        action="store_true",
+        help="Run only lightweight rules (excludes resource-intensive rules like hardware/firmware details)",
+    )
+
     # Get available profiles for the argument choices
     try:
         available_profiles = ProfileLoader.get_available_profiles()
@@ -223,6 +232,7 @@ def main() -> None:
             debug_rule_name=args.debug_rule,
             namespace=args.namespace,
             max_workers=50,
+            light_run=args.light_run,
         )
 
         # Handle list commands

--- a/src/in_cluster_checks/core/domain.py
+++ b/src/in_cluster_checks/core/domain.py
@@ -59,6 +59,23 @@ class RuleDomain(abc.ABC):
         """
         raise NotImplementedError(f"get_rule_classes() must be implemented in {self.__class__.__name__}")
 
+    def _filter_rules_for_light_run(self, rule_classes: List[type]) -> List[type]:
+        """
+        Filter rules based on light_run mode.
+
+        Args:
+            rule_classes: List of Rule classes to filter
+
+        Returns:
+            Filtered list based on light_run mode:
+            - Normal mode (light_run=False): Returns all rules
+            - Light mode (light_run=True): Returns only rules with include_in_light_run=True
+        """
+        if not global_config.light_run:
+            return rule_classes
+
+        return [rule_class for rule_class in rule_classes if rule_class.include_in_light_run]
+
     def verify(self, host_executors_dict: Dict[str, Any]) -> Dict[str, Any]:
         """
         Run all rules in this domain using HC's parallel execution pattern.
@@ -75,7 +92,7 @@ class RuleDomain(abc.ABC):
         """
         self.logger.info(f"Running domain: {self.domain_name()}")
 
-        rule_classes = self.get_rule_classes()
+        rule_classes = self._filter_rules_for_light_run(self.get_rule_classes())
         self.logger.debug(f"Domain has {len(rule_classes)} rule classes")
 
         printer = StructedPrinter()

--- a/src/in_cluster_checks/core/rule.py
+++ b/src/in_cluster_checks/core/rule.py
@@ -32,6 +32,8 @@ class Rule(Operator):
     - objective_hosts: List of Objectives where this rule should run (required)
     - links: List of reference URLs (optional)
               Format: ["https://docs.example.com", "https://access.redhat.com/..."]
+    - include_in_light_run: Whether to include this rule in light-run mode (default: True)
+              Set to False for resource-intensive rules that should only run in full mode
     """
 
     PREREQUISITES_CHECKS = []
@@ -40,6 +42,7 @@ class Rule(Operator):
     title = None
     links = None
     supported_profiles = {"general"}
+    include_in_light_run: bool = True
 
     def __init__(self, host_executor, node_executors=None):
         """

--- a/src/in_cluster_checks/global_config.py
+++ b/src/in_cluster_checks/global_config.py
@@ -10,6 +10,7 @@ max_workers: int = 50
 profiles_hierarchy = Profiles()
 active_profile: str = ""  # Must be set via set_config() - no default
 namespace: str = "default"
+light_run: bool = False
 
 
 def set_config(
@@ -18,6 +19,7 @@ def set_config(
     debug_rule_name_val: str = "",
     max_workers_val: int = 50,
     namespace_val: str = "default",
+    light_run_val: bool = False,
 ):
     """Update global configuration values.
 
@@ -27,11 +29,12 @@ def set_config(
         debug_rule_name_val: Name of specific rule to run in debug mode
         max_workers_val: Maximum number of concurrent workers
         namespace_val: Namespace for debug pods (default: "default")
+        light_run_val: Enable light-run mode (exclude resource-intensive rules, default: False)
 
     Raises:
         ValueError: If active_profile_val is not provided or is empty
     """
-    global debug_rule_flag, debug_rule_name, max_workers, profiles_hierarchy, active_profile, namespace
+    global debug_rule_flag, debug_rule_name, max_workers, profiles_hierarchy, active_profile, namespace, light_run
 
     # Validate active_profile is set
     if not active_profile_val:
@@ -42,5 +45,6 @@ def set_config(
     max_workers = max_workers_val
     active_profile = active_profile_val
     namespace = namespace_val
+    light_run = light_run_val
     profiles_hierarchy = Profiles()
     ProfileLoader.load(profiles_hierarchy)

--- a/src/in_cluster_checks/rules/hw_fw_details/firmware_rule.py
+++ b/src/in_cluster_checks/rules/hw_fw_details/firmware_rule.py
@@ -28,6 +28,7 @@ class FirmwareDetailsRule(HwFwRule):
 
     unique_name = "firmware_details"
     title = "Firmware Details"
+    include_in_light_run = False
 
     def get_data_collectors(self) -> List[type]:
         """Get list of firmware/BIOS data collectors."""

--- a/src/in_cluster_checks/rules/hw_fw_details/hardware_rule.py
+++ b/src/in_cluster_checks/rules/hw_fw_details/hardware_rule.py
@@ -54,6 +54,7 @@ class HardwareDetailsRule(HwFwRule):
 
     unique_name = "hardware_details"
     title = "Hardware Details"
+    include_in_light_run = False
 
     def get_data_collectors(self) -> List[type]:
         """Get list of hardware data collectors."""

--- a/src/in_cluster_checks/runner.py
+++ b/src/in_cluster_checks/runner.py
@@ -39,6 +39,7 @@ class InClusterCheckRunner:
         namespace: str = "default",
         max_workers: int = 50,
         domain_package: str = "in_cluster_checks.domains",
+        light_run: bool = False,
     ):
         """
         Initialize runner.
@@ -50,6 +51,7 @@ class InClusterCheckRunner:
             namespace: Namespace for debug pods (default: "default")
             max_workers: Maximum number of concurrent workers for parallel execution
             domain_package: Python package path for domain discovery
+            light_run: Enable light-run mode (exclude resource-intensive rules, default: False)
         """
         self.logger = logging.getLogger(__name__)
         self.domain_package = domain_package
@@ -63,6 +65,7 @@ class InClusterCheckRunner:
             debug_rule_name_val=debug_rule_name,
             namespace_val=namespace,
             max_workers_val=max_workers,
+            light_run_val=light_run,
         )
 
     def discover_domains(self) -> Dict[str, type]:
@@ -114,7 +117,8 @@ class InClusterCheckRunner:
         rule_component_map = {}
 
         for domain_name, domain in domains.items():
-            for rule_class in domain.get_rule_classes():
+            rule_classes = domain._filter_rules_for_light_run(domain.get_rule_classes())
+            for rule_class in rule_classes:
                 # Get unique name without instantiation (uses class variable if available)
                 rule_name = rule_class.get_unique_name_classmethod()
                 if rule_name:

--- a/tests/core/test_domain.py
+++ b/tests/core/test_domain.py
@@ -22,6 +22,9 @@ from profiles.profile import Profiles
 @pytest.fixture(autouse=True)
 def setup_profiles():
     """Set up profiles for all tests in this module."""
+    # Reset light_run before test
+    global_config.light_run = False
+
     # Create minimal profile configuration
     profile = Profiles()
     profile['general'] = {'general'}  # Minimal profile: general includes only itself
@@ -35,6 +38,7 @@ def setup_profiles():
     # Cleanup
     global_config.profiles_hierarchy = Profiles()
     global_config.active_profile = ""
+    global_config.light_run = False
 
 
 class MockRule(Rule):
@@ -356,4 +360,128 @@ class TestRuleDomain:
 
         # Should return empty list (no executor with ONE_WORKER role)
         assert len(instances) == 0
+
+
+class MockRuleIncluded(Rule):
+    """Mock rule included in light run."""
+
+    objective_hosts = (Objectives.MASTERS,)
+    unique_name = "mock_rule_included"
+    include_in_light_run = True
+
+    def run_rule(self) -> RuleResult:
+        return RuleResult.passed()
+
+
+class MockRuleExcluded(Rule):
+    """Mock rule excluded from light run."""
+
+    objective_hosts = (Objectives.MASTERS,)
+    unique_name = "mock_rule_excluded"
+    include_in_light_run = False
+
+    def run_rule(self) -> RuleResult:
+        return RuleResult.passed()
+
+
+class MockDomainForLightRun(RuleDomain):
+    """Mock domain for testing light run filtering."""
+
+    def domain_name(self) -> str:
+        return "mock_domain"
+
+    def get_rule_classes(self) -> list[type[Rule]]:
+        all_rules = [MockRuleIncluded, MockRuleExcluded]
+        return self._filter_rules_for_light_run(all_rules)
+
+
+class TestFilterRulesForLightRun:
+    """Test _filter_rules_for_light_run() helper method."""
+
+    def test_normal_mode_includes_all_rules(self):
+        """Normal mode (light_run=False) should return all rules."""
+        # Set normal mode
+        global_config.light_run = False
+
+        domain = MockDomainForLightRun()
+        all_rules = [MockRuleIncluded, MockRuleExcluded]
+        filtered = domain._filter_rules_for_light_run(all_rules)
+
+        assert len(filtered) == 2
+        assert MockRuleIncluded in filtered
+        assert MockRuleExcluded in filtered
+
+    def test_light_mode_excludes_heavy_rules(self):
+        """Light mode (light_run=True) should exclude rules with include_in_light_run=False."""
+        # Set light mode
+        global_config.light_run = True
+
+        domain = MockDomainForLightRun()
+        all_rules = [MockRuleIncluded, MockRuleExcluded]
+        filtered = domain._filter_rules_for_light_run(all_rules)
+
+        assert len(filtered) == 1
+        assert MockRuleIncluded in filtered
+        assert MockRuleExcluded not in filtered
+
+    def test_light_mode_with_all_included_rules(self):
+        """Light mode with only included rules should return all."""
+        global_config.light_run = True
+
+        domain = MockDomainForLightRun()
+        all_rules = [MockRuleIncluded]
+        filtered = domain._filter_rules_for_light_run(all_rules)
+
+        assert len(filtered) == 1
+        assert MockRuleIncluded in filtered
+
+    def test_light_mode_with_all_excluded_rules(self):
+        """Light mode with only excluded rules should return empty list."""
+        global_config.light_run = True
+
+        domain = MockDomainForLightRun()
+        all_rules = [MockRuleExcluded]
+        filtered = domain._filter_rules_for_light_run(all_rules)
+
+        assert len(filtered) == 0
+
+    def test_rule_without_include_in_light_run_defaults_to_true(self):
+        """Rules without include_in_light_run attribute should default to True."""
+
+        class MockRuleNoAttribute(Rule):
+            objective_hosts = (Objectives.MASTERS,)
+            unique_name = "mock_rule_no_attr"
+
+            def run_rule(self) -> RuleResult:
+                return RuleResult.passed()
+
+        global_config.light_run = True
+
+        domain = MockDomainForLightRun()
+        all_rules = [MockRuleNoAttribute]
+        filtered = domain._filter_rules_for_light_run(all_rules)
+
+        assert len(filtered) == 1
+        assert MockRuleNoAttribute in filtered
+
+    def test_runner_build_component_map_filters_light_run_rules(self):
+        """Test InClusterCheckRunner.build_component_map() reflects light-run filtering."""
+        from in_cluster_checks.runner import InClusterCheckRunner
+
+        # Create runner with light_run=True
+        runner = InClusterCheckRunner(light_run=True)
+
+        # Verify global config was set
+        assert global_config.light_run is True
+
+        # Build component map using mock domain
+        domains = {"mock_domain": MockDomainForLightRun()}
+        component_map = runner.build_component_map(domains)
+
+        # Should include only MockRuleIncluded (include_in_light_run=True)
+        assert "mock_rule_included" in component_map
+        assert "mock_rule_excluded" not in component_map
+
+        # Verify component path format
+        assert component_map["mock_rule_included"] == f"{MockRuleIncluded.__module__}.MockRuleIncluded"
 

--- a/tests/test_light_run_integration.py
+++ b/tests/test_light_run_integration.py
@@ -1,0 +1,58 @@
+"""Integration tests for --light-run flag."""
+
+import pytest
+
+from in_cluster_checks import global_config
+from in_cluster_checks.domains.hw_fw_details_domain import HwFwDetailsValidationDomain
+from in_cluster_checks.domains.k8s_domain import K8sValidationDomain
+from in_cluster_checks.rules.hw_fw_details.firmware_rule import FirmwareDetailsRule
+from in_cluster_checks.rules.hw_fw_details.hardware_rule import HardwareDetailsRule
+
+
+@pytest.fixture(autouse=True)
+def reset_light_run():
+    """Reset light_run flag after each test."""
+    yield
+    global_config.light_run = False
+
+
+class TestLightRunIntegration:
+    """Integration tests for light-run mode."""
+
+    def test_normal_mode_includes_hw_fw_details_rules(self):
+        """Normal mode should include hw_fw_details rules."""
+        global_config.light_run = False
+
+        domain = HwFwDetailsValidationDomain()
+        all_rules = domain.get_rule_classes()
+        filtered_rules = domain._filter_rules_for_light_run(all_rules)
+
+        assert len(filtered_rules) == 2
+        assert HardwareDetailsRule in filtered_rules
+        assert FirmwareDetailsRule in filtered_rules
+
+    def test_light_mode_excludes_hw_fw_details_rules(self):
+        """Light mode should exclude hw_fw_details rules."""
+        global_config.light_run = True
+
+        domain = HwFwDetailsValidationDomain()
+        all_rules = domain.get_rule_classes()
+        filtered_rules = domain._filter_rules_for_light_run(all_rules)
+
+        assert len(filtered_rules) == 0
+
+    def test_light_mode_includes_k8s_rules(self):
+        """Light mode should still include K8s rules (they have include_in_light_run=True)."""
+        global_config.light_run = True
+
+        domain = K8sValidationDomain()
+        all_rules = domain.get_rule_classes()
+        filtered_rules = domain._filter_rules_for_light_run(all_rules)
+
+        # K8s rules should all be included (default include_in_light_run=True)
+        assert len(filtered_rules) > 0
+
+    def test_hw_fw_details_rules_have_include_in_light_run_false(self):
+        """Verify hw_fw_details rules have include_in_light_run=False."""
+        assert HardwareDetailsRule.include_in_light_run is False
+        assert FirmwareDetailsRule.include_in_light_run is False


### PR DESCRIPTION
Add --light-run flag that excludes resource-intensive rules (hw_fw_details) from execution for faster cluster health checks.

Changes:
- Add include_in_light_run class variable to Rule base class (default True)
- Add light_run to global_config
- Add _filter_rules_for_light_run() helper to RuleDomain
- Update all domains to use filtering helper
- Mark HardwareDetailsRule and FirmwareDetailsRule as excluded
- Add --light-run CLI argument
- Show [full-run-only] indicator in --list-rules output
- Add unit and integration tests
- Update documentation and examples

Assisted-by: Claude Code (Claude Sonnet 4.5) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--light-run` CLI flag to run only rules eligible for lightweight execution.
  * Introduced a `light_run` configuration option and a rule-level `include_in_light_run` flag (default: included).

* **Documentation**
  * Added Light-Run Mode guidance, including how rule listing marks full-run-only rules and which domains/rules are omitted.

* **Bug Fixes**
  * Light-run mode now excludes hardware/firmware details rules.

* **Tests**
  * Added unit and integration tests validating rule filtering and the `include_in_light_run` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->