### PR TITLE
docs: add profile guidance to Claude rules and skills

### DIFF
--- a/.claude/rules/in-cluster-check.md
+++ b/.claude/rules/in-cluster-check.md
@@ -65,7 +65,7 @@ All rules use the `Status` enum (`utils/enums.py`):
 - Set `supported_profiles` as a class variable with a set of profile names (e.g., `supported_profiles = {"telco-base"}`)
 - Only omit `supported_profiles` (leaving default `{"general"}`) for truly generic rules that apply to ANY cluster type
 - Rules are automatically filtered based on the active profile — only rules matching the profile hierarchy are executed
-- Common profiles: `"general"` (default, all clusters), `"telco-base"` (telco-specific checks)
+- Check `src/profiles/profiles.yaml` for the full list of available profiles and their hierarchy
 - Example:
   ```python
   class VerifyNFDOperatorHealth(Rule):

--- a/.claude/skills/implement-rule-from-jira/SKILL.md
+++ b/.claude/skills/implement-rule-from-jira/SKILL.md
@@ -72,7 +72,8 @@ Extract from the ticket description and acceptance criteria:
 2. **Domain**: Identify which domain to use (hw, network, linux, storage, k8s, etcd, security) or create a new domain if none fit
 3. **Rule type**: Determine if it's a `Rule` or `OrchestratorRule`
 4. **Objective hosts**: Which nodes to run on (ALL_NODES, MASTERS, WORKERS, etc.)
-5. **Validation logic**: What command(s) to run and what to check
+5. **Supported profile**: Check `src/profiles/profiles.yaml` for available profiles and ask the user which profile this rule should target. Only use `"general"` if the rule applies to ALL cluster types.
+6. **Validation logic**: What command(s) to run and what to check
 
 Present this analysis to the user and ask for confirmation before proceeding.
 
@@ -317,6 +318,7 @@ Before marking complete, verify:
 - [ ] Ticket type validated as "Story"
 - [ ] Branch created with format: `TICKET-NUMBER_description`
 - [ ] Rule class created with all required fields
+- [ ] Asked user about `supported_profiles` if rule may be specific to a deployment type
 - [ ] All commands use `SafeCmdString`
 - [ ] No `self.logger` usage in rule
 - [ ] Rule registered in domain

--- a/.claude/skills/new-rule/SKILL.md
+++ b/.claude/skills/new-rule/SKILL.md
@@ -249,9 +249,23 @@ self.oc_api.run_rsh_cmd(namespace, pod, cmd2)
 - One SafeCmdString per line (except `SafeCmdString() + SafeCmdString()` is allowed)
 
 
+## Step 6: Set Supported Profile
+
+If the rule may be specific to a deployment type (e.g., telco, AI, Spectrum-X), **ask the user which profile it should target** before finalizing.
+
+Check `src/profiles/profiles.yaml` for available profiles and their hierarchy. Only leave the default `{"general"}` if the rule applies to ALL cluster types.
+
+```python
+class MyRuleName(Rule):
+    supported_profiles = {"spectrum-x"}  # Only runs for spectrum-x profile
+```
+
+See "Supported Profiles" in @.claude/rules/in-cluster-check.md for details.
+
 ## Checklist
 
 - [ ] Rule class created with `objective_hosts`, `unique_name`, `title`
+- [ ] Asked user about `supported_profiles` if rule may be specific to a deployment type
 - [ ] `run_rule()` implemented returning `RuleResult`
 - [ ] `is_prerequisite_fulfilled()` added if rule requires specific tools/conditions
 - [ ] `UnExpectedSystemOutput` used for command failures


### PR DESCRIPTION
## Summary

- Update `.claude/rules/in-cluster-check.md` to point to `profiles.yaml` for available profiles
- Add profile step to `/new-rule` skill — asks user about `supported_profiles` if the rule may be deployment-specific
- Add profile consideration to `/implement-rule-from-jira` skill — includes profile in ticket analysis and checklist

This ensures Claude prompts contributors about profile targeting when creating new rules, rather than silently defaulting to `general`.

## Changes

- `.claude/rules/in-cluster-check.md` — replaced hardcoded profile list with reference to `src/profiles/profiles.yaml`
- `.claude/skills/new-rule/SKILL.md` — added Step 6 (Set Supported Profile) and checklist item
- `.claude/skills/implement-rule-from-jira/SKILL.md` — added profile to Step 3 analysis and checklist

## Test plan

- [x] No code changes — Claude rules and skill definitions only