### PR TITLE
fix(PDRIVE-760): use dedicated namespace for debug pods

### DIFF
--- a/src/in_cluster_checks/cli.py
+++ b/src/in_cluster_checks/cli.py
@@ -204,12 +204,22 @@ def main() -> None:
     parser.add_argument(
         "--namespace",
         type=str,
-        default="default",
-        help="Namespace for debug pods (default: default). "
-        "Note: User must have permissions to create debug pods in the specified namespace.",
+        default=None,
+        help="Namespace for debug pods (default: auto-generated unique name per run). "
+        "When provided, namespace creation, NetworkPolicy, RBAC, and cleanup are skipped. "
+        "User must have permissions to create debug pods in the specified namespace.",
     )
 
     args = parser.parse_args()
+    namespace_user_provided = args.namespace is not None
+
+    if args.namespace == "default":
+        print(
+            "Error: The 'default' namespace is not allowed for debug pods. "
+            "Omit --namespace for an auto-generated namespace, or specify a dedicated one.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
 
     # Setup logging
     try:
@@ -230,7 +240,8 @@ def main() -> None:
             active_profile=args.profile,
             debug_rule_flag=(args.debug_rule != ""),
             debug_rule_name=args.debug_rule,
-            namespace=args.namespace,
+            namespace=args.namespace or "",
+            namespace_user_provided=namespace_user_provided,
             max_workers=50,
             light_run=args.light_run,
         )

--- a/src/in_cluster_checks/core/executor.py
+++ b/src/in_cluster_checks/core/executor.py
@@ -97,7 +97,12 @@ class NodeExecutor:
     DEFAULT_POD_TIMEOUT_HOURS = 4
 
     def __init__(
-        self, node_name: str, node_ip: str, roles: list = None, node_labels: str = "", namespace: str = "default"
+        self,
+        node_name: str,
+        node_ip: str,
+        roles: list = None,
+        node_labels: str = "",
+        namespace: str = "default",
     ):
         """
         Initialize node executor.
@@ -107,7 +112,7 @@ class NodeExecutor:
             node_ip: IP address of the node
             roles: List of Objectives (roles) for this node (e.g., [Objectives.MASTERS, Objectives.ALL_NODES])
             node_labels: String with node role labels (e.g., "master,worker" or "control-plane")
-            namespace: Namespace to create debug pod in (default: default)
+            namespace: Namespace to create debug pod in
         """
         if oc is None:
             raise ImportError("openshift_client library is required for NodeExecutor")

--- a/src/in_cluster_checks/core/executor_factory.py
+++ b/src/in_cluster_checks/core/executor_factory.py
@@ -210,9 +210,11 @@ class NodeExecutorFactory:
 
     def ensure_namespace(self):
         """
-        Create the configured namespace if it doesn't already exist.
+        Create the auto-generated namespace for this run.
 
-        Only creates/manages the namespace when using the default namespace
+        Raises RuntimeError if the namespace already exists (unexpected for UUID-based names).
+
+        Only creates/manages the namespace when using the auto-generated namespace
         (i.e. user did not explicitly supply --namespace). When the user provides
         a custom namespace, it is assumed to already exist and be managed externally.
 

--- a/src/in_cluster_checks/core/executor_factory.py
+++ b/src/in_cluster_checks/core/executor_factory.py
@@ -5,6 +5,7 @@ Adapted from support's OpenshiftHostExecutorFactory.
 Provides centralized creation and management of NodeExecutor instances.
 """
 
+import json
 import logging
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Dict, List
@@ -53,6 +54,7 @@ class NodeExecutorFactory:
 
         self.logger = logging.getLogger(__name__)
         self._host_executors_dict: Dict[str, NodeExecutor] = {}
+        self._namespace_created = False
 
     def build_host_executors(self) -> Dict[str, NodeExecutor]:
         """
@@ -205,6 +207,70 @@ class NodeExecutorFactory:
             Dictionary of {node_name: NodeExecutor}
         """
         return self._host_executors_dict
+
+    def ensure_namespace(self):
+        """
+        Create the configured namespace if it doesn't already exist.
+
+        Only creates/manages the namespace when using the default namespace
+        (i.e. user did not explicitly supply --namespace). When the user provides
+        a custom namespace, it is assumed to already exist and be managed externally.
+
+        Sets pod-security labels to allow privileged workloads (required for debug pods).
+        """
+        if global_config.namespace_user_provided:
+            self.logger.info(f"Using user-provided namespace '{global_config.namespace}' (will not auto-create)")
+            return
+
+        namespace = global_config.namespace
+
+        with oc.timeout(30):
+            result = oc.invoke("get", ["namespace", namespace], auto_raise=False)
+            if result.status() == 0:
+                raise RuntimeError(
+                    f"Namespace '{namespace}' already exists. "
+                    f"This is unexpected for an auto-generated namespace. "
+                    f"Delete it manually or re-run to generate a new one."
+                )
+
+        self.logger.info(f"Creating namespace '{namespace}'...")
+        ns_manifest = {
+            "apiVersion": "v1",
+            "kind": "Namespace",
+            "metadata": {
+                "name": namespace,
+                "labels": {
+                    "pod-security.kubernetes.io/enforce": "privileged",
+                    "pod-security.kubernetes.io/audit": "restricted",
+                    "pod-security.kubernetes.io/warn": "restricted",
+                    "created-by": "in-cluster-checks",
+                },
+            },
+        }
+        with oc.timeout(30):
+            oc.create(json.dumps(ns_manifest))
+        self._namespace_created = True
+        self.logger.info(f"Created namespace '{namespace}'")
+
+    def delete_namespace(self):
+        """
+        Delete the namespace if it was created by ensure_namespace().
+
+        Skips deletion if the namespace already existed before the run.
+        """
+        if not self._namespace_created:
+            return
+
+        namespace = global_config.namespace
+        self.logger.info(f"Deleting namespace '{namespace}'...")
+        try:
+            with oc.timeout(60):
+                oc.invoke("delete", ["namespace", namespace, "--wait=false"])
+            self.logger.info(f"Namespace '{namespace}' deletion initiated")
+        except Exception as e:
+            self.logger.warning(f"Failed to delete namespace '{namespace}': {e}")
+        finally:
+            self._namespace_created = False
 
     def validate_namespace_permissions(self) -> bool:
         """

--- a/src/in_cluster_checks/global_config.py
+++ b/src/in_cluster_checks/global_config.py
@@ -1,7 +1,11 @@
 """Global configuration for in-cluster checks."""
 
+import uuid
+
 from profiles.loader import ProfileLoader
 from profiles.profile import Profiles
+
+NAMESPACE_PREFIX = "incluster-checks"
 
 # Global configuration values
 debug_rule_flag: bool = False
@@ -9,8 +13,14 @@ debug_rule_name: str = ""
 max_workers: int = 50
 profiles_hierarchy = Profiles()
 active_profile: str = ""  # Must be set via set_config() - no default
-namespace: str = "default"
+namespace: str = ""
+namespace_user_provided: bool = False
 light_run: bool = False
+
+
+def _generate_namespace_name() -> str:
+    """Generate a unique namespace name for this run."""
+    return f"{NAMESPACE_PREFIX}-{uuid.uuid4().hex[:8]}"
 
 
 def set_config(
@@ -18,7 +28,8 @@ def set_config(
     debug_rule_flag_val: bool = False,
     debug_rule_name_val: str = "",
     max_workers_val: int = 50,
-    namespace_val: str = "default",
+    namespace_val: str = "",
+    namespace_user_provided_val: bool = False,
     light_run_val: bool = False,
 ):
     """Update global configuration values.
@@ -28,13 +39,15 @@ def set_config(
         debug_rule_flag_val: Enable debug mode for detailed output
         debug_rule_name_val: Name of specific rule to run in debug mode
         max_workers_val: Maximum number of concurrent workers
-        namespace_val: Namespace for debug pods (default: "default")
+        namespace_val: Namespace for debug pods (auto-generated if empty)
+        namespace_user_provided_val: Whether the namespace was explicitly provided by the user
         light_run_val: Enable light-run mode (exclude resource-intensive rules, default: False)
 
     Raises:
         ValueError: If active_profile_val is not provided or is empty
     """
-    global debug_rule_flag, debug_rule_name, max_workers, profiles_hierarchy, active_profile, namespace, light_run
+    global debug_rule_flag, debug_rule_name, max_workers, profiles_hierarchy, active_profile, namespace
+    global namespace_user_provided, light_run
 
     # Validate active_profile is set
     if not active_profile_val:
@@ -44,7 +57,8 @@ def set_config(
     debug_rule_name = debug_rule_name_val
     max_workers = max_workers_val
     active_profile = active_profile_val
-    namespace = namespace_val
+    namespace = namespace_val if namespace_val else _generate_namespace_name()
+    namespace_user_provided = namespace_user_provided_val
     light_run = light_run_val
     profiles_hierarchy = Profiles()
     ProfileLoader.load(profiles_hierarchy)

--- a/src/in_cluster_checks/runner.py
+++ b/src/in_cluster_checks/runner.py
@@ -9,7 +9,7 @@ import importlib
 import logging
 import pkgutil
 from pathlib import Path
-from typing import Dict
+from typing import Dict, Optional
 
 from in_cluster_checks import global_config
 from in_cluster_checks.core.data_collector_runner import DataCollectorRunner
@@ -37,7 +37,7 @@ class InClusterCheckRunner:
         debug_rule_flag: bool = False,
         debug_rule_name: str = "",
         namespace: str = "",
-        namespace_user_provided: bool = False,
+        namespace_user_provided: Optional[bool] = None,
         max_workers: int = 50,
         domain_package: str = "in_cluster_checks.domains",
         light_run: bool = False,
@@ -50,11 +50,15 @@ class InClusterCheckRunner:
             debug_rule_flag: Enable debug mode for detailed output
             debug_rule_name: Name of specific rule to run in debug mode
             namespace: Namespace for debug pods (auto-generated if empty)
-            namespace_user_provided: Whether the namespace was explicitly provided by the user
+            namespace_user_provided: Whether the namespace was explicitly provided by the user.
+                If None (default), derived from whether namespace is non-empty.
             max_workers: Maximum number of concurrent workers for parallel execution
             domain_package: Python package path for domain discovery
             light_run: Enable light-run mode (exclude resource-intensive rules, default: False)
         """
+        if namespace_user_provided is None:
+            namespace_user_provided = bool(namespace)
+
         self.logger = logging.getLogger(__name__)
         self.domain_package = domain_package
         self.factory = None
@@ -181,10 +185,10 @@ class InClusterCheckRunner:
         # 2. Ensure namespace exists (creates if needed, only for default namespace)
         self.factory.ensure_namespace()
 
-        # 3. Validate namespace permissions before attempting connections
-        self.factory.validate_namespace_permissions()
-
         try:
+            # 3. Validate namespace permissions before attempting connections
+            self.factory.validate_namespace_permissions()
+
             # 4. Connect to all nodes
             self.factory.connect_all()
             # 5. Discover and instantiate domains

--- a/src/in_cluster_checks/runner.py
+++ b/src/in_cluster_checks/runner.py
@@ -36,7 +36,8 @@ class InClusterCheckRunner:
         active_profile: str = "general",
         debug_rule_flag: bool = False,
         debug_rule_name: str = "",
-        namespace: str = "default",
+        namespace: str = "",
+        namespace_user_provided: bool = False,
         max_workers: int = 50,
         domain_package: str = "in_cluster_checks.domains",
         light_run: bool = False,
@@ -48,7 +49,8 @@ class InClusterCheckRunner:
             active_profile: Active profile name (default: 'general'). Examples: 'general', 'nvidia', 'telco'
             debug_rule_flag: Enable debug mode for detailed output
             debug_rule_name: Name of specific rule to run in debug mode
-            namespace: Namespace for debug pods (default: "default")
+            namespace: Namespace for debug pods (auto-generated if empty)
+            namespace_user_provided: Whether the namespace was explicitly provided by the user
             max_workers: Maximum number of concurrent workers for parallel execution
             domain_package: Python package path for domain discovery
             light_run: Enable light-run mode (exclude resource-intensive rules, default: False)
@@ -64,6 +66,7 @@ class InClusterCheckRunner:
             debug_rule_flag_val=debug_rule_flag,
             debug_rule_name_val=debug_rule_name,
             namespace_val=namespace,
+            namespace_user_provided_val=namespace_user_provided,
             max_workers_val=max_workers,
             light_run_val=light_run,
         )
@@ -175,21 +178,24 @@ class InClusterCheckRunner:
         self.node_executors = self.factory.build_host_executors()
         self.logger.info(f"Built {len(self.node_executors)} node executor(s)")
 
-        # 2. Validate namespace permissions before attempting connections
+        # 2. Ensure namespace exists (creates if needed, only for default namespace)
+        self.factory.ensure_namespace()
+
+        # 3. Validate namespace permissions before attempting connections
         self.factory.validate_namespace_permissions()
 
         try:
-            # 3. Connect to all nodes
+            # 4. Connect to all nodes
             self.factory.connect_all()
-            # 4. Discover and instantiate domains
+            # 5. Discover and instantiate domains
             available_domain_classes = self.discover_domains()
             domains = {name: domain_class() for name, domain_class in available_domain_classes.items()}
             self.logger.info(f"Running {len(domains)} in-cluster domain(s): {', '.join(domains.keys())}")
 
-            # 5. Build component map for all rules
+            # 6. Build component map for all rules
             rule_component_map = self.build_component_map(domains)
 
-            # 6. Run in-cluster RuleDomains
+            # 7. Run in-cluster RuleDomains
             results = []
             for domain_name, domain in domains.items():
                 self.logger.info(f"Running in-cluster domain: {domain_name}")
@@ -199,24 +205,25 @@ class InClusterCheckRunner:
             # Clear data collector cache after all domains complete
             DataCollectorRunner.clear_data_collector_cache()
 
-            # 7. Aggregate and format results
+            # 8. Aggregate and format results
             reports = StructedPrinter.format_results(results, rule_component_map)
 
-            # 8. Generate JSON output (skip in debug mode)
+            # 9. Generate JSON output (skip in debug mode)
             if not global_config.debug_rule_flag:
                 StructedPrinter.print_to_json(reports, str(output_path))
                 self.logger.info(f"In-cluster check results saved to: {output_path}")
             else:
                 self.logger.info("Debug mode: JSON output disabled")
 
-            # 9. Log summary
+            # 10. Log summary
             self.log_summary(reports)
 
             return str(output_path)
 
         finally:
-            # 10. Cleanup: disconnect from all nodes
+            # 11. Cleanup: disconnect from all nodes, then delete namespace if we created it
             if self.factory:
                 self.factory.disconnect_all()
+                self.factory.delete_namespace()
 
             self.logger.info("Direct in-cluster rule checks completed")

--- a/tests/core/test_executor.py
+++ b/tests/core/test_executor.py
@@ -19,7 +19,7 @@ class TestNodeExecutor:
     @patch('in_cluster_checks.core.executor.oc')
     def test_init(self, mock_oc):
         """Test NodeExecutor initialization."""
-        executor = NodeExecutor("test-node", "192.168.1.10", "default")
+        executor = NodeExecutor("test-node", "192.168.1.10")
 
         assert executor.node_name == "test-node"
         assert executor.ip == "192.168.1.10"

--- a/tests/core/test_executor_factory.py
+++ b/tests/core/test_executor_factory.py
@@ -308,6 +308,98 @@ class TestNodeExecutorFactory:
         global_config.namespace = "test-default"
 
     @patch("in_cluster_checks.core.executor_factory.oc")
+    def test_ensure_namespace_skips_when_user_provided(self, mock_oc):
+        """Test that ensure_namespace skips creation when namespace is user-provided."""
+        global_config.namespace = "my-custom-ns"
+        global_config.namespace_user_provided = True
+        factory = NodeExecutorFactory()
+
+        factory.ensure_namespace()
+
+        mock_oc.invoke.assert_not_called()
+        assert factory._namespace_created is False
+
+        global_config.namespace_user_provided = False
+
+    @patch("in_cluster_checks.core.executor_factory.oc")
+    def test_ensure_namespace_raises_if_already_exists(self, mock_oc):
+        """Test that ensure_namespace raises RuntimeError if namespace already exists."""
+        global_config.namespace = "incluster-checks-abc123"
+        global_config.namespace_user_provided = False
+        factory = NodeExecutorFactory()
+
+        mock_result = Mock()
+        mock_result.status.return_value = 0
+        mock_oc.invoke.return_value = mock_result
+        mock_oc.timeout.return_value.__enter__ = Mock()
+        mock_oc.timeout.return_value.__exit__ = Mock(return_value=False)
+
+        with pytest.raises(RuntimeError, match="already exists"):
+            factory.ensure_namespace()
+
+        assert factory._namespace_created is False
+
+    @patch("in_cluster_checks.core.executor_factory.oc")
+    def test_ensure_namespace_creates_successfully(self, mock_oc):
+        """Test that ensure_namespace creates namespace with correct labels."""
+        global_config.namespace = "incluster-checks-abc123"
+        global_config.namespace_user_provided = False
+        factory = NodeExecutorFactory()
+
+        mock_result = Mock()
+        mock_result.status.return_value = 1
+        mock_oc.invoke.return_value = mock_result
+        mock_oc.timeout.return_value.__enter__ = Mock()
+        mock_oc.timeout.return_value.__exit__ = Mock(return_value=False)
+
+        factory.ensure_namespace()
+
+        assert factory._namespace_created is True
+        mock_oc.create.assert_called_once()
+
+    @patch("in_cluster_checks.core.executor_factory.oc")
+    def test_delete_namespace_skips_when_not_created(self, mock_oc):
+        """Test that delete_namespace is a no-op when namespace was not created."""
+        factory = NodeExecutorFactory()
+        factory._namespace_created = False
+
+        factory.delete_namespace()
+
+        mock_oc.invoke.assert_not_called()
+
+    @patch("in_cluster_checks.core.executor_factory.oc")
+    def test_delete_namespace_deletes_when_created(self, mock_oc):
+        """Test that delete_namespace deletes the namespace when it was created."""
+        global_config.namespace = "incluster-checks-abc123"
+        factory = NodeExecutorFactory()
+        factory._namespace_created = True
+
+        mock_oc.timeout.return_value.__enter__ = Mock()
+        mock_oc.timeout.return_value.__exit__ = Mock(return_value=False)
+
+        factory.delete_namespace()
+
+        mock_oc.invoke.assert_called_once_with(
+            "delete", ["namespace", "incluster-checks-abc123", "--wait=false"]
+        )
+        assert factory._namespace_created is False
+
+    @patch("in_cluster_checks.core.executor_factory.oc")
+    def test_delete_namespace_handles_failure_gracefully(self, mock_oc):
+        """Test that delete_namespace warns on failure and resets flag."""
+        global_config.namespace = "incluster-checks-abc123"
+        factory = NodeExecutorFactory()
+        factory._namespace_created = True
+
+        mock_oc.timeout.return_value.__enter__ = Mock()
+        mock_oc.timeout.return_value.__exit__ = Mock(return_value=False)
+        mock_oc.invoke.side_effect = Exception("delete failed")
+
+        factory.delete_namespace()
+
+        assert factory._namespace_created is False
+
+    @patch("in_cluster_checks.core.executor_factory.oc")
     def test_validate_namespace_permissions_success(self, mock_oc):
         """Test namespace permission validation when user has permissions."""
         global_config.namespace = "test-namespace"

--- a/tests/core/test_executor_factory.py
+++ b/tests/core/test_executor_factory.py
@@ -305,7 +305,7 @@ class TestNodeExecutorFactory:
         )
 
         # Reset global config
-        global_config.namespace = "default"
+        global_config.namespace = "test-default"
 
     @patch("in_cluster_checks.core.executor_factory.oc")
     def test_validate_namespace_permissions_success(self, mock_oc):
@@ -326,7 +326,7 @@ class TestNodeExecutorFactory:
         mock_oc.invoke.assert_called_once_with("auth", ["can-i", "create", "pods", "--namespace=test-namespace"])
 
         # Reset global config
-        global_config.namespace = "default"
+        global_config.namespace = "test-default"
 
     @patch("in_cluster_checks.core.executor_factory.oc")
     def test_validate_namespace_permissions_denied(self, mock_oc):
@@ -344,7 +344,7 @@ class TestNodeExecutorFactory:
             factory.validate_namespace_permissions()
 
         # Reset global config
-        global_config.namespace = "default"
+        global_config.namespace = "test-default"
 
     @patch("in_cluster_checks.core.executor_factory.oc")
     def test_validate_namespace_permissions_error(self, mock_oc):
@@ -360,4 +360,4 @@ class TestNodeExecutorFactory:
             factory.validate_namespace_permissions()
 
         # Reset global config
-        global_config.namespace = "default"
+        global_config.namespace = "test-default"

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -20,7 +20,7 @@ class TestInClusterCheckRunner:
         assert global_config.debug_rule_flag is False
         assert global_config.debug_rule_name == ""
         assert global_config.max_workers == 50
-        assert global_config.namespace == "default"
+        assert global_config.namespace.startswith("incluster-checks-")
 
     def test_init_custom_config(self):
         """Test runner initialization with custom parameters."""
@@ -42,12 +42,16 @@ class TestInClusterCheckRunner:
         # Verify global config was set with custom namespace
         assert global_config.namespace == "openshift-debug"
 
-    def test_init_namespace_default(self):
-        """Test runner initialization uses default namespace."""
-        runner = InClusterCheckRunner()
+    def test_init_namespace_auto_generated(self):
+        """Test runner initialization generates unique namespace."""
+        runner1 = InClusterCheckRunner()
+        ns1 = global_config.namespace
+        runner2 = InClusterCheckRunner()
+        ns2 = global_config.namespace
 
-        # Verify global config was set with default namespace
-        assert global_config.namespace == "default"
+        assert ns1.startswith("incluster-checks-")
+        assert ns2.startswith("incluster-checks-")
+        assert ns1 != ns2
 
     @patch('in_cluster_checks.runner.NodeExecutorFactory')
     def test_run_success(self, mock_executor_factory):


### PR DESCRIPTION
## Summary

- Debug pods now run in a unique auto-generated namespace per run (`incluster-checks-<uuid>`) instead of the shared `default` namespace
- Namespace is created with PodSecurity Admission labels (`enforce=privileged`, `audit/warn=restricted`)
- Namespace is deleted after the run completes
- CLI refuses `--namespace default` with a clear error message
- When user provides `--namespace`, namespace lifecycle (create/delete) is skipped

## Test plan

- [x] Run without `--namespace` — verify unique namespace is created and deleted
- [x] Run with `--namespace my-ns` — verify it uses the provided namespace without creating/deleting
- [x] Run with `--namespace default` — verify CLI exits with error
- [x] Verify two concurrent runs use different namespaces

Jira: https://redhat.atlassian.net/browse/PDRIVE-760

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Namespace can be omitted and will be generated automatically for each run.
  * Added automatic namespace lifecycle handling, including creation when needed and cleanup afterward.
  * Improved JSON output support.
* **Bug Fixes**
  * Using `--namespace default` now shows an error and exits instead of proceeding with an invalid value.
  * Runs now track whether the namespace was explicitly provided vs auto-generated to ensure safer cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->