### PR TITLE
Add JUnit XML output format support

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -50,6 +50,9 @@ pre-commit run --all-files          # Code quality checks
 # Run all checks (output saved to ./cluster-checks.json)
 in-cluster-checks --output ./cluster-checks.json
 
+# Output as JUnit XML (for CI dashboard integration)
+in-cluster-checks --format junit --output ./cluster-checks.xml
+
 # Run only lightweight rules (excludes resource-intensive rules marked with include_in_light_run=False)
 # Currently excludes: hw_fw_details domain (hardware/firmware inventory collection)
 in-cluster-checks --light-run --output ./quick-check.json

--- a/.claude/rules/in-cluster-check.md
+++ b/.claude/rules/in-cluster-check.md
@@ -23,7 +23,7 @@ The in-cluster check framework runs direct rule checks on live clusters using `o
 2. **Executor Creation**: Creates `NodeExecutor` instances for each node using `oc debug`
 3. **Domain Discovery**: `InClusterCheckRunner.discover_domains()` auto-discovers all `RuleDomain` subclasses
 4. **Domain Execution**: Each `RuleDomain` runs its rules via `ParallelRunner`
-5. **Result Aggregation**: `StructedPrinter` collects results and generates JSON output
+5. **Result Aggregation**: `StructedPrinter` collects results and generates output (JSON or JUnit XML)
 6. **Cleanup**: Disconnect from all nodes
 
 ## Rule Types
@@ -50,7 +50,7 @@ All rules use the `Status` enum (`utils/enums.py`):
 - `DataCollector` (`core/operations.py`): Base class for data collection
 - `NodeExecutor` (`core/executor.py`): Runs commands on nodes via `oc debug`
 - `NodeExecutorFactory` (`core/executor_factory.py`): Node discovery and executor creation
-- `StructedPrinter` (`core/printer.py`): Result collection, formatting, and JSON output
+- `StructedPrinter` (`core/printer.py`): Result collection, formatting, and output (JSON/JUnit XML)
 
 ## Development Guidelines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ Logical groupings of related rules. Each domain:
 The main orchestrator that:
 - Auto-discovers all domain classes in the `domains` package
 - Executes rules in parallel across multiple nodes
-- Aggregates results and generates JSON output
+- Aggregates results and generates output (JSON or JUnit XML)
 - Manages `oc debug` connections and cleanup
 
 **Location:** `src/in_cluster_checks/runner.py`
@@ -511,6 +511,9 @@ in-cluster-checks --debug-rule your_rule_name
 
 # Run all checks with debug logging
 in-cluster-checks --log-level DEBUG --output ./test-results.json
+
+# Run all checks with JUnit XML output (for CI integration)
+in-cluster-checks --format junit --output ./test-results.xml
 ```
 
 ### Writing Tests

--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ You can run in-cluster-checks with the following options:
 # Run all checks. Use --output to save run results to ./cluster-checks.json
 in-cluster-checks --output ./cluster-checks.json
 
+# Output as JUnit XML (for CI dashboard integration)
+in-cluster-checks --format junit --output ./cluster-checks.xml
+
 # Run a specific rule (disables secret filtering)
 in-cluster-checks --debug-rule "check_disk_usage"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "in-cluster-checks"
-version = "0.1.39"
+version = "0.2.0"
 description = "Generic framework for running health validation rules on OpenShift cluster nodes"
 readme = "README.md"
 license = "BSD-3-Clause"

--- a/src/in_cluster_checks/cli.py
+++ b/src/in_cluster_checks/cli.py
@@ -14,6 +14,24 @@ from pathlib import Path
 from in_cluster_checks.runner import InClusterCheckRunner
 from profiles.loader import ProfileLoader
 
+OUTPUT_DEFAULTS = {
+    "json": "./cluster-checks.json",
+    "junit": "./cluster-checks.xml",
+}
+
+
+def get_default_output(output_format: str) -> str:
+    """
+    Return the default output file path for the given format.
+
+    Args:
+        output_format: Output format ("json" or "junit")
+
+    Returns:
+        Default output file path with the appropriate extension
+    """
+    return OUTPUT_DEFAULTS.get(output_format, OUTPUT_DEFAULTS["json"])
+
 
 def setup_logging(level: str) -> None:
     """
@@ -156,8 +174,16 @@ def main() -> None:
         "--output",
         "-o",
         type=str,
-        default="./cluster-checks.json",
-        help="Output file path for JSON results (default: ./cluster-checks.json)",
+        default=None,
+        help="Output file path for results (default: ./cluster-checks.json or ./cluster-checks.xml for junit)",
+    )
+
+    parser.add_argument(
+        "--format",
+        type=str,
+        choices=["json", "junit"],
+        default="json",
+        help="Output format (default: json)",
     )
 
     parser.add_argument(
@@ -221,6 +247,9 @@ def main() -> None:
         )
         sys.exit(2)
 
+    if args.output is None:
+        args.output = get_default_output(args.format)
+
     # Setup logging
     try:
         setup_logging(args.log_level)
@@ -278,7 +307,7 @@ def main() -> None:
             logger.info("Secret filtering is DISABLED in debug mode")
             logger.info("JSON output is DISABLED in debug mode")
 
-        result_path = runner.run(output_path=output_path)
+        result_path = runner.run(output_path=output_path, output_format=args.format)
 
         logger.info("=" * 60)
         logger.info("Checks completed successfully")

--- a/src/in_cluster_checks/core/printer.py
+++ b/src/in_cluster_checks/core/printer.py
@@ -342,7 +342,7 @@ class StructedPrinter:
             domain_groups.setdefault(report["domain"], []).append(report)
 
         for domain_name, reports in domain_groups.items():
-            testsuite = ET.SubElement(testsuites, "testsuite", name=domain_name)
+            testsuite = ET.SubElement(testsuites, "testsuite", name=_strip_xml_illegal_chars(domain_name))
             test_count = 0
             failure_count = 0
             skipped_count = 0
@@ -350,10 +350,10 @@ class StructedPrinter:
             for report in reports:
                 for host_result in report["details"]:
                     test_count += 1
-                    node_name = host_result.get("node_name", "unknown")
+                    node_name = _strip_xml_illegal_chars(host_result.get("node_name", "unknown"))
                     tc_attrs = {
-                        "name": f"{report['key']} [{node_name}]",
-                        "classname": report["component"],
+                        "name": f"{_strip_xml_illegal_chars(report['key'])} [{node_name}]",
+                        "classname": _strip_xml_illegal_chars(report["component"]),
                     }
                     run_time = host_result.get("run_time")
                     if run_time is not None:

--- a/src/in_cluster_checks/core/printer.py
+++ b/src/in_cluster_checks/core/printer.py
@@ -8,12 +8,21 @@ Outputs in Insights-compatible format similar to pg.json
 import json
 import logging
 import os
+import re
+import xml.etree.ElementTree as ET
 from collections import OrderedDict
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 from in_cluster_checks import global_config
 from in_cluster_checks.utils.enums import Status
 from in_cluster_checks.utils.secret_filter import SecretFilter
+
+_XML_ILLEGAL_CHARS_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x84\x86-\x9f]")
+
+
+def _strip_xml_illegal_chars(text: str) -> str:
+    """Remove control characters that are illegal in XML 1.0."""
+    return _XML_ILLEGAL_CHARS_RE.sub("", text)
 
 
 # ANSI color codes
@@ -314,6 +323,66 @@ class StructedPrinter:
         with os.fdopen(file_descriptor, "w") as f:
             os.fchmod(f.fileno(), 0o600)
             json.dump(results, f, indent=2, default=str)
+
+    @staticmethod
+    def print_to_junit(results: List[Dict[str, Any]], output_file: str) -> None:
+        """
+        Write rule results to JUnit XML file.
+
+        Emits one testcase per rule+host combination for CI dashboard granularity.
+
+        Args:
+            results: List of report dicts from format_results()
+            output_file: Path to output XML file
+        """
+        testsuites = ET.Element("testsuites")
+
+        domain_groups: Dict[str, list] = OrderedDict()
+        for report in results:
+            domain_groups.setdefault(report["domain"], []).append(report)
+
+        for domain_name, reports in domain_groups.items():
+            testsuite = ET.SubElement(testsuites, "testsuite", name=domain_name)
+            test_count = 0
+            failure_count = 0
+            skipped_count = 0
+
+            for report in reports:
+                for host_result in report["details"]:
+                    test_count += 1
+                    node_name = host_result.get("node_name", "unknown")
+                    tc_attrs = {
+                        "name": f"{report['key']} [{node_name}]",
+                        "classname": report["component"],
+                    }
+                    run_time = host_result.get("run_time")
+                    if run_time is not None:
+                        tc_attrs["time"] = str(run_time)
+
+                    testcase = ET.SubElement(testsuite, "testcase", **tc_attrs)
+                    status = host_result.get("status")
+                    message = _strip_xml_illegal_chars(host_result.get("message", ""))
+
+                    if status in (Status.FAILED.value, Status.WARNING.value):
+                        failure_count += 1
+                        failure_type = "warning" if status == Status.WARNING.value else "failure"
+                        ET.SubElement(testcase, "failure", message=message, type=failure_type)
+                    elif status in (Status.SKIP.value, Status.NOT_APPLICABLE.value):
+                        skipped_count += 1
+                        ET.SubElement(testcase, "skipped", message=message)
+
+                    rule_log = host_result.get("rule_log", [])
+                    if rule_log:
+                        system_out = ET.SubElement(testcase, "system-out")
+                        system_out.text = "\n".join(_strip_xml_illegal_chars(line) for line in rule_log)
+
+            testsuite.set("tests", str(test_count))
+            testsuite.set("failures", str(failure_count))
+            testsuite.set("skipped", str(skipped_count))
+
+        tree = ET.ElementTree(testsuites)
+        ET.indent(tree)
+        tree.write(output_file, encoding="unicode", xml_declaration=True)
 
     @staticmethod
     def format_results(flow_results: list, rule_component_map: Dict[str, str]) -> Dict[str, Any]:

--- a/src/in_cluster_checks/runner.py
+++ b/src/in_cluster_checks/runner.py
@@ -165,15 +165,16 @@ class InClusterCheckRunner:
         self.logger.info(f"  Not Applicable: {not_applicable}")
         self.logger.info("=" * 60)
 
-    def run(self, output_path: Path) -> str:
+    def run(self, output_path: Path, output_format: str = "json") -> str:
         """
         Run complete in-cluster check workflow.
 
         Args:
-            output_path: Full path where JSON output will be saved
+            output_path: Full path where output will be saved
+            output_format: Output format - "json" or "junit" (default: "json")
 
         Returns:
-            Path to generated JSON file
+            Path to generated output file
         """
         self.logger.info("Starting direct in-cluster rule checks")
 
@@ -212,12 +213,15 @@ class InClusterCheckRunner:
             # 8. Aggregate and format results
             reports = StructedPrinter.format_results(results, rule_component_map)
 
-            # 9. Generate JSON output (skip in debug mode)
+            # 9. Generate output (skip in debug mode)
             if not global_config.debug_rule_flag:
-                StructedPrinter.print_to_json(reports, str(output_path))
+                if output_format == "junit":
+                    StructedPrinter.print_to_junit(reports, str(output_path))
+                else:
+                    StructedPrinter.print_to_json(reports, str(output_path))
                 self.logger.info(f"In-cluster check results saved to: {output_path}")
             else:
-                self.logger.info("Debug mode: JSON output disabled")
+                self.logger.info("Debug mode: output disabled")
 
             # 10. Log summary
             self.log_summary(reports)

--- a/tests/core/test_printer.py
+++ b/tests/core/test_printer.py
@@ -1,11 +1,12 @@
 """
-Tests for StructedPrinter (JSON formatter).
+Tests for StructedPrinter (JSON and JUnit XML formatter).
 """
 
 import json
 import os
 import stat
 import tempfile
+import xml.etree.ElementTree as ET
 from collections import OrderedDict
 from pathlib import Path
 
@@ -13,6 +14,31 @@ import pytest
 
 from in_cluster_checks.core.printer import StructedPrinter
 from in_cluster_checks.utils.enums import Status
+
+
+def _make_report(domain, key, status, component=None, details=None):
+    if component is None:
+        component = f"in_cluster_checks.{domain}.{key}"
+    if details is None:
+        details = [
+            {
+                "node_ip": "192.168.1.10",
+                "node_name": "node1",
+                "status": status,
+                "bash_cmd_lines": [],
+                "rule_log": [],
+                "timestamp": "2026-01-18 10:00:00",
+            }
+        ]
+    return {
+        "rule_id": f"{domain}|{key}",
+        "component": component,
+        "key": key,
+        "status": status,
+        "description": f"Test {key}",
+        "domain": domain,
+        "details": details,
+    }
 
 
 class TestStructedPrinter:
@@ -370,3 +396,281 @@ class TestStructedPrinter:
         # Aggregated status should be 'warning' (worst among passed/warning)
         assert result[0]['status'] == Status.WARNING.value
         assert len(result[0]['details']) == 3
+
+
+class TestJUnitOutput:
+    """Test JUnit XML output formatting."""
+
+    def test_print_to_junit_creates_valid_xml(self, tmp_path):
+        output_file = tmp_path / "results.xml"
+        reports = [_make_report("hw", "check_disk", Status.PASSED.value)]
+
+        StructedPrinter.print_to_junit(reports, str(output_file))
+
+        assert output_file.exists()
+        tree = ET.parse(output_file)
+        root = tree.getroot()
+        assert root.tag == "testsuites"
+
+        suites = root.findall("testsuite")
+        assert len(suites) == 1
+        assert suites[0].get("name") == "hw"
+
+        cases = suites[0].findall("testcase")
+        assert len(cases) == 1
+        assert cases[0].get("name") == "check_disk [node1]"
+        assert cases[0].get("classname") == "in_cluster_checks.hw.check_disk"
+
+        assert cases[0].find("failure") is None
+        assert cases[0].find("skipped") is None
+
+    def test_print_to_junit_failed_status(self, tmp_path):
+        output_file = tmp_path / "results.xml"
+        details = [
+            {
+                "node_ip": "192.168.1.10",
+                "node_name": "node1",
+                "status": Status.FAILED.value,
+                "message": "Disk usage at 98%",
+                "bash_cmd_lines": [],
+                "rule_log": [],
+                "timestamp": "2026-01-18 10:00:00",
+            }
+        ]
+        reports = [_make_report("hw", "check_disk", Status.FAILED.value, details=details)]
+
+        StructedPrinter.print_to_junit(reports, str(output_file))
+
+        tree = ET.parse(output_file)
+        case = tree.getroot().find(".//testcase")
+        failure = case.find("failure")
+        assert failure is not None
+        assert failure.get("message") == "Disk usage at 98%"
+        assert failure.get("type") == "failure"
+
+    def test_print_to_junit_warning_status(self, tmp_path):
+        output_file = tmp_path / "results.xml"
+        details = [
+            {
+                "node_ip": "192.168.1.10",
+                "node_name": "node1",
+                "status": Status.WARNING.value,
+                "message": "Disk usage at 80%",
+                "bash_cmd_lines": [],
+                "rule_log": [],
+                "timestamp": "2026-01-18 10:00:00",
+            }
+        ]
+        reports = [_make_report("hw", "check_disk", Status.WARNING.value, details=details)]
+
+        StructedPrinter.print_to_junit(reports, str(output_file))
+
+        tree = ET.parse(output_file)
+        case = tree.getroot().find(".//testcase")
+        failure = case.find("failure")
+        assert failure is not None
+        assert failure.get("message") == "Disk usage at 80%"
+        assert failure.get("type") == "warning"
+
+    def test_print_to_junit_skip_status(self, tmp_path):
+        output_file = tmp_path / "results.xml"
+        details = [
+            {
+                "node_ip": "192.168.1.10",
+                "node_name": "node1",
+                "status": Status.SKIP.value,
+                "message": "Command timed out",
+                "bash_cmd_lines": [],
+                "rule_log": [],
+                "timestamp": "2026-01-18 10:00:00",
+            }
+        ]
+        reports = [_make_report("hw", "check_disk", Status.SKIP.value, details=details)]
+
+        StructedPrinter.print_to_junit(reports, str(output_file))
+
+        tree = ET.parse(output_file)
+        case = tree.getroot().find(".//testcase")
+        skipped = case.find("skipped")
+        assert skipped is not None
+        assert skipped.get("message") == "Command timed out"
+        assert case.find("failure") is None
+
+    def test_print_to_junit_not_applicable_status(self, tmp_path):
+        output_file = tmp_path / "results.xml"
+        details = [
+            {
+                "node_ip": "192.168.1.10",
+                "node_name": "node1",
+                "status": Status.NOT_APPLICABLE.value,
+                "message": "Prerequisite not met",
+                "bash_cmd_lines": [],
+                "rule_log": [],
+                "timestamp": "2026-01-18 10:00:00",
+            }
+        ]
+        reports = [_make_report("hw", "check_disk", Status.NOT_APPLICABLE.value, details=details)]
+
+        StructedPrinter.print_to_junit(reports, str(output_file))
+
+        tree = ET.parse(output_file)
+        case = tree.getroot().find(".//testcase")
+        skipped = case.find("skipped")
+        assert skipped is not None
+        assert skipped.get("message") == "Prerequisite not met"
+
+    def test_print_to_junit_info_status(self, tmp_path):
+        output_file = tmp_path / "results.xml"
+        reports = [_make_report("hw", "sys_info", Status.INFO.value)]
+
+        StructedPrinter.print_to_junit(reports, str(output_file))
+
+        tree = ET.parse(output_file)
+        case = tree.getroot().find(".//testcase")
+        assert case.find("failure") is None
+        assert case.find("skipped") is None
+
+    def test_print_to_junit_multi_host(self, tmp_path):
+        output_file = tmp_path / "results.xml"
+        details = [
+            {
+                "node_ip": "192.168.1.10",
+                "node_name": "master-0",
+                "status": Status.PASSED.value,
+                "bash_cmd_lines": [],
+                "rule_log": [],
+                "timestamp": "2026-01-25 14:30:00",
+            },
+            {
+                "node_ip": "192.168.1.11",
+                "node_name": "master-1",
+                "status": Status.FAILED.value,
+                "message": "Port bond0 is missing",
+                "bash_cmd_lines": [],
+                "rule_log": [],
+                "timestamp": "2026-01-25 14:30:01",
+            },
+            {
+                "node_ip": "192.168.1.20",
+                "node_name": "worker-0",
+                "status": Status.PASSED.value,
+                "bash_cmd_lines": [],
+                "rule_log": [],
+                "timestamp": "2026-01-25 14:30:02",
+            },
+        ]
+        reports = [_make_report("network", "ovs_check", Status.FAILED.value, details=details)]
+
+        StructedPrinter.print_to_junit(reports, str(output_file))
+
+        tree = ET.parse(output_file)
+        suite = tree.getroot().find("testsuite")
+        assert suite.get("tests") == "3"
+        assert suite.get("failures") == "1"
+
+        cases = suite.findall("testcase")
+        assert len(cases) == 3
+        assert cases[0].get("name") == "ovs_check [master-0]"
+        assert cases[0].find("failure") is None
+        assert cases[1].get("name") == "ovs_check [master-1]"
+        assert cases[1].find("failure") is not None
+        assert cases[2].get("name") == "ovs_check [worker-0]"
+        assert cases[2].find("failure") is None
+
+    def test_print_to_junit_multi_domain(self, tmp_path):
+        output_file = tmp_path / "results.xml"
+        reports = [
+            _make_report("hw", "check_disk", Status.PASSED.value),
+            _make_report("network", "ovs_check", Status.PASSED.value),
+        ]
+
+        StructedPrinter.print_to_junit(reports, str(output_file))
+
+        tree = ET.parse(output_file)
+        suites = tree.getroot().findall("testsuite")
+        assert len(suites) == 2
+        suite_names = {s.get("name") for s in suites}
+        assert suite_names == {"hw", "network"}
+
+    def test_print_to_junit_rule_log_in_system_out(self, tmp_path):
+        output_file = tmp_path / "results.xml"
+        details = [
+            {
+                "node_ip": "192.168.1.10",
+                "node_name": "node1",
+                "status": Status.PASSED.value,
+                "bash_cmd_lines": [],
+                "rule_log": ["line 1", "line 2", "line 3"],
+                "timestamp": "2026-01-18 10:00:00",
+            }
+        ]
+        reports = [_make_report("hw", "check_disk", Status.PASSED.value, details=details)]
+
+        StructedPrinter.print_to_junit(reports, str(output_file))
+
+        tree = ET.parse(output_file)
+        case = tree.getroot().find(".//testcase")
+        system_out = case.find("system-out")
+        assert system_out is not None
+        assert "line 1" in system_out.text
+        assert "line 2" in system_out.text
+        assert "line 3" in system_out.text
+
+    def test_print_to_junit_testcase_time(self, tmp_path):
+        output_file = tmp_path / "results.xml"
+        details = [
+            {
+                "node_ip": "192.168.1.10",
+                "node_name": "node1",
+                "status": Status.PASSED.value,
+                "bash_cmd_lines": [],
+                "rule_log": [],
+                "run_time": 2.5,
+                "timestamp": "2026-01-18 10:00:00",
+            }
+        ]
+        reports = [_make_report("hw", "check_disk", Status.PASSED.value, details=details)]
+
+        StructedPrinter.print_to_junit(reports, str(output_file))
+
+        tree = ET.parse(output_file)
+        case = tree.getroot().find(".//testcase")
+        assert case.get("time") == "2.5"
+
+    def test_print_to_junit_strips_illegal_xml_chars(self, tmp_path):
+        output_file = tmp_path / "results.xml"
+        details = [
+            {
+                "node_ip": "192.168.1.10",
+                "node_name": "node1",
+                "status": Status.FAILED.value,
+                "message": "bad\x00output\x07here",
+                "bash_cmd_lines": [],
+                "rule_log": ["line\x01one", "line\x1ftwo"],
+                "timestamp": "2026-01-18 10:00:00",
+            }
+        ]
+        reports = [_make_report("hw", "check_disk", Status.FAILED.value, details=details)]
+
+        StructedPrinter.print_to_junit(reports, str(output_file))
+
+        tree = ET.parse(output_file)
+        case = tree.getroot().find(".//testcase")
+        failure = case.find("failure")
+        assert failure.get("message") == "badoutputhere"
+        system_out = case.find("system-out")
+        assert "\x01" not in system_out.text
+        assert "\x1f" not in system_out.text
+        assert "lineone" in system_out.text
+        assert "linetwo" in system_out.text
+
+    def test_print_to_junit_empty_results(self, tmp_path):
+        output_file = tmp_path / "results.xml"
+
+        StructedPrinter.print_to_junit([], str(output_file))
+
+        assert output_file.exists()
+        tree = ET.parse(output_file)
+        root = tree.getroot()
+        assert root.tag == "testsuites"
+        assert root.findall("testsuite") == []

--- a/tests/core/test_printer.py
+++ b/tests/core/test_printer.py
@@ -664,6 +664,42 @@ class TestJUnitOutput:
         assert "lineone" in system_out.text
         assert "linetwo" in system_out.text
 
+    def test_print_to_junit_strips_illegal_chars_from_attributes(self, tmp_path):
+        """Verify that domain, node_name, key, and component are sanitized."""
+        output_file = tmp_path / "results.xml"
+        details = [
+            {
+                "node_ip": "192.168.1.10",
+                "node_name": "node\x00one",
+                "status": Status.PASSED.value,
+                "message": "",
+                "bash_cmd_lines": [],
+                "rule_log": [],
+                "timestamp": "2026-01-18 10:00:00",
+            }
+        ]
+        reports = [
+            {
+                "rule_id": "hw\x07bad|check\x01disk",
+                "component": "in_cluster\x0b.hw.check_disk",
+                "key": "check\x03disk",
+                "status": Status.PASSED.value,
+                "description": "Test",
+                "domain": "h\x08w",
+                "details": details,
+            }
+        ]
+
+        StructedPrinter.print_to_junit(reports, str(output_file))
+
+        tree = ET.parse(output_file)
+        suite = tree.getroot().find("testsuite")
+        assert suite.get("name") == "hw"
+
+        case = suite.find("testcase")
+        assert case.get("name") == "checkdisk [nodeone]"
+        assert case.get("classname") == "in_cluster.hw.check_disk"
+
     def test_print_to_junit_empty_results(self, tmp_path):
         output_file = tmp_path / "results.xml"
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,7 @@ import pytest
 
 from in_cluster_checks.cli import (
     check_oc_available,
+    get_default_output,
     list_domains,
     list_rules,
     main,
@@ -128,9 +129,85 @@ class TestCLI:
         mock_runner = Mock()
         mock_runner.run.return_value = "/tmp/results.json"
         mock_runner_class.return_value = mock_runner
-        
+
         test_args = ['in-cluster-checks', '--debug-rule', 'test_rule', '--output', '/tmp/test.json']
         with patch.object(sys, 'argv', test_args):
             with pytest.raises(SystemExit) as exc_info:
                 main()
             assert exc_info.value.code == 0
+
+    @patch('in_cluster_checks.cli.InClusterCheckRunner')
+    @patch('in_cluster_checks.cli.check_oc_available')
+    def test_main_default_format_is_json(self, mock_check_oc, mock_runner_class):
+        """Test that default format is json when --format is not specified."""
+        mock_runner = Mock()
+        mock_runner.run.return_value = "/tmp/results.json"
+        mock_runner_class.return_value = mock_runner
+
+        test_args = ['in-cluster-checks', '--output', '/tmp/test.json']
+        with patch.object(sys, 'argv', test_args):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            assert exc_info.value.code == 0
+            mock_runner.run.assert_called_once()
+            call_kwargs = mock_runner.run.call_args
+            assert call_kwargs.kwargs.get("output_format") == "json"
+
+    @patch('in_cluster_checks.cli.InClusterCheckRunner')
+    @patch('in_cluster_checks.cli.check_oc_available')
+    def test_main_with_format_json(self, mock_check_oc, mock_runner_class):
+        """Test main with --format json."""
+        mock_runner = Mock()
+        mock_runner.run.return_value = "/tmp/results.json"
+        mock_runner_class.return_value = mock_runner
+
+        test_args = ['in-cluster-checks', '--format', 'json', '--output', '/tmp/test.json']
+        with patch.object(sys, 'argv', test_args):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            assert exc_info.value.code == 0
+            mock_runner.run.assert_called_once()
+            call_kwargs = mock_runner.run.call_args
+            assert call_kwargs.kwargs.get("output_format") == "json"
+
+    @patch('in_cluster_checks.cli.InClusterCheckRunner')
+    @patch('in_cluster_checks.cli.check_oc_available')
+    def test_main_with_format_junit(self, mock_check_oc, mock_runner_class):
+        """Test main with --format junit."""
+        mock_runner = Mock()
+        mock_runner.run.return_value = "/tmp/results.xml"
+        mock_runner_class.return_value = mock_runner
+
+        test_args = ['in-cluster-checks', '--format', 'junit', '--output', '/tmp/test.xml']
+        with patch.object(sys, 'argv', test_args):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            assert exc_info.value.code == 0
+            mock_runner.run.assert_called_once()
+            call_kwargs = mock_runner.run.call_args
+            assert call_kwargs.kwargs.get("output_format") == "junit"
+
+    def test_get_default_output_json(self):
+        """Test default output path for json format."""
+        assert get_default_output("json") == "./cluster-checks.json"
+
+    def test_get_default_output_junit(self):
+        """Test default output path for junit format."""
+        assert get_default_output("junit") == "./cluster-checks.xml"
+
+    @patch('in_cluster_checks.cli.InClusterCheckRunner')
+    @patch('in_cluster_checks.cli.check_oc_available')
+    def test_main_junit_default_output_is_xml(self, mock_check_oc, mock_runner_class):
+        """Test that --format junit without --output defaults to .xml extension."""
+        mock_runner = Mock()
+        mock_runner.run.return_value = "./cluster-checks.xml"
+        mock_runner_class.return_value = mock_runner
+
+        test_args = ['in-cluster-checks', '--format', 'junit']
+        with patch.object(sys, 'argv', test_args):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            assert exc_info.value.code == 0
+            call_args = mock_runner.run.call_args
+            output_path = call_args.kwargs.get("output_path")
+            assert str(output_path).endswith(".xml")

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -103,3 +103,45 @@ class TestInClusterCheckRunner:
                     # In debug mode, JSON output should NOT be called
                     mock_print.assert_not_called()
                     assert result == str(output_path)
+
+    @patch('in_cluster_checks.runner.NodeExecutorFactory')
+    def test_run_json_format_calls_print_to_json(self, mock_executor_factory):
+        """Test that format='json' calls print_to_json."""
+        mock_factory_instance = Mock()
+        mock_factory_instance.build_host_executors.return_value = []
+        mock_factory_instance.connect_all.return_value = None
+        mock_factory_instance.disconnect_all.return_value = None
+        mock_executor_factory.return_value = mock_factory_instance
+
+        runner = InClusterCheckRunner()
+        output_path = Path("/tmp/test-results.json")
+
+        with patch.object(runner, 'discover_domains', return_value={}):
+            with patch('in_cluster_checks.runner.StructedPrinter.format_results', return_value=[]):
+                with patch('in_cluster_checks.runner.StructedPrinter.print_to_json') as mock_json:
+                    with patch('in_cluster_checks.runner.StructedPrinter.print_to_junit') as mock_junit:
+                        runner.run(output_path=output_path, output_format="json")
+
+                        mock_json.assert_called_once()
+                        mock_junit.assert_not_called()
+
+    @patch('in_cluster_checks.runner.NodeExecutorFactory')
+    def test_run_junit_format_calls_print_to_junit(self, mock_executor_factory):
+        """Test that format='junit' calls print_to_junit."""
+        mock_factory_instance = Mock()
+        mock_factory_instance.build_host_executors.return_value = []
+        mock_factory_instance.connect_all.return_value = None
+        mock_factory_instance.disconnect_all.return_value = None
+        mock_executor_factory.return_value = mock_factory_instance
+
+        runner = InClusterCheckRunner()
+        output_path = Path("/tmp/test-results.xml")
+
+        with patch.object(runner, 'discover_domains', return_value={}):
+            with patch('in_cluster_checks.runner.StructedPrinter.format_results', return_value=[]):
+                with patch('in_cluster_checks.runner.StructedPrinter.print_to_json') as mock_json:
+                    with patch('in_cluster_checks.runner.StructedPrinter.print_to_junit') as mock_junit:
+                        runner.run(output_path=output_path, output_format="junit")
+
+                        mock_junit.assert_called_once()
+                        mock_json.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -315,7 +315,7 @@ wheels = [
 
 [[package]]
 name = "in-cluster-checks"
-version = "0.1.6"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "cryptography" },


### PR DESCRIPTION
Allow users to export health check results as JUnit XML via `--format junit`, enabling integration with CI dashboards that consume Junit reports.

Each rule+host combination maps to a separate <testcase> for per-node
granularity. Status mapping: fail/warning -> <failure>, skip/na ->
<skipped>, pass/info -> success.

Avoid the use of external libs and uses only stdlib xml.etree.ElementTree.

Bumps the version to 0.2.0 (backward compatible, keeping defaults to json output)

Files changed:
- Implementation: printer.py, runner.py, cli.py
- Tests: test_printer.py, test_cli.py, test_runner.py
- Docs: README.md, CONTRIBUTING.md, CLAUDE.md, in-cluster-check.md

Assisted-by: Claude

---

JUnit XML is the de facto standard for test result reporting across CI/CD systems. Adding `--format junit` enables direct integration with tools that already consume this format, no custom JSON parsers needed.

As a consumer of in-cluster, through DCI, tests results feed into dashboards for run-over-run comparison, catching regressions or improvements across deployments. In broader QE/QA workflows (Jenkins, GitLab CI, Tekton, GHA), results surface natively with per-node, per-rule granularity in existing reporting infrastructure.

The proposed change keeps JSON as the default avoiding backward compatibility and the implementation uses xml from stdlib avoiding other dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added JUnit XML output alongside JSON, with format-specific default filenames (`./cluster-checks.json` / `./cluster-checks.xml`).
  * CLI and runner now honor the selected output format consistently.
* **Bug Fixes**
  * Improved JUnit XML safety by stripping illegal XML control characters from generated text.
* **Documentation**
  * Updated README and check/CI guidance with JUnit XML usage examples.
* **Tests**
  * Added/extended coverage for JUnit XML generation details (status mapping, aggregation, timing, rule logs, sanitization) plus CLI and runner routing.
* **Chores**
  * Bumped the project version to `0.2.0`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->