### PR TITLE
fix(PDRIVE-799): restrict output file permissions to owner-only (0o600)

### DIFF
--- a/src/in_cluster_checks/core/printer.py
+++ b/src/in_cluster_checks/core/printer.py
@@ -7,6 +7,7 @@ Outputs in Insights-compatible format similar to pg.json
 
 import json
 import logging
+import os
 from collections import OrderedDict
 from typing import Any, Dict
 
@@ -303,13 +304,15 @@ class StructedPrinter:
     @staticmethod
     def print_to_json(results: Dict[str, Any], output_file: str) -> None:
         """
-        Write rule results to JSON file.
+        Write rule results to JSON file with restricted permissions (owner-only).
 
         Args:
             results: Dictionary with rule results in Insights format
             output_file: Path to output JSON file
         """
-        with open(output_file, "w") as f:
+        file_descriptor = os.open(output_file, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(file_descriptor, "w") as f:
+            os.fchmod(f.fileno(), 0o600)
             json.dump(results, f, indent=2, default=str)
 
     @staticmethod

--- a/tests/core/test_printer.py
+++ b/tests/core/test_printer.py
@@ -3,6 +3,8 @@ Tests for StructedPrinter (JSON formatter).
 """
 
 import json
+import os
+import stat
 import tempfile
 from collections import OrderedDict
 from pathlib import Path
@@ -17,7 +19,7 @@ class TestStructedPrinter:
     """Test StructedPrinter JSON formatting."""
 
     def test_print_to_json_creates_file(self, tmp_path):
-        """Test that print_to_json creates a JSON file."""
+        """Test that print_to_json creates a JSON file with restricted permissions."""
         output_file = tmp_path / "test_output.json"
 
         test_data = {
@@ -32,6 +34,25 @@ class TestStructedPrinter:
             loaded_data = json.load(f)
 
         assert loaded_data == test_data
+
+        file_mode = stat.S_IMODE(os.stat(output_file).st_mode)
+        assert file_mode == 0o600
+
+    def test_print_to_json_overwrites_existing_file(self, tmp_path):
+        """Test that print_to_json overwrites an existing file and sets restricted permissions."""
+        output_file = tmp_path / "test_output.json"
+        output_file.write_text('{"old": "data"}')
+        os.chmod(output_file, 0o644)
+
+        new_data = {"new": "data"}
+        StructedPrinter.print_to_json(new_data, str(output_file))
+
+        with open(output_file) as f:
+            loaded_data = json.load(f)
+        assert loaded_data == new_data
+
+        file_mode = stat.S_IMODE(os.stat(output_file).st_mode)
+        assert file_mode == 0o600
 
     def test_format_results_insights_format(self):
         """Test that format_results produces Insights-compatible format with grouped hosts."""


### PR DESCRIPTION
## Summary

Fixes security audit finding FIND-014: the output JSON file (`cluster-checks.json`) was created with default umask permissions (typically `0644`, world-readable), but contains sensitive cluster data (node IPs, executed commands, firmware versions, certificate paths).

**Ticket**: https://redhat.atlassian.net/browse/PDRIVE-799

### Changes

- `print_to_json()` now uses `os.open()` with `0o600` + `os.fchmod()` to ensure the file is always owner-only (read/write), both for new files and when overwriting existing ones
- Added permission assertion to the existing `test_print_to_json_creates_file` test
- Added `test_print_to_json_overwrites_existing_file` test to verify permissions are tightened when overwriting a pre-existing file with looser permissions

### Testing

- All 884 tests pass
- All pre-commit checks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Improvements**
  * JSON output files are now created with restricted, owner-only permissions to limit access.
  * Overwriting an existing JSON file now also applies the same restricted permissions while keeping the JSON content correct.
* **Bug Fixes**
  * Improved JSON file writing behavior to ensure the output is reliably generated with the intended access permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->