### PR TITLE
feat(PDRIVE-824): add spectrum-x profile

### DIFF
--- a/src/profiles/profiles.yaml
+++ b/src/profiles/profiles.yaml
@@ -15,6 +15,9 @@ profiles:
   # --- Layer 3: Platforms & Hardware ---
   gpu:
     include: [ai-base] # GPU implies AI-base rules
+  spectrum-x:
+    description: "NVIDIA Spectrum-X networking platform for AI factories"
+    include: [general]
   rh-nokia:
     include: [telco-base]
 

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -440,3 +440,13 @@ class TestGlobalConfig:
         # Test with telco profile
         global_config.set_config(active_profile_val="telco")
         assert global_config.active_profile == "telco"
+
+    def test_spectrum_x_profile_resolves_correctly(self):
+        """Test that spectrum-x profile resolves with general."""
+        global_config.set_config(active_profile_val="spectrum-x")
+        assert global_config.active_profile == "spectrum-x"
+
+        spectrum_x_deps = global_config.profiles_hierarchy["spectrum-x"]
+        assert "spectrum-x" in spectrum_x_deps
+        assert "general" in spectrum_x_deps
+        assert len(spectrum_x_deps) == 2


### PR DESCRIPTION
## Summary

- Add new `spectrum-x` profile to `profiles.yaml` for NVIDIA Spectrum-X networking platform validation on OpenShift clusters with Voyager kernel (RHEL-NV)
- Profile includes `general` — spectrum-x specific rules will be added in subsequent tickets under [PDRIVE-741](https://redhat.atlassian.net/browse/PDRIVE-741)
- Add unit test verifying profile dependency resolution

## Jira

[PDRIVE-824](https://redhat.atlassian.net/browse/PDRIVE-824)

## Changes

- `src/profiles/profiles.yaml` — Added `spectrum-x` profile under Layer 3 (Platforms & Hardware) with `include: [general]`
- `tests/test_profiles.py` — Added `test_spectrum_x_profile_resolves_correctly` verifying the profile loads and resolves to `{spectrum-x, general}`

## Test plan

- [x] `pytest tests/test_profiles.py` — 18 tests passed
- [x] `pre-commit run --all-files` — all checks passed

[PDRIVE-741]: https://redhat.atlassian.net/browse/PDRIVE-741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PDRIVE-824]: https://redhat.atlassian.net/browse/PDRIVE-824?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ