### PR TITLE
fix(PDRIVE-760): fix SBOM attestation format detection

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
           python -m venv sbom-env
           sbom-env/bin/python -m pip install dist/*.whl
           cyclonedx-py environment sbom-env/bin/python \
-            --sv 1.6 --of JSON --output-reproducible \
+            --sv 1.6 --of JSON \
             --pyproject pyproject.toml --mc-type library \
             --validate -o sbom.cdx.json
 


### PR DESCRIPTION
## Summary

Fixes the SBOM attestation failure in the v0.1.36 publish workflow.

**Root cause**: The `--output-reproducible` flag in `cyclonedx-py` strips the `serialNumber` field from the CycloneDX JSON output. The `actions/attest-sbom` action (which delegates to `actions/attest`) requires all three fields — `bomFormat`, `serialNumber`, and `specVersion` — to detect a valid CycloneDX SBOM ([source](https://github.com/actions/attest/blob/main/src/sbom.ts#L60-L66)).

**Fix**: Remove `--output-reproducible` flag so `serialNumber` is included in the SBOM.

## Test plan

- [ ] Merge and create a new release to trigger the publish workflow
- [ ] Verify `attestations` job passes (SLSA provenance + SBOM attestation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the software bill of materials generation process to produce CycloneDX JSON output without reproducible-output formatting.
  * All other publishing workflow steps remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->