### PR TITLE
chore: bump version to 0.1.40

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "in-cluster-checks"
-version = "0.2.0"
+version = "0.1.40"
 description = "Generic framework for running health validation rules on OpenShift cluster nodes"
 readme = "README.md"
 license = "BSD-3-Clause"


### PR DESCRIPTION
Automated version bump to 0.1.40 from Pendrive release pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version to 0.1.40.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->