### PR TITLE
fix: use correct attribute in OrphanCsiVolumes prerequisite check

### DIFF
--- a/src/in_cluster_checks/rules/storage/storage_validations.py
+++ b/src/in_cluster_checks/rules/storage/storage_validations.py
@@ -443,7 +443,7 @@ class OrphanCsiVolumes(CephRule):
         """
         # First check base Ceph prerequisites (namespace, operator, tools)
         base_result = super().is_prerequisite_fulfilled()
-        if not base_result.met:
+        if not base_result.fulfilled:
             return base_result
 
         # Check if ceph filesystem exists


### PR DESCRIPTION
## Summary
- Fix `OrphanCsiVolumes.is_prerequisite_fulfilled()` checking `base_result.met` (static method, always truthy) instead of `base_result.fulfilled` (instance attribute)
- This caused the base prerequisite short-circuit to never trigger — on LVMS-only clusters (openshift-storage namespace exists but no Ceph operator pod), `_run_ceph_cmd()` was called despite the base prerequisite returning `not_met`, logging a spurious ERROR
- The ERROR caused CI's `test_validate_no_errors` to fail (6 failures in main in the last 14 days)

## Root Cause
`PrerequisiteResult` has a `fulfilled` instance attribute and a `met` static method. Accessing `.met` on an instance returns the bound method reference (always truthy), so `not base_result.met` was always `False`.

## Test plan
- [x] `pytest tests/rules/storage/` — all 50 tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed prerequisite validation in storage checks. The system now correctly evaluates whether Ceph prerequisites are satisfied before proceeding with orphan CSI volume and Ceph subvolume-group validations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->