### PR TITLE
feat: register VerifyMdrOperatorHealth in k8s domain

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -126,6 +126,13 @@ reviews:
         - When checking resource health conditions (e.g., cluster operators), verify all relevant
           conditions are covered, not just the primary one.
 
+        **Domain registration:**
+        - Every new rule class MUST be registered in the corresponding domain's get_rule_classes() method
+          (e.g., K8sValidationDomain for k8s rules, NetworkValidationDomain for network rules).
+          A rule that exists in `src/in_cluster_checks/rules/` but is not listed in any domain's
+          get_rule_classes() will never execute. Flag any new rule class that is not imported and
+          listed in the appropriate domain file under `src/in_cluster_checks/domains/`.
+
         **Code cleanliness:**
         - Rules must NOT use self.logger. Return messages via RuleResult.failed() or RuleResult.warning().
         - Flag redundant if-statements inside blocks that already guarantee the condition.

--- a/src/in_cluster_checks/domains/k8s_domain.py
+++ b/src/in_cluster_checks/domains/k8s_domain.py
@@ -25,6 +25,7 @@ from in_cluster_checks.rules.k8s.k8s_validations import (
     VerifyFARControllerReplicas,
     VerifyFarOperatorHealth,
     VerifyInternalRegistry,
+    VerifyMdrOperatorHealth,
     VerifyNetworkDiagnosticsDisabled,
     VerifyNfdOperatorHealth,
     VerifyNfdPodRestartCount,
@@ -73,4 +74,5 @@ class K8sValidationDomain(RuleDomain):
             VerifyFarOperatorHealth,
             VerifyFARControllerReplicas,
             VerifyFarContainerNonRoot,
+            VerifyMdrOperatorHealth,
         ]

--- a/src/in_cluster_checks/rules/k8s/k8s_validations.py
+++ b/src/in_cluster_checks/rules/k8s/k8s_validations.py
@@ -1716,7 +1716,7 @@ class VerifyMdrOperatorHealth(SubscriptionOperatorRule):
     title = "Verify MDR operator pods are healthy"
     supported_profiles = {"telco-base"}
     links = [
-        "https://github.com/RedHatInsights/incluster-checks/wiki/K8s-%E2%80%90-Verify-MDR-operator-health",
+        "https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418418399/Verify+MDR+operator+health",
         "https://docs.redhat.com/en/documentation/workload_availability_for_red_hat_openshift"
         "/23.3/html/remediation_fencing_and_maintenance/machine-deletion-remediation-operator-remediate-nodes",
     ]

--- a/src/in_cluster_checks/rules/network/dns_validations.py
+++ b/src/in_cluster_checks/rules/network/dns_validations.py
@@ -85,7 +85,7 @@ class VerifyDnsReachability(Rule):
     unique_name = "verify_dns_reachability"
     title = "Verify DNS server reachability"
     links: ClassVar[list] = [
-        "https://github.com/RedHatInsights/incluster-checks/wiki/Network-%E2%80%90-Verify-DNS-reachability",
+        "https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418450933/Verify+DNS+reachability",
     ]
     RESOLV_CONF_PATH = "/etc/resolv.conf"
 

--- a/tests/domains/test_k8s_domain.py
+++ b/tests/domains/test_k8s_domain.py
@@ -15,6 +15,7 @@ from in_cluster_checks.rules.k8s.k8s_validations import (
     VerifyFARControllerReplicas,
     VerifyFarOperatorHealth,
     VerifyInternalRegistry,
+    VerifyMdrOperatorHealth,
     VerifyNetworkDiagnosticsDisabled,
     VerifyNfdOperatorHealth,
     VerifyNfdPodRestartCount,
@@ -34,7 +35,7 @@ def test_k8s_domain_rules():
     domain = K8sValidationDomain()
     rules = domain.get_rule_classes()
 
-    assert len(rules) == 21
+    assert len(rules) == 22
     assert AllPodsReadyAndRunning in rules
     assert NodesAreReady in rules
     assert NodesCpuAndMemoryStatus in rules
@@ -53,3 +54,4 @@ def test_k8s_domain_rules():
     assert VerifyAcmOperatorHealth in rules
     assert VerifyNmoOperatorHealth in rules
     assert VerifyFarOperatorHealth in rules
+    assert VerifyMdrOperatorHealth in rules


### PR DESCRIPTION
## Summary

- Register `VerifyMdrOperatorHealth` in `K8sValidationDomain.get_rule_classes()` — the rule class existed but was never executed because it wasn't listed in the domain
- Update domain test to expect 22 rules and assert the new rule is present
- Add CodeRabbit instruction to flag new rule classes that are not registered in any domain's `get_rule_classes()`

## Test plan

- [x] All 832 tests pass
- [x] `test_k8s_domain_rules` updated with new count and assertion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MDR Operator health validation to Kubernetes/OpenShift healthchecks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->