### PR TITLE
feat(PDRIVE-760): add SBOM, provenance attestation to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,6 +58,7 @@ jobs:
       - build
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       id-token: write
       attestations: write
 
@@ -94,6 +95,7 @@ jobs:
       name: pypi
       url: https://pypi.org/p/in-cluster-checks
     permissions:
+      actions: read
       id-token: write
 
     steps:
@@ -112,6 +114,7 @@ jobs:
       - publish-to-pypi
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: write
 
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,16 +34,67 @@ jobs:
           name: python-package-distributions
           path: dist/
 
+      - name: Install SBOM tooling
+        run: pip install cyclonedx-bom
+
+      - name: Generate CycloneDX SBOM
+        run: |
+          python -m venv sbom-env
+          sbom-env/bin/python -m pip install dist/*.whl
+          cyclonedx-py environment sbom-env/bin/python \
+            --sv 1.6 --of JSON --output-reproducible \
+            --pyproject pyproject.toml --mc-type library \
+            --validate -o sbom.cdx.json
+
+      - name: Store the SBOM
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: sbom
+          path: sbom.cdx.json
+
+  attestations:
+    name: Generate attestations
+    needs:
+      - build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
+
+    steps:
+      - name: Download distribution packages
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
+      - name: Download SBOM
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: sbom
+
+      - name: Generate SLSA build provenance
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: "dist/*"
+
+      - name: Generate SBOM attestation
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        with:
+          subject-path: "dist/*"
+          sbom-path: "sbom.cdx.json"
+
   publish-to-pypi:
     name: Publish to PyPI
     needs:
       - build
+      - attestations
     runs-on: ubuntu-latest
     environment:
       name: pypi
       url: https://pypi.org/p/in-cluster-checks
     permissions:
-      id-token: write  # IMPORTANT: mandatory for trusted publishing
+      id-token: write
 
     steps:
       - name: Download all the dists
@@ -54,6 +105,26 @@ jobs:
 
       - name: Publish distribution to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+
+  release-assets:
+    name: Attach SBOM to GitHub Release
+    needs:
+      - publish-to-pypi
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download SBOM
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: sbom
+
+      - name: Upload SBOM to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: gh release upload "$TAG" sbom.cdx.json --clobber
 
   # Uncomment this job if you want to publish to TestPyPI first for testing
   # publish-to-testpypi:


### PR DESCRIPTION
## Summary

Addresses security audit finding **FIND-010** — publish workflow produces no SBOM, provenance attestation, or Sigstore signature.

- **SBOM**: Generate CycloneDX 1.6 JSON SBOM from the built wheel using `cyclonedx-bom`
- **SLSA provenance**: Add `actions/attest-build-provenance@v4.1.1` for signed build provenance attestation
- **SBOM attestation**: Add `actions/attest-sbom@v4.1.0` to sign the SBOM itself
- **Release assets**: Attach `sbom.cdx.json` to the GitHub Release
- **PyPI attestations**: Already enabled by default in `pypa/gh-action-pypi-publish` v1.11+ (PEP 740)

All new actions are SHA-pinned. Each job declares only the permissions it needs (least privilege).

### New workflow pipeline

```
build → attestations → publish-to-pypi → release-assets
```

Consumers can now verify artifacts with:
```bash
gh attestation verify <artifact> --owner RedHatInsights
```

## Test plan

- [x] YAML syntax validated locally
- [x] Action SHAs verified against GitHub tags
- [ ] Full end-to-end test requires creating a GitHub Release (triggers the workflow)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security and Compliance**
  * Builds now include a CycloneDX Software Bill of Materials (SBOM) for improved transparency into released packages.
  * Release artifacts are accompanied by SBOM and SLSA provenance attestations to help verify their origin and integrity.

* **Release Management**
  * The SBOM is attached to each corresponding GitHub Release for convenient download and review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->