### PR TITLE
chore(PDRIVE-760): add SECURITY.md vulnerability disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,9 +2,13 @@
 
 ## Supported Versions
 
-| Version | Supported |
-|---------|-----------|
-| Latest  | Yes       |
+Only the latest release is supported. Fixes (including security fixes) are
+shipped in new releases and are not backported to older versions.
+
+| Version | Supported          |
+|---------|--------------------|
+| 0.1.x   | :white_check_mark: |
+| < 0.1   | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| Latest  | Yes       |
+
+## Reporting a Vulnerability
+
+**Do NOT open a public GitHub issue for security vulnerabilities.**
+
+Please report security vulnerabilities by emailing
+[secalert@redhat.com](mailto:secalert@redhat.com).
+
+You can also visit the [Product Security Center](https://access.redhat.com/security/)
+or [contact our security team](https://access.redhat.com/security/team/contact/).
+
+If you are a Red Hat customer, you may also
+[contact our support](https://access.redhat.com/support/).
+
+## Response SLA
+
+We aim to acknowledge reports within 3 business days and provide an initial
+assessment within 10 business days.


### PR DESCRIPTION
## Summary

- Add `SECURITY.md` with vulnerability disclosure policy referencing Red Hat Product Security (`secalert@redhat.com`)
- Include supported versions table and response SLA (3 business days acknowledgment, 10 business days initial assessment)
- Addresses FIND-012 from security audit (missing SECURITY.md)

## Test plan

- [x] Verify SECURITY.md content matches RedHatInsights conventions
- [x] Verify `secalert@redhat.com` is listed as primary contact
- [x] Verify response SLA is included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a security policy outlining supported versions and release coverage.
  * Provided private channels for reporting vulnerabilities and alternative security contacts.
  * Documented expected acknowledgement and initial assessment timelines for security reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->