### PR TITLE
fix(PDRIVE-810): run shell inside chroot so globs expand against host…

### DIFF
--- a/src/in_cluster_checks/core/executor.py
+++ b/src/in_cluster_checks/core/executor.py
@@ -218,7 +218,7 @@ class NodeExecutor:
             with oc.project(self.namespace):
                 result = oc.invoke(
                     "rsh",
-                    cmd_args=[self._pod_id, "bash", "-c", f"chroot /host {cmd}"],
+                    cmd_args=[self._pod_id, "chroot", "/host", "bash", "-c", cmd],
                     auto_raise=False,  # Don't raise exception on non-zero exit codes
                 )
         return result


### PR DESCRIPTION
… filesystem

Previously commands were run as `bash -c "chroot /host <cmd>"`, which meant the outer bash expanded globs against the debug pod's filesystem before chroot changed the root. Paths only present on the host (e.g. /etc/kubernetes/...) failed to match, causing rules like node_certificate_expiry to silently get no results.

Changed to `chroot /host bash -c "<cmd>"` so bash runs inside the chroot and glob expansion sees the host filesystem.

Assisted-by: Claude Code (Claude Opus 4.6) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved execution of diagnostic commands within the host environment.
  * Increased reliability for node-level command runs that use host filesystem access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->