### PR TITLE
feat(PDRIVE-687): add mypy-based pre-commit hook for SafeCmdString ty…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,6 +58,13 @@ repos:
         types: [python]
         files: ^src/in_cluster_checks/
 
+      - id: safecmdstring-mypy-check
+        name: check SafeCmdString types with mypy
+        entry: mypy
+        language: system
+        types: [python]
+        files: ^src/in_cluster_checks/
+
       - id: pytest-coverage
         name: pytest with coverage
         entry: python -m pytest

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,19 @@
+[mypy]
+python_version = 3.12
+check_untyped_defs = True
+show_error_codes = True
+
+# Only report SafeCmdString type errors
+disable_error_code = assignment,var-annotated,no-untyped-def,return-value,import-untyped,no-any-return,attr-defined
+
+# Ignore third-party modules without stubs
+ignore_missing_imports = True
+
+# Files to check
+files = src/in_cluster_checks/
+
+[mypy-openshift_client.*]
+ignore_missing_imports = True
+
+[mypy-dateutil.*]
+ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dev = [
     "black>=24.1.1",
     "flake8>=7.0.0",
     "isort>=5.13.2",
+    "mypy>=1.0.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Add a pre-commit hook that runs mypy and filters output to only report SafeCmdString type violations, catching command injection issues at commit time.

- Add check_safecmdstring_mypy.py linter script
- Add mypy.ini configuration tuned for SafeCmdString checking
- Add safecmdstring-mypy-check hook to .pre-commit-config.yaml
- Add mypy to dev dependencies

Assisted-by: Claude Code (Claude Opus 4.6) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated static type checking for SafeCmdString-related code.
  * Updated development tooling to include mypy.
  * Enhanced type-checking configuration for Python 3.12 and untyped function bodies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->