### PR TITLE
PDRIVE-823: add guide for accessing remote clusters from local machin…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -598,6 +598,27 @@ We recommend developing and testing directly on a machine with OpenShift cluster
 
 If all tests pass and pre-commit runs successfully, your development environment is ready!
 
+### Accessing OpenShift Clusters from Local Machine
+
+**Prerequisite**: You must be able to run `oc` commands successfully against your target OpenShift cluster from your local machine before using `in-cluster-checks`.
+
+**Setup requirements**:
+
+1. **Install OpenShift CLI (`oc`)**: Refer to [OpenShift CLI documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/cli_tools/openshift-cli-oc)
+
+2. **Configure cluster access**: Ensure `oc get nodes` works from your local machine
+   - For direct access: Configure your `KUBECONFIG` to point to the cluster
+   - For restricted networks: Set up SSH port forwarding or VPN access to reach the cluster API server
+
+Refer to [OpenShift CLI documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/cli_tools/openshift-cli-oc) for detailed cluster access configuration.
+
+**Verify access**:
+
+```bash
+export KUBECONFIG=/path/to/your/kubeconfig
+oc get nodes  # Should list cluster nodes
+```
+
 ### Making Code Changes
 
 1. **Create a new branch**:


### PR DESCRIPTION
…e on CONTRIBUTING.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a new “Accessing OpenShift Clusters from Local Machine” section under “Development Setup.”
  - Updated prerequisites to require successful local `oc` connectivity before proceeding.
  - Provided brief guidance to configure access using either local `KUBECONFIG` or network access via SSH port-forwarding/VPN.
  - Included a minimal verification snippet: export `KUBECONFIG`, then run `oc get nodes`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->