### PR TITLE
fix(PDRIVE-696): handle 'doesn't have a resource type' error in nmstate prerequisite

### DIFF
--- a/src/in_cluster_checks/rules/network/nmstate_validations.py
+++ b/src/in_cluster_checks/rules/network/nmstate_validations.py
@@ -46,7 +46,11 @@ class VerifyAllNNCPsAvailable(OrchestratorRule):
             return PrerequisiteResult.met()
         except oc.OpenShiftPythonException as e:
             error_msg = str(e).lower()
-            if "not found" in error_msg or "no matches for kind" in error_msg:
+            if (
+                "not found" in error_msg
+                or "no matches for kind" in error_msg
+                or "doesn't have a resource type" in error_msg
+            ):
                 return PrerequisiteResult.not_met("NMState operator is not installed (NNCP CRD not found)")
             raise
 

--- a/tests/rules/network/test_nmstate_validations.py
+++ b/tests/rules/network/test_nmstate_validations.py
@@ -95,6 +95,18 @@ class TestVerifyAllNNCPsAvailable(RuleTestBase):
             },
         ),
         RuleScenarioParams(
+            "server doesn't have resource type",
+            tested_object_mock_dict={
+                "oc_api": Mock(
+                    select_resources=Mock(
+                        side_effect=oc.OpenShiftPythonException(
+                            'error: the server doesn\'t have a resource type "nodenetworkconfigurationpolicies"'
+                        )
+                    )
+                )
+            },
+        ),
+        RuleScenarioParams(
             "no NNCPs found",
             tested_object_mock_dict={
                 "oc_api": Mock(select_resources=Mock(return_value=[]))


### PR DESCRIPTION
## Summary

Fixes the `VerifyAllNNCPsAvailable` rule to return `NOT_APPLICABLE` status instead of `SKIP` when the NMState CRD is not installed on the cluster.

## Problem

The prerequisite check caught some error patterns (`"not found"`, `"no matches for kind"`) but not the actual error returned by clusters without NMState:
```
error: the server doesn't have a resource type "nodenetworkconfigurationpolicies"
```

This caused the rule to return `SKIP` status with an exception stack trace instead of the cleaner `NOT_APPLICABLE` status.

## Changes

- Updated error pattern matching in `is_prerequisite_fulfilled()` to include `"doesn't have a resource type"`
- Added test case for this specific error scenario
- All tests pass, coverage improved to 92%

## Testing

```bash
pytest tests/rules/network/test_nmstate_validations.py -v
# 13 passed, 4 skipped
```

Jira: https://redhat.atlassian.net/browse/PDRIVE-696

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for network configuration prerequisite checks, including new scenarios where the API server cannot locate specific resource types.

* **Refactor**
  * Improved code formatting in error message validation logic for better maintainability and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->