### PR TITLE
Fix verify_dns_reachability validation

### DIFF
--- a/src/in_cluster_checks/rules/network/dns_validations.py
+++ b/src/in_cluster_checks/rules/network/dns_validations.py
@@ -96,7 +96,7 @@ class VerifyDnsReachability(Rule):
         Returns:
             PrerequisiteResult indicating if ping is available
         """
-        return_code, _, _ = self.run_cmd("which ping")
+        return_code, _, _ = self.run_cmd(SafeCmdString("which ping"))
         if return_code != 0:
             return PrerequisiteResult.not_met("ping binary not available on this node")
 
@@ -110,12 +110,12 @@ class VerifyDnsReachability(Rule):
             RuleResult indicating DNS reachability status for this node
         """
         # Get DNS servers from DNS operator config (shared across all nodes)
-        dns_operator_config = self.get_data_from_collector(DnsOperatorConfigCollector)
+        dns_operator_config = self.run_data_collector(DnsOperatorConfigCollector)
+        # dns_operator_config is dict: {orchestrator_ip: [dns_servers]}
+        # All nodes have same DNS servers, so fetch from first orchestrator
+        dns_servers = next(iter(dns_operator_config.values()))
 
-        if dns_operator_config:
-            # dns_operator_config is dict: {orchestrator_ip: [dns_servers]}
-            # All nodes have same DNS servers, so fetch from first orchestrator
-            dns_servers = next(iter(dns_operator_config.values()))
+        if dns_servers:
             source = "DNS operator upstream resolvers"
         else:
             # Read DNS servers from local /etc/resolv.conf on this node

--- a/src/in_cluster_checks/rules/network/dns_validations.py
+++ b/src/in_cluster_checks/rules/network/dns_validations.py
@@ -112,8 +112,21 @@ class VerifyDnsReachability(Rule):
         # Get DNS servers from DNS operator config (shared across all nodes)
         dns_operator_config = self.run_data_collector(DnsOperatorConfigCollector)
         # dns_operator_config is dict: {orchestrator_ip: [dns_servers]}
-        # All nodes have same DNS servers, so fetch from first orchestrator
-        dns_servers = next(iter(dns_operator_config.values()))
+
+        # Handle empty dict case (no orchestrators returned data)
+        dns_servers = next(iter(dns_operator_config.values()), [])
+
+        # Validate DNS configuration consistency across orchestrators
+        if dns_operator_config:
+            dns_configs_set = {tuple(sorted(servers)) for servers in dns_operator_config.values()}
+            if len(dns_configs_set) > 1:
+                # Configuration mismatch - report which orchestrators have different configs
+                config_details = []
+                for orch_ip, servers in dns_operator_config.items():
+                    config_details.append(f"{orch_ip}: {', '.join(servers) if servers else '(empty)'}")
+                return RuleResult.failed(
+                    "DNS configuration mismatch across orchestrators:\n" + "\n".join(config_details)
+                )
 
         if dns_servers:
             source = "DNS operator upstream resolvers"

--- a/tests/rules/network/test_dns_validations.py
+++ b/tests/rules/network/test_dns_validations.py
@@ -92,7 +92,7 @@ nameserver 8.8.8.8
         RuleScenarioParams(
             scenario_title="all_dns_servers_reachable_from_operator",
             tested_object_mock_dict={
-                "get_data_from_collector": Mock(return_value={"orchestrator_ip1": ["192.168.1.1", "8.8.8.8"]}),
+                "run_data_collector": Mock(return_value={"orchestrator_ip1": ["192.168.1.1", "8.8.8.8"]}),
             },
             cmd_input_output_dict={
                 "ping -c 1 -W 2 192.168.1.1": CmdOutput("PING 192.168.1.1 (192.168.1.1) 56(84) bytes of data.\n"),
@@ -102,7 +102,7 @@ nameserver 8.8.8.8
         RuleScenarioParams(
             scenario_title="all_dns_servers_reachable_from_resolv_conf",
             tested_object_mock_dict={
-                "get_data_from_collector": Mock(return_value={}),
+                "run_data_collector": Mock(return_value={"orchestrator_ip1": []}),
             },
             cmd_input_output_dict={
                 "ls /etc/resolv.conf": CmdOutput("/etc/resolv.conf"),
@@ -118,7 +118,7 @@ nameserver 8.8.8.8
         RuleScenarioParams(
             scenario_title="some_dns_servers_unreachable",
             tested_object_mock_dict={
-                "get_data_from_collector": Mock(return_value={"orchestrator_ip1": ["192.168.1.1", "8.8.8.8"]}),
+                "run_data_collector": Mock(return_value={"orchestrator_ip1": ["192.168.1.1", "8.8.8.8"]}),
             },
             cmd_input_output_dict={
                 "ping -c 1 -W 2 192.168.1.1": CmdOutput("PING 192.168.1.1 (192.168.1.1) 56(84) bytes of data.\n"),
@@ -129,7 +129,7 @@ nameserver 8.8.8.8
         RuleScenarioParams(
             scenario_title="no_dns_servers_found",
             tested_object_mock_dict={
-                "get_data_from_collector": Mock(return_value={}),
+                "run_data_collector": Mock(return_value={"orchestrator_ip1": []}),
             },
             cmd_input_output_dict={
                 "ls /etc/resolv.conf": CmdOutput("", return_code=2),  # File not found

--- a/tests/rules/network/test_dns_validations.py
+++ b/tests/rules/network/test_dns_validations.py
@@ -112,6 +112,19 @@ nameserver 8.8.8.8
                 "ping -c 1 -W 2 8.8.8.8": CmdOutput("PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.\n"),
             },
         ),
+        RuleScenarioParams(
+            scenario_title="empty_dns_operator_config",
+            tested_object_mock_dict={
+                "run_data_collector": Mock(return_value={}),
+            },
+            cmd_input_output_dict={
+                "ls /etc/resolv.conf": CmdOutput("/etc/resolv.conf"),
+                "cat /etc/resolv.conf": CmdOutput(resolv_conf_content),
+                "hostname -I": CmdOutput("10.0.0.10 10.0.0.11\n"),
+                "ping -c 1 -W 2 192.168.1.1": CmdOutput("PING 192.168.1.1 (192.168.1.1) 56(84) bytes of data.\n"),
+                "ping -c 1 -W 2 8.8.8.8": CmdOutput("PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.\n"),
+            },
+        ),
     ]
 
     scenario_failed = [
@@ -135,6 +148,19 @@ nameserver 8.8.8.8
                 "ls /etc/resolv.conf": CmdOutput("", return_code=2),  # File not found
             },
             failed_msg="No DNS servers found at /etc/resolv.conf",
+        ),
+        RuleScenarioParams(
+            scenario_title="dns_config_mismatch_across_orchestrators",
+            tested_object_mock_dict={
+                "run_data_collector": Mock(
+                    return_value={
+                        "10.0.0.1": ["192.168.1.1", "8.8.8.8"],
+                        "10.0.0.2": ["192.168.1.1", "8.8.4.4"],
+                    }
+                ),
+            },
+            cmd_input_output_dict={},
+            failed_msg="DNS configuration mismatch across orchestrators:\n10.0.0.1: 192.168.1.1, 8.8.8.8\n10.0.0.2: 192.168.1.1, 8.8.4.4",
         ),
     ]
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DNS reachability validation to more reliably discover DNS upstream resolvers, with clearer fallback behavior when orchestrator DNS data is missing.
  * Added detection and reporting for mismatched DNS upstream resolver lists across orchestrators.
* **Tests**
  * Updated DNS validation test scenarios and mocking to reflect the new DNS data collection flow, including new coverage for empty DNS configuration and cross-orchestrator mismatches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->