### PR TITLE
chore: bump version to 0.1.37

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "in-cluster-checks"
-version = "0.1.36"
+version = "0.1.37"
 description = "Generic framework for running health validation rules on OpenShift cluster nodes"
 readme = "README.md"
 license = "BSD-3-Clause"


### PR DESCRIPTION
## Summary

- Bump version to 0.1.37 for release with SBOM attestation fix (#102)

## Test plan

- [x] Version updated in pyproject.toml