### PR TITLE
fix(PDRIVE-837,PDRIVE-838): distinguish connectivity errors from validation failures in OVN-K8s rules

### DIFF
--- a/src/in_cluster_checks/rules/network/ovnk8s_validations.py
+++ b/src/in_cluster_checks/rules/network/ovnk8s_validations.py
@@ -130,10 +130,10 @@ class LogicalSwitchNodeValidator(OVNKubernetesBase):
         if not ovn_pod_to_node_dict:
             return RuleResult.not_applicable("No ovnkube-node pods found")
 
-        failed_checks = []
+        connectivity_errors = []
+        validation_failures = []
 
         for ovnkube_pod, node in ovn_pod_to_node_dict.items():
-            # Check if logical switch exists with node name using run_rsh_cmd
             rc, out, err = self.oc_api.run_rsh_cmd(
                 namespace="openshift-ovn-kubernetes",
                 pod=ovnkube_pod,
@@ -141,16 +141,22 @@ class LogicalSwitchNodeValidator(OVNKubernetesBase):
             )
 
             if rc != 0:
-                failed_checks.append(f"ovnkube-node {ovnkube_pod}: cannot execute ovn-nbctl ls-list - {err}")
+                connectivity_errors.append(
+                    f"ovnkube-node {ovnkube_pod}: could not verify logical switch (command error) - {err}"
+                )
                 continue
 
-            # Check if node name appears in logical switch list
             if f"({node})" not in out:
-                failed_checks.append(f"ovnkube-node {ovnkube_pod}: there is no logical switch with node name - {node}")
+                validation_failures.append(
+                    f"ovnkube-node {ovnkube_pod}: there is no logical switch with node name - {node}"
+                )
 
-        if failed_checks:
-            message = "\n".join(failed_checks)
-            return RuleResult.failed(message)
+        if validation_failures:
+            all_messages = validation_failures + connectivity_errors
+            return RuleResult.failed("\n".join(all_messages))
+
+        if connectivity_errors:
+            return RuleResult.warning("\n".join(connectivity_errors))
 
         return RuleResult.passed(
             f"All {len(ovn_pod_to_node_dict)} ovnkube-node pods have corresponding logical switches"
@@ -183,7 +189,8 @@ class MTUOverlayInterfaces(OVNKubernetesBase):
         if expected_mtu is None:
             return RuleResult.skip("Cannot determine expected MTU from network.operator/cluster")
 
-        failed_checks = []
+        connectivity_errors = []
+        mtu_failures = []
         for ovnkube_pod in ovn_pod_to_node_dict:
             rc, out, err = self.oc_api.run_rsh_cmd(
                 namespace="openshift-ovn-kubernetes",
@@ -192,24 +199,28 @@ class MTUOverlayInterfaces(OVNKubernetesBase):
             )
 
             if rc != 0:
-                failed_checks.append(f"[OVNKube Node: {ovnkube_pod}] Failed to run ip link show: {err}")
+                connectivity_errors.append(f"[OVNKube Node: {ovnkube_pod}] Could not exec into pod (skipped): {err}")
                 continue
 
             overlay_interfaces = self._parse_overlay_interfaces(out)
 
             if not overlay_interfaces:
-                failed_checks.append(f"[OVNKube Node: {ovnkube_pod}] No overlay network interfaces found")
+                mtu_failures.append(f"[OVNKube Node: {ovnkube_pod}] No overlay network interfaces found")
                 continue
 
             for interface, actual_mtu in overlay_interfaces:
                 if expected_mtu != actual_mtu:
-                    failed_checks.append(
+                    mtu_failures.append(
                         f"[OVNKube Node: {ovnkube_pod}] MTU Mismatch: "
                         f"Expected (Network CR) = {expected_mtu}, Actual ({interface}) = {actual_mtu}"
                     )
 
-        if failed_checks:
-            return RuleResult.failed("\n".join(failed_checks))
+        if mtu_failures:
+            all_messages = mtu_failures + connectivity_errors
+            return RuleResult.failed("\n".join(all_messages))
+
+        if connectivity_errors:
+            return RuleResult.warning("\n".join(connectivity_errors))
 
         return RuleResult.passed()
 

--- a/tests/rules/network/test_ovnk8s_validations.py
+++ b/tests/rules/network/test_ovnk8s_validations.py
@@ -158,7 +158,7 @@ class TestLogicalSwitchNodeValidator(OVNKubernetesTestBase):
 
     scenario_failed = [
         RuleScenarioParams(
-            scenario_title="scenario_failed",
+            scenario_title="logical switch missing for node",
             tested_object_mock_dict={
                 "get_ovn_pod_to_node_dict": Mock(
                     return_value={
@@ -175,8 +175,61 @@ class TestLogicalSwitchNodeValidator(OVNKubernetesTestBase):
                     "some-other-logical-switch (other-node)"
                 ),
             },
-            failed_msg="ovnkube-node ovnkube-node-7dphn: there is no logical switch with node name - mgmt1-m2\novnkube-node ovnkube-node-927b4: there is no logical switch with node name - mgmt1-m1",
-        )
+            failed_msg=(
+                "ovnkube-node ovnkube-node-7dphn: there is no logical switch with node name - mgmt1-m2\n"
+                "ovnkube-node ovnkube-node-927b4: there is no logical switch with node name - mgmt1-m1"
+            ),
+        ),
+        RuleScenarioParams(
+            scenario_title="logical switch missing with connectivity error on another pod",
+            tested_object_mock_dict={
+                "get_ovn_pod_to_node_dict": Mock(
+                    return_value={
+                        "ovnkube-node-7dphn": "mgmt1-m2",
+                        "ovnkube-node-927b4": "mgmt1-m1",
+                    }
+                ),
+            },
+            rsh_cmd_output_dict={
+                ("openshift-ovn-kubernetes", "ovnkube-node-7dphn", "ovn-nbctl ls-list"): CmdOutput(
+                    "some-other-logical-switch (other-node)"
+                ),
+                ("openshift-ovn-kubernetes", "ovnkube-node-927b4", "ovn-nbctl ls-list"): CmdOutput(
+                    "", return_code=1, err="error dialing backend: tls: first record does not look like a TLS handshake"
+                ),
+            },
+            failed_msg=(
+                "ovnkube-node ovnkube-node-7dphn: there is no logical switch with node name - mgmt1-m2\n"
+                "ovnkube-node ovnkube-node-927b4: could not verify logical switch (command error) "
+                "- error dialing backend: tls: first record does not look like a TLS handshake"
+            ),
+        ),
+    ]
+
+    scenario_warning = [
+        RuleScenarioParams(
+            scenario_title="connectivity error only (no validation failure)",
+            tested_object_mock_dict={
+                "get_ovn_pod_to_node_dict": Mock(
+                    return_value={
+                        "ovnkube-node-7dphn": "mgmt1-m2",
+                        "ovnkube-node-927b4": "mgmt1-m1",
+                    }
+                ),
+            },
+            rsh_cmd_output_dict={
+                ("openshift-ovn-kubernetes", "ovnkube-node-7dphn", "ovn-nbctl ls-list"): CmdOutput(
+                    "dcd1b6b9-41e5-4591-976f-bdf738f80660 (mgmt1-m2)"
+                ),
+                ("openshift-ovn-kubernetes", "ovnkube-node-927b4", "ovn-nbctl ls-list"): CmdOutput(
+                    "", return_code=1, err="error dialing backend: tls: first record does not look like a TLS handshake"
+                ),
+            },
+            failed_msg=(
+                "ovnkube-node ovnkube-node-927b4: could not verify logical switch (command error) "
+                "- error dialing backend: tls: first record does not look like a TLS handshake"
+            ),
+        ),
     ]
 
     @pytest.mark.parametrize("scenario_params", scenario_passed)
@@ -186,6 +239,10 @@ class TestLogicalSwitchNodeValidator(OVNKubernetesTestBase):
     @pytest.mark.parametrize("scenario_params", scenario_failed)
     def test_scenario_failed(self, scenario_params, tested_object):
         RuleTestBase.test_scenario_failed(self, scenario_params, tested_object)
+
+    @pytest.mark.parametrize("scenario_params", scenario_warning)
+    def test_scenario_warning(self, scenario_params, tested_object):
+        RuleTestBase.test_scenario_warning(self, scenario_params, tested_object)
 
 
 IP_LINK_SHOW_ALL_MATCH = (
@@ -277,21 +334,57 @@ class TestMTUOverlayInterfaces(OVNKubernetesTestBase):
             failed_msg="[OVNKube Node: ovnkube-node-7dphn] No overlay network interfaces found",
         ),
         RuleScenarioParams(
-            "ip link show command fails",
+            "MTU mismatch with connectivity error on another pod",
             tested_object_mock_dict={
                 "get_ovn_pod_to_node_dict": Mock(
                     return_value={
                         "ovnkube-node-7dphn": "mgmt1-m2",
+                        "ovnkube-node-927b4": "mgmt1-m1",
                     }
                 ),
                 "_get_expected_mtu": Mock(return_value=1400),
             },
             rsh_cmd_output_dict={
                 ("openshift-ovn-kubernetes", "ovnkube-node-7dphn", "ip link show"): CmdOutput(
-                    "", return_code=1, err="command not found"
+                    IP_LINK_SHOW_MTU_MISMATCH
+                ),
+                ("openshift-ovn-kubernetes", "ovnkube-node-927b4", "ip link show"): CmdOutput(
+                    "", return_code=1, err="error dialing backend: tls: first record does not look like a TLS handshake"
                 ),
             },
-            failed_msg="[OVNKube Node: ovnkube-node-7dphn] Failed to run ip link show: command not found",
+            failed_msg=(
+                "[OVNKube Node: ovnkube-node-7dphn] MTU Mismatch: "
+                "Expected (Network CR) = 1400, Actual (br-int) = 1500\n"
+                "[OVNKube Node: ovnkube-node-927b4] Could not exec into pod (skipped): "
+                "error dialing backend: tls: first record does not look like a TLS handshake"
+            ),
+        ),
+    ]
+
+    scenario_warning = [
+        RuleScenarioParams(
+            "connectivity error only (no MTU mismatch)",
+            tested_object_mock_dict={
+                "get_ovn_pod_to_node_dict": Mock(
+                    return_value={
+                        "ovnkube-node-7dphn": "mgmt1-m2",
+                        "ovnkube-node-927b4": "mgmt1-m1",
+                    }
+                ),
+                "_get_expected_mtu": Mock(return_value=1400),
+            },
+            rsh_cmd_output_dict={
+                ("openshift-ovn-kubernetes", "ovnkube-node-7dphn", "ip link show"): CmdOutput(
+                    IP_LINK_SHOW_ALL_MATCH
+                ),
+                ("openshift-ovn-kubernetes", "ovnkube-node-927b4", "ip link show"): CmdOutput(
+                    "", return_code=1, err="error dialing backend: tls: first record does not look like a TLS handshake"
+                ),
+            },
+            failed_msg=(
+                "[OVNKube Node: ovnkube-node-927b4] Could not exec into pod (skipped): "
+                "error dialing backend: tls: first record does not look like a TLS handshake"
+            ),
         ),
     ]
 
@@ -302,6 +395,10 @@ class TestMTUOverlayInterfaces(OVNKubernetesTestBase):
     @pytest.mark.parametrize("scenario_params", scenario_failed)
     def test_scenario_failed(self, scenario_params, tested_object):
         RuleTestBase.test_scenario_failed(self, scenario_params, tested_object)
+
+    @pytest.mark.parametrize("scenario_params", scenario_warning)
+    def test_scenario_warning(self, scenario_params, tested_object):
+        RuleTestBase.test_scenario_warning(self, scenario_params, tested_object)
 
 
 class TestOvnRoutingHealthCheck(OvnDetectingNodeRuleTestBase):


### PR DESCRIPTION
## Summary

- [PDRIVE-837](https://redhat.atlassian.net/browse/PDRIVE-837): `LogicalSwitchNodeValidator` was reporting false positives when `oc rsh` failed due to transient TLS connectivity errors on NotReady nodes
- [PDRIVE-838](https://redhat.atlassian.net/browse/PDRIVE-838): `MTUOverlayInterfaces` had the same issue — exec failures were treated as MTU mismatches

Both rules now separate connectivity/exec errors from actual validation failures:
- **Actual validation failure** (missing logical switch / MTU mismatch) → `RuleResult.failed()`
- **Exec error** (TLS, timeout, pod unreachable) + **no validation failures** → `RuleResult.warning()`
- **Both** validation failures and connectivity errors → `RuleResult.failed()` with all messages included

## Testing

- Unit tests updated with new scenarios: warning-only, failed+connectivity combined
- Verified on live cluster (pdrive-big2) with a NotReady node — both rules now correctly report `[WARN]` instead of `[FAIL]`
- All 913 tests pass, pre-commit passes

[PDRIVE-837]: https://redhat.atlassian.net/browse/PDRIVE-837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PDRIVE-838]: https://redhat.atlassian.net/browse/PDRIVE-838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OVN-Kubernetes validation reporting by distinguishing connectivity issues from actual configuration failures.
  * Connectivity-only issues now produce warnings instead of failing validation.
  * Validation failures continue to fail checks and include relevant connectivity details when both occur.
  * Enhanced logical switch and overlay MTU diagnostics with clearer, aggregated messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->