### PR TITLE
feat(PDRIVE-806): replace all-namespaces pod check with scoped infra rule

### DIFF
--- a/.claude/rules/confluence-guidelines.md
+++ b/.claude/rules/confluence-guidelines.md
@@ -21,8 +21,32 @@ Example location: `src/in_cluster_checks/rules/network/ovs_validations.py`
 
 ## Step 2: Create Confluence Page
 
-**Naming convention:** `<Domain>-<Rule-Name>`
-- Examples: `Network-OVS-Physical-Port-Health-Check`, `Storage-Disk-Space-Check`
+**Title convention:** Use the rule's `title` field exactly as defined in the class.
+- Examples: `Verify infrastructure pods are ready and running`, `TLS certificate expiry`, `Check deployment replicas status`
+- The page is placed under the appropriate domain parent page (K8s, Network, Security, etc.), so no domain prefix is needed in the title.
+
+**Domain parent page IDs** (under [In-Cluster Checks Rules](https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418417677)):
+- DPF: `418450735`
+- Hardware: `418418340`
+- K8s: `418516155`
+- Linux: `418482835`
+- Network: `418482854`
+- Resources: `418450807`
+- Security: `418516403`
+
+**Space ID:** `377096307`
+
+**Create pages using the Confluence MCP tool:**
+```python
+mcp__plugin_atlassian_atlassian__createConfluencePage(
+  cloudId: "redhat.atlassian.net",
+  spaceId: "377096307",
+  parentId: "<domain-parent-page-id>",
+  title: "<rule-title>",
+  contentFormat: "html",
+  body: "<page-content>"
+)
+```
 
 **Template sections (in order):**
 1. **Description** - What the rule checks and when it fails (1-3 sentences)
@@ -237,5 +261,6 @@ Or use numbered steps for multi-step procedures:
 
 ## Documentation Page Examples
 
-- [Security - TLS certificate expiry](https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418482936)
-- [Security - Node certificate expiry](https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418418558)
+- [TLS certificate expiry](https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418482936)
+- [Node certificate expiry](https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418418558)
+- [Verify infrastructure pods are ready and running](https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/435226813)

--- a/.claude/rules/in-cluster-check.md
+++ b/.claude/rules/in-cluster-check.md
@@ -101,8 +101,9 @@ All rules use the `Status` enum (`utils/enums.py`):
 **Creating Documentation Page Content:**
 - **Workflow**:
   1. Read an existing Confluence page as a template (e.g., [TLS certificate expiry](https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418482936))
-  2. Create the new documentation page in Confluence under the appropriate domain
+  2. Create the new documentation page in Confluence under the appropriate domain using `mcp__plugin_atlassian_atlassian__createConfluencePage`
   3. Add the Confluence page URL to the rule's `links` field
+- **Page title**: Use the rule's `title` field exactly (e.g., "Verify infrastructure pods are ready and running"), not a `Domain-Rule-Name` format
 
 **Documentation Page Structure:**
 All documentation pages should follow this standard structure:
@@ -115,7 +116,7 @@ All documentation pages should follow this standard structure:
   - **Resources**: Links to official documentation, KCS articles, troubleshooting guides
 
 **Documentation Page Examples:**
-- See existing templates: [Security - TLS certificate expiry](https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418482936), [Security - Node certificate expiry](https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418418558)
+- See existing templates: [TLS certificate expiry](https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418482936), [Node certificate expiry](https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418418558)
 
 **Detailed Documentation Creation:**
 For comprehensive guidelines on creating Confluence documentation pages, see [@.claude/rules/confluence-guidelines.md](confluence-guidelines.md).

--- a/.claude/skills/implement-rule-from-jira/SKILL.md
+++ b/.claude/skills/implement-rule-from-jira/SKILL.md
@@ -144,15 +144,26 @@ Ensure all tests pass before proceeding.
 
 ### 6a. Review Existing Template
 
-Read an existing Confluence page as a template:
-- [TLS certificate expiry](https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418482936)
-- [Node certificate expiry](https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418418558)
+Read an existing Confluence page as a template using Confluence MCP:
+- [TLS certificate expiry](https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418482936) (page ID: 418482936)
+- [Node certificate expiry](https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418418558) (page ID: 418418558)
 
-### 6b. Generate Documentation Content
+### 6b. Create Documentation Page via Confluence MCP
 
-Create documentation page content following the standard structure:
+Create the page directly using `mcp__plugin_atlassian_atlassian__createConfluencePage`.
 
-**Standard Structure**:
+**Page title**: Use the rule's `title` field exactly (e.g., "Verify infrastructure pods are ready and running").
+
+**Domain parent page IDs** (space ID: `377096307`):
+- DPF: `418450735`
+- Hardware: `418418340`
+- K8s: `418516155`
+- Linux: `418482835`
+- Network: `418482854`
+- Resources: `418450807`
+- Security: `418516403`
+
+**Standard Structure** (use `contentFormat: "html"`):
 - **Description**: What the rule checks, why it's important, severity, failure thresholds
 - **Prerequisites**: Required access, tools, or conditions
 - **Impact**: What happens if the condition fails
@@ -161,28 +172,13 @@ Create documentation page content following the standard structure:
 - **Solution**: Step-by-step remediation with code examples
 - **Resources**: Links to official docs, KCS articles, guides
 
-### 6c. Present Documentation Content
+See @.claude/rules/confluence-guidelines.md for detailed formatting rules.
 
-Show the complete page content in a markdown code block for easy copy-paste:
+### 6c. Add Confluence Link to Rule
 
-```
-Here's the documentation page content for your new rule.
-
-**IMPORTANT - Manual Steps Required:**
-
-1. **Navigate to**: https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418417677/In-Cluster+Checks+Rules
-2. Open the appropriate **domain page** (e.g., Network, K8s, Security)
-3. Click **Create** to add a child page
-4. Set the title to the rule's title
-5. Paste the content from below
-6. **Publish** the page
-7. **Copy the page URL** and add it to the rule's `links` field
-
-```markdown
-[Documentation content here]
-```
-
-**Note**: After creating the page, copy the Confluence URL and update the rule's `links` field to match.
+After page creation, the MCP tool returns the page ID. Add the link to the rule's `links` field:
+```python
+links = ["https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/{PAGE_ID}"]
 ```
 
 ## Step 7: Run All Tests
@@ -276,7 +272,6 @@ Use `mcp__plugin_github_github__create_pull_request`:
   
   ## Documentation
   Confluence page: https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/{PAGE_ID}
-  (Will be created after PR approval)
   ```
 
 Return the PR URL to the user.
@@ -328,10 +323,8 @@ Before marking complete, verify:
 - [ ] Tests written with passed and failed scenarios
 - [ ] All tests passing
 - [ ] Pre-commit checks passing
-- [ ] Documentation page content created and provided to user
-- [ ] User instructed to create Confluence page under appropriate domain
+- [ ] Confluence documentation page created via MCP under appropriate domain
 - [ ] Confluence link added to rule's `links` field
-- [ ] User reminded to verify Confluence link matches actual page URL
 - [ ] Committed with conventional commit format
 - [ ] Rebased on upstream/main
 - [ ] Pushed to origin
@@ -352,7 +345,7 @@ Expected flow:
 6. Create rule in src/in_cluster_checks/rules/network/
 7. Register in NetworkValidationDomain
 8. Create tests in tests/rules/network/
-9. Generate documentation page content and provide to user
+9. Create Confluence documentation page via MCP under Network domain
 10. Run tests → all pass ✓
 11. Commit with: feat(PDRIVE-505): add network connectivity validation
 12. Rebase on upstream/main

--- a/src/in_cluster_checks/domains/k8s_domain.py
+++ b/src/in_cluster_checks/domains/k8s_domain.py
@@ -8,11 +8,11 @@ Based on HealthChecks/flows/K8s/k8s_components/K8s_flow.py
 from typing import List
 
 from in_cluster_checks.core.domain import RuleDomain
-from in_cluster_checks.rules.k8s.k8s_validations import (
+from in_cluster_checks.rules.k8s.k8s_validations import (  # AllPodsReadyAndRunning disabled (PDRIVE-806)
     AllDeploymentsAvailable,
-    AllPodsReadyAndRunning,
     AllStatefulsetsReady,
     CheckDeploymentsReplicaStatus,
+    InfraPodsReadyAndRunning,
     NodesAreReady,
     NodesCpuAndMemoryStatus,
     OpenshiftOperatorStatus,
@@ -53,7 +53,8 @@ class K8sValidationDomain(RuleDomain):
             List of Rule classes
         """
         return [
-            AllPodsReadyAndRunning,
+            # AllPodsReadyAndRunning,  # Disabled: replaced by InfraPodsReadyAndRunning (PDRIVE-806)
+            InfraPodsReadyAndRunning,
             NodesAreReady,
             NodesCpuAndMemoryStatus,
             ValidateNamespaceStatus,

--- a/src/in_cluster_checks/rules/k8s/k8s_validations.py
+++ b/src/in_cluster_checks/rules/k8s/k8s_validations.py
@@ -5,6 +5,7 @@ Direct port from: HealthChecks/flows/K8s/k8s_components/k8s_sanity_checks.py
 """
 
 import json
+from datetime import datetime, timezone
 
 from in_cluster_checks.core.exceptions import UnExpectedSystemOutput
 from in_cluster_checks.core.rule import OrchestratorRule
@@ -96,6 +97,160 @@ class AllPodsReadyAndRunning(OrchestratorRule):
                 ready_pods.append(pod_info)
 
         return ready_pods, not_running_pods
+
+
+class InfraPodsReadyAndRunning(OrchestratorRule):
+    """Verify pods in infrastructure namespaces are ready and running.
+
+    Scoped replacement for AllPodsReadyAndRunning that only checks critical
+    OpenShift infrastructure namespaces, avoiding scale/memory issues and
+    false positives from user workload pods.
+    """
+
+    objective_hosts = [Objectives.ORCHESTRATOR]
+    unique_name = "infra_pods_ready_and_running"
+    title = "Verify infrastructure pods are ready and running"
+    links = ["https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/435226813"]
+
+    HISTORICAL_POD_AGE_THRESHOLD = 86400  # 24 hours in seconds
+
+    INFRA_NAMESPACES = [
+        "openshift-etcd",
+        "openshift-kube-apiserver",
+        "openshift-kube-controller-manager",
+        "openshift-kube-scheduler",
+        "openshift-apiserver",
+        "openshift-controller-manager",
+        "openshift-machine-api",
+        "openshift-machine-config-operator",
+        "openshift-ingress",
+        "openshift-dns",
+        "openshift-sdn",
+        "openshift-ovn-kubernetes",
+        "openshift-multus",
+        "openshift-monitoring",
+        "openshift-image-registry",
+        "openshift-authentication",
+        "openshift-oauth-apiserver",
+        "openshift-operator-lifecycle-manager",
+        "openshift-marketplace",
+        "openshift-console",
+        "openshift-cluster-storage-operator",
+        "openshift-network-operator",
+    ]
+
+    def run_rule(self):
+        """Check if infrastructure pods are ready and running."""
+        ready_pods, not_running_pods, old_failed_pods = self._get_pods_lists()
+
+        if len(ready_pods) == 0 and len(not_running_pods) == 0 and len(old_failed_pods) == 0:
+            return RuleResult.failed("Did not get any pods from infrastructure namespaces")
+
+        threshold_hours = self.HISTORICAL_POD_AGE_THRESHOLD // 3600
+
+        if not_running_pods:
+            message = "Not all infrastructure pods are running\n"
+            message += "Following pods are not running or partially not ready:\n"
+            for pod_info in not_running_pods:
+                namespace = pod_info["namespace"]
+                pod_name = pod_info["name"]
+                status = pod_info["status"]
+                ready = pod_info["ready"]
+                message += f"  {namespace}/{pod_name} - Ready: {ready}, Status: {status}\n"
+            if old_failed_pods:
+                message += f"\nOld (>{threshold_hours}h) failed pods (non-critical):\n"
+                for pod_info in old_failed_pods:
+                    message += f"  {pod_info['namespace']}/{pod_info['name']}\n"
+            return RuleResult.failed(message)
+
+        if old_failed_pods:
+            message = f"Found old (>{threshold_hours}h) failed pods in infrastructure namespaces:\n"
+            for pod_info in old_failed_pods:
+                message += f"  {pod_info['namespace']}/{pod_info['name']}\n"
+            return RuleResult.warning(message)
+
+        return RuleResult.passed()
+
+    def _get_pods_lists(self):
+        """Get lists of ready, not-ready, and old failed pods from infrastructure namespaces.
+
+        Old Failed Job/CronJob pods are skipped entirely.
+        Other old Failed pods are collected separately for warning.
+
+        Returns:
+            tuple: (ready_pods_list, not_running_pods_list, old_failed_pods_list)
+        """
+        ready_pods = []
+        not_running_pods = []
+        old_failed_pods = []
+
+        for namespace in self.INFRA_NAMESPACES:
+            pod_objects = self.oc_api.get_pods(namespace=namespace, timeout=30)
+            if not pod_objects:
+                continue
+
+            for pod in pod_objects:
+                pod_data = pod.as_dict()
+                pod_name = pod_data["metadata"]["name"]
+                status_dict = pod_data.get("status", {})
+                phase = status_dict.get("phase", "Unknown")
+
+                if phase == "Succeeded":
+                    continue
+
+                if phase == "Failed" and self._is_old_pod(pod_data, self.HISTORICAL_POD_AGE_THRESHOLD):
+                    if self._is_job_or_cronjob_owned(pod_data):
+                        continue
+                    old_failed_pods.append({"namespace": namespace, "name": pod_name})
+                    continue
+
+                container_statuses = status_dict.get("containerStatuses", [])
+                total_containers = len(container_statuses)
+                ready_containers = sum(1 for c in container_statuses if c.get("ready", False))
+                ready_str = f"{ready_containers}/{total_containers}"
+
+                pod_info = {
+                    "namespace": namespace,
+                    "name": pod_name,
+                    "status": phase,
+                    "ready": ready_str,
+                }
+
+                if phase != "Running" or total_containers == 0 or ready_containers != total_containers:
+                    not_running_pods.append(pod_info)
+                else:
+                    ready_pods.append(pod_info)
+
+        return ready_pods, not_running_pods, old_failed_pods
+
+    @staticmethod
+    def _is_job_or_cronjob_owned(pod_data: dict) -> bool:
+        """Check if a pod is owned by a Job or CronJob."""
+        owner_references = pod_data.get("metadata", {}).get("ownerReferences", [])
+        return any(ref.get("kind") in ("Job", "CronJob") for ref in owner_references)
+
+    @staticmethod
+    def _is_old_pod(pod_data: dict, threshold_seconds: int) -> bool:
+        """Check if a pod is older than the given threshold.
+
+        Uses the most recent container finishedAt if available, otherwise falls back to creationTimestamp.
+        """
+        finished_timestamps = []
+        for cs in pod_data.get("status", {}).get("containerStatuses", []):
+            finished_at = cs.get("state", {}).get("terminated", {}).get("finishedAt")
+            if finished_at:
+                finished_timestamps.append(finished_at)
+        timestamp_str = max(finished_timestamps) if finished_timestamps else None
+        if not timestamp_str:
+            timestamp_str = pod_data.get("metadata", {}).get("creationTimestamp")
+        if not timestamp_str:
+            return False
+        try:
+            parsed_time = datetime.fromisoformat(timestamp_str.replace("Z", "+00:00"))
+            age_seconds = (datetime.now(timezone.utc) - parsed_time).total_seconds()
+            return age_seconds > threshold_seconds
+        except (ValueError, AttributeError) as err:
+            raise UnExpectedSystemOutput(f"Failed to parse pod timestamp: {timestamp_str}") from err
 
 
 class NodesAreReady(OrchestratorRule):

--- a/tests/domains/test_k8s_domain.py
+++ b/tests/domains/test_k8s_domain.py
@@ -2,7 +2,7 @@
 
 from in_cluster_checks.domains.k8s_domain import K8sValidationDomain
 from in_cluster_checks.rules.k8s.k8s_validations import (
-    AllPodsReadyAndRunning,
+    InfraPodsReadyAndRunning,
     NodesAreReady,
     NodesCpuAndMemoryStatus,
     OpenshiftOperatorStatus,
@@ -10,7 +10,7 @@ from in_cluster_checks.rules.k8s.k8s_validations import (
     ValidateAllPoliciesCompliant,
     ValidateNamespaceStatus,
     VerifyClusterOperatorsAvailable,
-VerifyFARControllerReplicas,
+    VerifyFARControllerReplicas,
     VerifyInternalRegistry,
     VerifyNetworkDiagnosticsDisabled,
     VerifyWebConsoleDisabled,
@@ -36,7 +36,7 @@ def test_k8s_domain_rules():
     rules = domain.get_rule_classes()
 
     assert len(rules) == 20
-    assert AllPodsReadyAndRunning in rules
+    assert InfraPodsReadyAndRunning in rules
     assert NodesAreReady in rules
     assert NodesCpuAndMemoryStatus in rules
     assert ValidateNamespaceStatus in rules

--- a/tests/rules/k8s/test_k8s_validations.py
+++ b/tests/rules/k8s/test_k8s_validations.py
@@ -13,6 +13,7 @@ from in_cluster_checks.rules.k8s.k8s_validations import (
     AllDeploymentsAvailable,
     AllPodsReadyAndRunning,
     AllStatefulsetsReady,
+    InfraPodsReadyAndRunning,
     CheckDeploymentsReplicaStatus,
     NodesAreReady,
     NodesCpuAndMemoryStatus,
@@ -99,6 +100,230 @@ class TestAllPodsReadyAndRunning:
         result = tested_object.run_rule()
         assert result.status == Status.FAILED
         assert "Did not get any pods" in result.message
+
+
+def create_mock_infra_pod(
+    namespace, name, phase, ready_containers, total_containers, owner_kind=None, creation_timestamp=None,
+    finished_at=None,
+):
+    """Create a mock pod object with optional owner and timestamp fields."""
+    mock_pod = Mock()
+    container_statuses = [{"ready": i < ready_containers} for i in range(total_containers)]
+    if finished_at and container_statuses:
+        container_statuses[0]["state"] = {"terminated": {"finishedAt": finished_at}}
+    pod_dict = {
+        "metadata": {"namespace": namespace, "name": name},
+        "status": {
+            "phase": phase,
+            "containerStatuses": container_statuses,
+        },
+    }
+    if owner_kind:
+        pod_dict["metadata"]["ownerReferences"] = [{"kind": owner_kind}]
+    if creation_timestamp:
+        pod_dict["metadata"]["creationTimestamp"] = creation_timestamp
+    mock_pod.as_dict.return_value = pod_dict
+    return mock_pod
+
+
+class TestInfraPodsReadyAndRunning:
+    """Test InfraPodsReadyAndRunning rule."""
+
+    @pytest.fixture
+    def tested_object(self):
+        """Create instance of InfraPodsReadyAndRunning for testing."""
+        return InfraPodsReadyAndRunning(host_executor=Mock(), node_executors={})
+
+    def test_all_infra_pods_running(self, tested_object):
+        """Test when all infrastructure pods are running and ready."""
+        def mock_get_pods(namespace, timeout=30):
+            if namespace == "openshift-etcd":
+                return [create_mock_infra_pod("openshift-etcd", "etcd-master-0", "Running", 3, 3)]
+            if namespace == "openshift-kube-apiserver":
+                return [create_mock_infra_pod("openshift-kube-apiserver", "kube-apiserver-master-0", "Running", 2, 2)]
+            return []
+
+        tested_object.oc_api.get_pods = Mock(side_effect=mock_get_pods)
+        result = tested_object.run_rule()
+        assert result.status == Status.PASSED
+
+    def test_infra_pod_not_running(self, tested_object):
+        """Test when an infrastructure pod is in Pending state."""
+        def mock_get_pods(namespace, timeout=30):
+            if namespace == "openshift-etcd":
+                return [
+                    create_mock_infra_pod("openshift-etcd", "etcd-master-0", "Running", 3, 3),
+                    create_mock_infra_pod("openshift-etcd", "etcd-master-1", "Pending", 0, 3),
+                ]
+            return []
+
+        tested_object.oc_api.get_pods = Mock(side_effect=mock_get_pods)
+        result = tested_object.run_rule()
+        assert result.status == Status.FAILED
+        assert "etcd-master-1" in result.message
+        assert "Pending" in result.message
+
+    def test_infra_pod_partially_ready(self, tested_object):
+        """Test when a pod is Running but not all containers are ready."""
+        def mock_get_pods(namespace, timeout=30):
+            if namespace == "openshift-monitoring":
+                return [
+                    create_mock_infra_pod("openshift-monitoring", "prometheus-0", "Running", 1, 3),
+                ]
+            return []
+
+        tested_object.oc_api.get_pods = Mock(side_effect=mock_get_pods)
+        result = tested_object.run_rule()
+        assert result.status == Status.FAILED
+        assert "prometheus-0" in result.message
+        assert "1/3" in result.message
+
+    def test_completed_pods_ignored(self, tested_object):
+        """Test that Succeeded pods are skipped."""
+        def mock_get_pods(namespace, timeout=30):
+            if namespace == "openshift-etcd":
+                return [
+                    create_mock_infra_pod("openshift-etcd", "etcd-master-0", "Running", 3, 3),
+                    create_mock_infra_pod("openshift-etcd", "installer-1-completed", "Succeeded", 0, 1),
+                ]
+            return []
+
+        tested_object.oc_api.get_pods = Mock(side_effect=mock_get_pods)
+        result = tested_object.run_rule()
+        assert result.status == Status.PASSED
+
+    def test_no_infra_pods_found(self, tested_object):
+        """Test when no pods are found in any infrastructure namespace."""
+        tested_object.oc_api.get_pods = Mock(return_value=[])
+        result = tested_object.run_rule()
+        assert result.status == Status.FAILED
+        assert "Did not get any pods from infrastructure namespaces" in result.message
+
+    def test_old_failed_job_pod_skipped(self, tested_object):
+        """Test that old (>24h) Failed Job pods are skipped."""
+        def mock_get_pods(namespace, timeout=30):
+            if namespace == "openshift-image-registry":
+                return [
+                    create_mock_infra_pod("openshift-image-registry", "registry-pod", "Running", 1, 1),
+                    create_mock_infra_pod(
+                        "openshift-image-registry", "image-pruner-28000-abc",
+                        "Failed", 0, 1, owner_kind="Job",
+                        creation_timestamp="2020-01-01T00:00:00Z",
+                    ),
+                ]
+            return []
+
+        tested_object.oc_api.get_pods = Mock(side_effect=mock_get_pods)
+        result = tested_object.run_rule()
+        assert result.status == Status.PASSED
+
+    def test_recent_failed_job_pod_not_skipped(self, tested_object):
+        """Test that recent Failed Job pods are NOT skipped."""
+        from datetime import datetime, timezone
+
+        recent_time = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        def mock_get_pods(namespace, timeout=30):
+            if namespace == "openshift-image-registry":
+                return [
+                    create_mock_infra_pod("openshift-image-registry", "registry-pod", "Running", 1, 1),
+                    create_mock_infra_pod(
+                        "openshift-image-registry", "image-pruner-28001-xyz",
+                        "Failed", 0, 1, owner_kind="Job",
+                        creation_timestamp=recent_time,
+                    ),
+                ]
+            return []
+
+        tested_object.oc_api.get_pods = Mock(side_effect=mock_get_pods)
+        result = tested_object.run_rule()
+        assert result.status == Status.FAILED
+        assert "image-pruner-28001-xyz" in result.message
+
+    def test_old_failed_non_job_pod_warning(self, tested_object):
+        """Test that old Failed pods NOT owned by Job/CronJob produce a warning."""
+        def mock_get_pods(namespace, timeout=30):
+            if namespace == "openshift-etcd":
+                return [
+                    create_mock_infra_pod("openshift-etcd", "etcd-master-0", "Running", 3, 3),
+                    create_mock_infra_pod(
+                        "openshift-etcd", "installer-1-master-0",
+                        "Failed", 0, 1, owner_kind="ConfigMap",
+                        creation_timestamp="2020-01-01T00:00:00Z",
+                    ),
+                ]
+            return []
+
+        tested_object.oc_api.get_pods = Mock(side_effect=mock_get_pods)
+        result = tested_object.run_rule()
+        assert result.status == Status.WARNING
+        assert "installer-1-master-0" in result.message
+
+    def test_mixed_failed_and_old_failed_pods(self, tested_object):
+        """Test that FAILED result includes both not-running and old failed pods."""
+        def mock_get_pods(namespace, timeout=30):
+            if namespace == "openshift-etcd":
+                return [
+                    create_mock_infra_pod("openshift-etcd", "etcd-master-0", "Running", 3, 3),
+                    create_mock_infra_pod("openshift-etcd", "etcd-quorum-guard", "Pending", 0, 1),
+                ]
+            if namespace == "openshift-kube-apiserver":
+                return [
+                    create_mock_infra_pod(
+                        "openshift-kube-apiserver", "installer-1-master-0",
+                        "Failed", 0, 1, owner_kind="ConfigMap",
+                        creation_timestamp="2020-01-01T00:00:00Z",
+                    ),
+                ]
+            return []
+
+        tested_object.oc_api.get_pods = Mock(side_effect=mock_get_pods)
+        result = tested_object.run_rule()
+        assert result.status == Status.FAILED
+        assert "etcd-quorum-guard" in result.message
+        assert "installer-1-master-0" in result.message
+        assert "non-critical" in result.message
+
+    def test_old_failed_cronjob_pod_skipped(self, tested_object):
+        """Test that old (>24h) Failed CronJob pods are skipped."""
+        def mock_get_pods(namespace, timeout=30):
+            if namespace == "openshift-image-registry":
+                return [
+                    create_mock_infra_pod("openshift-image-registry", "registry-pod", "Running", 1, 1),
+                    create_mock_infra_pod(
+                        "openshift-image-registry", "image-pruner-cronjob-abc",
+                        "Failed", 0, 1, owner_kind="CronJob",
+                        finished_at="2020-01-01T00:00:00Z",
+                    ),
+                ]
+            return []
+
+        tested_object.oc_api.get_pods = Mock(side_effect=mock_get_pods)
+        result = tested_object.run_rule()
+        assert result.status == Status.PASSED
+
+    def test_pod_with_zero_containers_not_running(self, tested_object):
+        """Test that a Running pod with 0/0 containers is treated as not running."""
+        def mock_get_pods(namespace, timeout=30):
+            if namespace == "openshift-monitoring":
+                return [
+                    create_mock_infra_pod("openshift-monitoring", "empty-pod", "Running", 0, 0),
+                ]
+            return []
+
+        tested_object.oc_api.get_pods = Mock(side_effect=mock_get_pods)
+        result = tested_object.run_rule()
+        assert result.status == Status.FAILED
+        assert "empty-pod" in result.message
+        assert "0/0" in result.message
+
+    def test_only_queries_infra_namespaces(self, tested_object):
+        """Test that get_pods is only called for infrastructure namespaces."""
+        tested_object.oc_api.get_pods = Mock(return_value=[])
+        tested_object.run_rule()
+
+        called_namespaces = [call.kwargs.get("namespace") for call in tested_object.oc_api.get_pods.call_args_list]
+        assert set(called_namespaces) == set(InfraPodsReadyAndRunning.INFRA_NAMESPACES)
 
 
 def create_mock_node(name, ready_status, other_conditions=None):


### PR DESCRIPTION
## Ticket
https://redhat.atlassian.net/browse/PDRIVE-806

## Description
Replace `AllPodsReadyAndRunning` (queries all namespaces) with `InfraPodsReadyAndRunning` scoped to 22 critical OpenShift infrastructure namespaces. This avoids scale/memory issues and false positives from user workload pods.

## Changes
- Added `InfraPodsReadyAndRunning` rule with per-namespace queries (22 namespaces)
- Old (>24h) Failed Job/CronJob pods silently skipped (ephemeral by design)
- Old (>24h) Failed non-Job pods surfaced as WARNING (e.g. installer pods)
- Mixed scenario (new failures + old failed): FAILED with both sections separated
- `AllPodsReadyAndRunning` commented out in domain (not removed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Kubernetes validation to focus on infrastructure namespaces only, replacing the prior “all pods” readiness logic.
  * Improved pod-health evaluation with UTC-based “historical” handling for failed infra pods, producing clearer **fail/warn/pass** outcomes.
* **Tests**
  * Added comprehensive unit coverage for the new infra-scoped validation, including readiness-by-container and pod-age edge cases.
* **Documentation**
  * Refreshed Confluence rule-page creation guidance, including updated template examples and MCP-based page creation workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->