### PR TITLE
Reject 'default' namespace in set_config

### DIFF
--- a/src/in_cluster_checks/cli.py
+++ b/src/in_cluster_checks/cli.py
@@ -239,14 +239,6 @@ def main() -> None:
     args = parser.parse_args()
     namespace_user_provided = args.namespace is not None
 
-    if args.namespace == "default":
-        print(
-            "Error: The 'default' namespace is not allowed for debug pods. "
-            "Omit --namespace for an auto-generated namespace, or specify a dedicated one.",
-            file=sys.stderr,
-        )
-        sys.exit(2)
-
     if args.output is None:
         args.output = get_default_output(args.format)
 

--- a/src/in_cluster_checks/global_config.py
+++ b/src/in_cluster_checks/global_config.py
@@ -53,6 +53,12 @@ def set_config(
     if not active_profile_val:
         raise ValueError("active_profile must be provided and cannot be empty")
 
+    if namespace_val == "default":
+        raise ValueError(
+            "The 'default' namespace is not allowed for debug pods. "
+            "Use namespace='' for an auto-generated namespace, or specify a dedicated one."
+        )
+
     debug_rule_flag = debug_rule_flag_val
     debug_rule_name = debug_rule_name_val
     max_workers = max_workers_val

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -6,6 +6,8 @@ from pathlib import Path
 import pytest
 import yaml
 
+from in_cluster_checks import global_config
+from in_cluster_checks.core.rule import Rule
 from src.profiles.loader import ProfileLoader
 from src.profiles.profile import Profiles
 
@@ -276,8 +278,6 @@ class TestRuleProfileEnablement:
     @pytest.fixture
     def loaded_profiles(self, rule_profiles_yaml):
         """Load profiles for testing."""
-        from in_cluster_checks import global_config
-
         profile = Profiles()
         ProfileLoader.load(profile, rule_profiles_yaml)
         global_config.profiles_hierarchy = profile
@@ -286,8 +286,6 @@ class TestRuleProfileEnablement:
 
     def test_default_rule_runs_for_all_profiles(self, loaded_profiles):
         """Test that default rule (supported_profiles={'general'}) runs for all profiles."""
-        from in_cluster_checks import global_config
-        from in_cluster_checks.core.rule import Rule
 
         class DefaultRule(Rule):
             title = "Default Rule"
@@ -305,8 +303,6 @@ class TestRuleProfileEnablement:
 
     def test_nvidia_rule_only_runs_for_nvidia_ai(self, loaded_profiles):
         """Test that nvidia-specific rule only runs for nvidia/ai profiles."""
-        from in_cluster_checks import global_config
-        from in_cluster_checks.core.rule import Rule
 
         class NvidiaRule(Rule):
             title = "Nvidia Rule"
@@ -331,8 +327,6 @@ class TestRuleProfileEnablement:
 
     def test_telco_rule_only_runs_for_telco(self, loaded_profiles):
         """Test that telco-specific rule only runs for telco profiles."""
-        from in_cluster_checks import global_config
-        from in_cluster_checks.core.rule import Rule
 
         class TelcoRule(Rule):
             title = "Telco Rule"
@@ -354,8 +348,6 @@ class TestRuleProfileEnablement:
 
     def test_multi_profile_rule(self, loaded_profiles):
         """Test rule that supports multiple profiles."""
-        from in_cluster_checks import global_config
-        from in_cluster_checks.core.rule import Rule
 
         class MultiRule(Rule):
             title = "Multi Profile Rule"
@@ -384,8 +376,6 @@ class TestRuleProfileEnablement:
 
     def test_transitive_inclusion(self, loaded_profiles):
         """Test that rules work with transitive profile inclusion."""
-        from in_cluster_checks import global_config
-        from in_cluster_checks.core.rule import Rule
 
         class TelcoBaseRule(Rule):
             title = "Telco Base Rule"
@@ -415,8 +405,6 @@ class TestGlobalConfig:
 
     def test_set_config_requires_active_profile(self):
         """Test that set_config() raises ValueError when active_profile is empty."""
-        from in_cluster_checks import global_config
-
         with pytest.raises(ValueError) as exc_info:
             global_config.set_config(active_profile_val="")
 
@@ -424,10 +412,17 @@ class TestGlobalConfig:
         assert "active_profile" in error_message
         assert "cannot be empty" in error_message
 
+    def test_set_config_rejects_default_namespace(self):
+        """Test that set_config() raises ValueError when namespace is 'default'."""
+        with pytest.raises(ValueError) as exc_info:
+            global_config.set_config(active_profile_val="general", namespace_val="default")
+
+        error_message = str(exc_info.value)
+        assert "default" in error_message
+        assert "not allowed" in error_message
+
     def test_set_config_with_valid_profile(self):
         """Test that set_config() works correctly with a valid profile."""
-        from in_cluster_checks import global_config
-
         # Should not raise any exception
         global_config.set_config(active_profile_val="general")
 
@@ -438,8 +433,6 @@ class TestGlobalConfig:
 
     def test_set_config_with_custom_profile(self):
         """Test that set_config() works with different profile values."""
-        from in_cluster_checks import global_config
-
         # Test with nvidia profile
         global_config.set_config(active_profile_val="nvidia")
         assert global_config.active_profile == "nvidia"


### PR DESCRIPTION
Move the 'default' namespace validation from cli.py into global_config.set_config() so all consumers (CLI and Pendrive) are protected. The CLI check was redundant after this move.

Assisted-by: Claude Code (Claude Opus 4.6) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced consistent validation to prevent the reserved `"default"` namespace from being used.
  * Command-line namespace input is now handled by the same validation logic, ensuring a clear error when `"default"` is provided.
  * Added automated test coverage confirming `set_config` rejects `"default"` with an explanatory message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->