### PR TITLE
fix(PDRIVE-760): pass --repo to gh release upload

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -127,7 +127,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.event.release.tag_name }}
-        run: gh release upload "$TAG" sbom.cdx.json --clobber
+        run: gh release upload "$TAG" sbom.cdx.json --clobber --repo "${{ github.repository }}"
 
   # Uncomment this job if you want to publish to TestPyPI first for testing
   # publish-to-testpypi:


### PR DESCRIPTION
## Summary

Fixes `release-assets` job failure: `fatal: not a git repository`.

The `gh release upload` command requires a git repo context to determine the owner/repo. Since the job only downloads an artifact (no checkout), pass `--repo` explicitly via `${{ github.repository }}`.

## Test plan

- [ ] Merge, delete v0.1.36 release/tag, re-tag and re-release to verify