### PR TITLE
feat(PDRIVE-811): optimize InfraPodsReadyAndRunning rule

### DIFF
--- a/src/in_cluster_checks/rules/k8s/k8s_validations.py
+++ b/src/in_cluster_checks/rules/k8s/k8s_validations.py
@@ -5,15 +5,14 @@ Direct port from: HealthChecks/flows/K8s/k8s_components/k8s_sanity_checks.py
 """
 
 import json
-import logging
 from datetime import datetime, timezone
+
+from openshift_client import OpenShiftPythonException
 
 from in_cluster_checks.core.exceptions import UnExpectedSystemOutput
 from in_cluster_checks.core.rule import OrchestratorRule
 from in_cluster_checks.core.rule_result import PrerequisiteResult, RuleResult
 from in_cluster_checks.utils.enums import Objectives, Status
-
-logger = logging.getLogger(__name__)
 
 
 class AllPodsReadyAndRunning(OrchestratorRule):
@@ -204,14 +203,14 @@ class InfraPodsReadyAndRunning(OrchestratorRule):
                     field_selector=self._FIELD_SELECTOR,
                     timeout=30,
                 )
-            except Exception:
-                logger.warning("Failed to query pods in namespace %s, skipping", namespace)
+            except OpenShiftPythonException:
+                self.logger.warning("Failed to query pods in namespace %s, skipping", namespace)
                 continue
             if not pod_objects:
                 continue
 
             if len(pod_objects) > self.MAX_PODS_PER_NAMESPACE:
-                logger.warning(
+                self.logger.warning(
                     "Namespace %s has %d pods (limit: %d), results may be truncated",
                     namespace,
                     len(pod_objects),

--- a/src/in_cluster_checks/rules/k8s/k8s_validations.py
+++ b/src/in_cluster_checks/rules/k8s/k8s_validations.py
@@ -5,12 +5,15 @@ Direct port from: HealthChecks/flows/K8s/k8s_components/k8s_sanity_checks.py
 """
 
 import json
+import logging
 from datetime import datetime, timezone
 
 from in_cluster_checks.core.exceptions import UnExpectedSystemOutput
 from in_cluster_checks.core.rule import OrchestratorRule
 from in_cluster_checks.core.rule_result import PrerequisiteResult, RuleResult
 from in_cluster_checks.utils.enums import Objectives, Status
+
+logger = logging.getLogger(__name__)
 
 
 class AllPodsReadyAndRunning(OrchestratorRule):
@@ -113,6 +116,7 @@ class InfraPodsReadyAndRunning(OrchestratorRule):
     links = ["https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/435226813"]
 
     HISTORICAL_POD_AGE_THRESHOLD = 86400  # 24 hours in seconds
+    MAX_PODS_PER_NAMESPACE = 1000
 
     INFRA_NAMESPACES = [
         "openshift-etcd",
@@ -121,13 +125,17 @@ class InfraPodsReadyAndRunning(OrchestratorRule):
         "openshift-kube-scheduler",
         "openshift-apiserver",
         "openshift-controller-manager",
+        "openshift-cluster-version",
         "openshift-machine-api",
         "openshift-machine-config-operator",
         "openshift-ingress",
+        "openshift-ingress-operator",
         "openshift-dns",
         "openshift-sdn",
         "openshift-ovn-kubernetes",
         "openshift-multus",
+        "openshift-network-operator",
+        "openshift-network-diagnostics",
         "openshift-monitoring",
         "openshift-image-registry",
         "openshift-authentication",
@@ -135,15 +143,19 @@ class InfraPodsReadyAndRunning(OrchestratorRule):
         "openshift-operator-lifecycle-manager",
         "openshift-marketplace",
         "openshift-console",
+        "openshift-service-ca",
         "openshift-cluster-storage-operator",
-        "openshift-network-operator",
+        "openshift-kube-storage-version-migrator",
     ]
+
+    # Server-side filter: skip completed pods at the API level
+    _FIELD_SELECTOR = {"!status.phase": "Succeeded"}
 
     def run_rule(self):
         """Check if infrastructure pods are ready and running."""
-        ready_pods, not_running_pods, old_failed_pods = self._get_pods_lists()
+        ready_pod_count, not_running_pods, old_failed_pods = self._get_pods_lists()
 
-        if len(ready_pods) == 0 and len(not_running_pods) == 0 and len(old_failed_pods) == 0:
+        if ready_pod_count == 0 and len(not_running_pods) == 0 and len(old_failed_pods) == 0:
             return RuleResult.failed("Did not get any pods from infrastructure namespaces")
 
         threshold_hours = self.HISTORICAL_POD_AGE_THRESHOLD // 3600
@@ -174,29 +186,45 @@ class InfraPodsReadyAndRunning(OrchestratorRule):
     def _get_pods_lists(self):
         """Get lists of ready, not-ready, and old failed pods from infrastructure namespaces.
 
+        Uses server-side field selectors to skip Succeeded pods at the API level.
         Old Failed Job/CronJob pods are skipped entirely.
         Other old Failed pods are collected separately for warning.
 
         Returns:
-            tuple: (ready_pods_list, not_running_pods_list, old_failed_pods_list)
+            tuple: (ready_pod_count, not_running_pods_list, old_failed_pods_list)
         """
-        ready_pods = []
+        ready_pod_count = 0
         not_running_pods = []
         old_failed_pods = []
 
         for namespace in self.INFRA_NAMESPACES:
-            pod_objects = self.oc_api.get_pods(namespace=namespace, timeout=30)
+            try:
+                pod_objects = self.oc_api.get_pods(
+                    namespace=namespace,
+                    field_selector=self._FIELD_SELECTOR,
+                    timeout=30,
+                )
+            except Exception:
+                logger.warning("Failed to query pods in namespace %s, skipping", namespace)
+                continue
             if not pod_objects:
                 continue
+
+            if len(pod_objects) > self.MAX_PODS_PER_NAMESPACE:
+                logger.warning(
+                    "Namespace %s has %d pods (limit: %d), results may be truncated",
+                    namespace,
+                    len(pod_objects),
+                    self.MAX_PODS_PER_NAMESPACE,
+                )
+                pod_objects = pod_objects[: self.MAX_PODS_PER_NAMESPACE]
 
             for pod in pod_objects:
                 pod_data = pod.as_dict()
                 pod_name = pod_data["metadata"]["name"]
                 status_dict = pod_data.get("status", {})
                 phase = status_dict.get("phase", "Unknown")
-
-                if phase == "Succeeded":
-                    continue
+                container_statuses = status_dict.get("containerStatuses", [])
 
                 if phase == "Failed" and self._is_old_pod(pod_data, self.HISTORICAL_POD_AGE_THRESHOLD):
                     if self._is_job_or_cronjob_owned(pod_data):
@@ -204,24 +232,22 @@ class InfraPodsReadyAndRunning(OrchestratorRule):
                     old_failed_pods.append({"namespace": namespace, "name": pod_name})
                     continue
 
-                container_statuses = status_dict.get("containerStatuses", [])
                 total_containers = len(container_statuses)
                 ready_containers = sum(1 for c in container_statuses if c.get("ready", False))
-                ready_str = f"{ready_containers}/{total_containers}"
-
-                pod_info = {
-                    "namespace": namespace,
-                    "name": pod_name,
-                    "status": phase,
-                    "ready": ready_str,
-                }
 
                 if phase != "Running" or total_containers == 0 or ready_containers != total_containers:
-                    not_running_pods.append(pod_info)
+                    not_running_pods.append(
+                        {
+                            "namespace": namespace,
+                            "name": pod_name,
+                            "status": phase,
+                            "ready": f"{ready_containers}/{total_containers}",
+                        }
+                    )
                 else:
-                    ready_pods.append(pod_info)
+                    ready_pod_count += 1
 
-        return ready_pods, not_running_pods, old_failed_pods
+        return ready_pod_count, not_running_pods, old_failed_pods
 
     @staticmethod
     def _is_job_or_cronjob_owned(pod_data: dict) -> bool:

--- a/src/in_cluster_checks/utils/oc_api_utils.py
+++ b/src/in_cluster_checks/utils/oc_api_utils.py
@@ -352,6 +352,7 @@ class OcApiUtils:
         resource_type: str,
         namespace: str | None = None,
         labels: Dict[str, str] | None = None,
+        field_selector: dict | None = None,
         all_namespaces: bool = False,
         timeout: int = 30,
         single: bool = False,
@@ -368,6 +369,9 @@ class OcApiUtils:
             resource_type: Resource type to select (e.g., "node", "pod", "network.operator/cluster")
             namespace: Specific namespace to search in (mutually exclusive with all_namespaces)
             labels: Dictionary of label selectors (e.g., {"app": "myapp"})
+            field_selector: Dictionary of field selectors for server-side filtering.
+                           Prefix key with '!' for != logic.
+                           (e.g., {"!status.phase": "Succeeded"} for status.phase!=Succeeded)
             all_namespaces: Search across all namespaces (mutually exclusive with namespace)
             timeout: Timeout in seconds (default: 30)
             single: If True, return single object via .object() instead of list via .objects()
@@ -393,6 +397,11 @@ class OcApiUtils:
         if labels:
             label_str = ",".join([f"{k}={v}" for k, v in labels.items()])
             cmd_parts.extend(["-l", label_str])
+        if field_selector:
+            fs_str = ",".join(
+                f"{k.lstrip('!')}!={v}" if k.startswith("!") else f"{k}={v}" for k, v in field_selector.items()
+            )
+            cmd_parts.extend(["--field-selector", fs_str])
         cmd_str = " ".join(cmd_parts)
         self.operator._add_cmd_to_log(cmd_str)
 
@@ -404,6 +413,8 @@ class OcApiUtils:
             selector_kwargs = {}
             if labels:
                 selector_kwargs["labels"] = labels
+            if field_selector:
+                selector_kwargs["field_selectors"] = field_selector
             if all_namespaces:
                 selector_kwargs["all_namespaces"] = True
 
@@ -433,21 +444,42 @@ class OcApiUtils:
 
             return result
 
-    def get_pods(self, namespace: str = None, labels: dict = None, timeout: int = 30) -> list:
-        """Get pods from namespace with optional label filtering.
+    def get_pods(
+        self,
+        namespace: str = None,
+        labels: dict = None,
+        field_selector: dict = None,
+        timeout: int = 30,
+    ) -> list:
+        """Get pods from namespace with optional label and field selector filtering.
 
         Args:
             namespace: Namespace to search in. If None, searches all namespaces.
             labels: Optional dict of label selectors (e.g., {"app": "rook-ceph-tools"})
+            field_selector: Optional dict of field selectors for server-side filtering.
+                           Prefix key with '!' for != logic.
+                           (e.g., {"!status.phase": "Succeeded"} for status.phase!=Succeeded)
             timeout: Timeout in seconds (default: 30)
 
         Returns:
             List of pod objects, or empty list if none found
         """
         if namespace:
-            return self.select_resources("pod", namespace=namespace, labels=labels, timeout=timeout)
+            return self.select_resources(
+                "pod",
+                namespace=namespace,
+                labels=labels,
+                field_selector=field_selector,
+                timeout=timeout,
+            )
         else:
-            return self.select_resources("pod", labels=labels, all_namespaces=True, timeout=timeout)
+            return self.select_resources(
+                "pod",
+                labels=labels,
+                field_selector=field_selector,
+                all_namespaces=True,
+                timeout=timeout,
+            )
 
     def get_pod_name(self, namespace: str, labels: dict, log_errors: bool = True, timeout: int = 30) -> str | None:
         """Get pod name from a namespace using label selectors.

--- a/tests/rules/k8s/test_k8s_validations.py
+++ b/tests/rules/k8s/test_k8s_validations.py
@@ -136,7 +136,7 @@ class TestInfraPodsReadyAndRunning:
 
     def test_all_infra_pods_running(self, tested_object):
         """Test when all infrastructure pods are running and ready."""
-        def mock_get_pods(namespace, timeout=30):
+        def mock_get_pods(namespace, field_selector=None, timeout=30):
             if namespace == "openshift-etcd":
                 return [create_mock_infra_pod("openshift-etcd", "etcd-master-0", "Running", 3, 3)]
             if namespace == "openshift-kube-apiserver":
@@ -149,7 +149,7 @@ class TestInfraPodsReadyAndRunning:
 
     def test_infra_pod_not_running(self, tested_object):
         """Test when an infrastructure pod is in Pending state."""
-        def mock_get_pods(namespace, timeout=30):
+        def mock_get_pods(namespace, field_selector=None, timeout=30):
             if namespace == "openshift-etcd":
                 return [
                     create_mock_infra_pod("openshift-etcd", "etcd-master-0", "Running", 3, 3),
@@ -165,7 +165,7 @@ class TestInfraPodsReadyAndRunning:
 
     def test_infra_pod_partially_ready(self, tested_object):
         """Test when a pod is Running but not all containers are ready."""
-        def mock_get_pods(namespace, timeout=30):
+        def mock_get_pods(namespace, field_selector=None, timeout=30):
             if namespace == "openshift-monitoring":
                 return [
                     create_mock_infra_pod("openshift-monitoring", "prometheus-0", "Running", 1, 3),
@@ -178,19 +178,18 @@ class TestInfraPodsReadyAndRunning:
         assert "prometheus-0" in result.message
         assert "1/3" in result.message
 
-    def test_completed_pods_ignored(self, tested_object):
-        """Test that Succeeded pods are skipped."""
-        def mock_get_pods(namespace, timeout=30):
+    def test_completed_pods_filtered_by_field_selector(self, tested_object):
+        """Test that field selector is used to filter Succeeded pods at the API level."""
+        def mock_get_pods(namespace, field_selector=None, timeout=30):
             if namespace == "openshift-etcd":
-                return [
-                    create_mock_infra_pod("openshift-etcd", "etcd-master-0", "Running", 3, 3),
-                    create_mock_infra_pod("openshift-etcd", "installer-1-completed", "Succeeded", 0, 1),
-                ]
+                return [create_mock_infra_pod("openshift-etcd", "etcd-master-0", "Running", 3, 3)]
             return []
 
         tested_object.oc_api.get_pods = Mock(side_effect=mock_get_pods)
-        result = tested_object.run_rule()
-        assert result.status == Status.PASSED
+        tested_object.run_rule()
+
+        for call in tested_object.oc_api.get_pods.call_args_list:
+            assert call.kwargs.get("field_selector") == {"!status.phase": "Succeeded"}
 
     def test_no_infra_pods_found(self, tested_object):
         """Test when no pods are found in any infrastructure namespace."""
@@ -201,7 +200,7 @@ class TestInfraPodsReadyAndRunning:
 
     def test_old_failed_job_pod_skipped(self, tested_object):
         """Test that old (>24h) Failed Job pods are skipped."""
-        def mock_get_pods(namespace, timeout=30):
+        def mock_get_pods(namespace, field_selector=None, timeout=30):
             if namespace == "openshift-image-registry":
                 return [
                     create_mock_infra_pod("openshift-image-registry", "registry-pod", "Running", 1, 1),
@@ -223,7 +222,7 @@ class TestInfraPodsReadyAndRunning:
 
         recent_time = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
-        def mock_get_pods(namespace, timeout=30):
+        def mock_get_pods(namespace, field_selector=None, timeout=30):
             if namespace == "openshift-image-registry":
                 return [
                     create_mock_infra_pod("openshift-image-registry", "registry-pod", "Running", 1, 1),
@@ -242,7 +241,7 @@ class TestInfraPodsReadyAndRunning:
 
     def test_old_failed_non_job_pod_warning(self, tested_object):
         """Test that old Failed pods NOT owned by Job/CronJob produce a warning."""
-        def mock_get_pods(namespace, timeout=30):
+        def mock_get_pods(namespace, field_selector=None, timeout=30):
             if namespace == "openshift-etcd":
                 return [
                     create_mock_infra_pod("openshift-etcd", "etcd-master-0", "Running", 3, 3),
@@ -261,7 +260,7 @@ class TestInfraPodsReadyAndRunning:
 
     def test_mixed_failed_and_old_failed_pods(self, tested_object):
         """Test that FAILED result includes both not-running and old failed pods."""
-        def mock_get_pods(namespace, timeout=30):
+        def mock_get_pods(namespace, field_selector=None, timeout=30):
             if namespace == "openshift-etcd":
                 return [
                     create_mock_infra_pod("openshift-etcd", "etcd-master-0", "Running", 3, 3),
@@ -286,7 +285,7 @@ class TestInfraPodsReadyAndRunning:
 
     def test_old_failed_cronjob_pod_skipped(self, tested_object):
         """Test that old (>24h) Failed CronJob pods are skipped."""
-        def mock_get_pods(namespace, timeout=30):
+        def mock_get_pods(namespace, field_selector=None, timeout=30):
             if namespace == "openshift-image-registry":
                 return [
                     create_mock_infra_pod("openshift-image-registry", "registry-pod", "Running", 1, 1),
@@ -304,7 +303,7 @@ class TestInfraPodsReadyAndRunning:
 
     def test_pod_with_zero_containers_not_running(self, tested_object):
         """Test that a Running pod with 0/0 containers is treated as not running."""
-        def mock_get_pods(namespace, timeout=30):
+        def mock_get_pods(namespace, field_selector=None, timeout=30):
             if namespace == "openshift-monitoring":
                 return [
                     create_mock_infra_pod("openshift-monitoring", "empty-pod", "Running", 0, 0),
@@ -324,6 +323,108 @@ class TestInfraPodsReadyAndRunning:
 
         called_namespaces = [call.kwargs.get("namespace") for call in tested_object.oc_api.get_pods.call_args_list]
         assert set(called_namespaces) == set(InfraPodsReadyAndRunning.INFRA_NAMESPACES)
+
+    def test_pod_count_safety_limit(self, tested_object):
+        """Test that pod count per namespace is capped at MAX_PODS_PER_NAMESPACE."""
+        limit = InfraPodsReadyAndRunning.MAX_PODS_PER_NAMESPACE
+        excess_pods = [
+            create_mock_infra_pod("openshift-monitoring", f"pod-{i}", "Running", 1, 1)
+            for i in range(limit + 50)
+        ]
+
+        def mock_get_pods(namespace, field_selector=None, timeout=30):
+            if namespace == "openshift-monitoring":
+                return excess_pods
+            return []
+
+        tested_object.oc_api.get_pods = Mock(side_effect=mock_get_pods)
+        result = tested_object.run_rule()
+        assert result.status == Status.PASSED
+
+    def test_pod_count_safety_limit_logs_warning(self, tested_object, caplog):
+        """Test that exceeding MAX_PODS_PER_NAMESPACE logs a warning."""
+        import logging
+
+        limit = InfraPodsReadyAndRunning.MAX_PODS_PER_NAMESPACE
+        excess_pods = [
+            create_mock_infra_pod("openshift-monitoring", f"pod-{i}", "Running", 1, 1)
+            for i in range(limit + 50)
+        ]
+
+        def mock_get_pods(namespace, field_selector=None, timeout=30):
+            if namespace == "openshift-monitoring":
+                return excess_pods
+            return []
+
+        tested_object.oc_api.get_pods = Mock(side_effect=mock_get_pods)
+        with caplog.at_level(logging.WARNING, logger="in_cluster_checks.rules.k8s.k8s_validations"):
+            tested_object.run_rule()
+        assert "openshift-monitoring" in caplog.text
+        assert str(limit + 50) in caplog.text
+
+    def test_pod_count_safety_limit_truncates_not_running(self, tested_object):
+        """Test that not-running pods beyond MAX_PODS_PER_NAMESPACE are not reported."""
+        limit = InfraPodsReadyAndRunning.MAX_PODS_PER_NAMESPACE
+        pods = [
+            create_mock_infra_pod("openshift-monitoring", f"pod-{i}", "Running", 1, 1)
+            for i in range(limit)
+        ]
+        pods.append(create_mock_infra_pod("openshift-monitoring", "bad-pod-beyond-limit", "Pending", 0, 1))
+
+        def mock_get_pods(namespace, field_selector=None, timeout=30):
+            if namespace == "openshift-monitoring":
+                return pods
+            return []
+
+        tested_object.oc_api.get_pods = Mock(side_effect=mock_get_pods)
+        result = tested_object.run_rule()
+        assert result.status == Status.PASSED
+        assert "bad-pod-beyond-limit" not in result.message
+
+    def test_nonexistent_namespace_skipped(self, tested_object):
+        """Test that a namespace that raises an exception is skipped without crashing the rule."""
+
+        def mock_get_pods(namespace, field_selector=None, timeout=30):
+            if namespace == "openshift-sdn":
+                raise Exception("namespaces \"openshift-sdn\" not found")
+            if namespace == "openshift-etcd":
+                return [create_mock_infra_pod("openshift-etcd", "etcd-master-0", "Running", 3, 3)]
+            return []
+
+        tested_object.oc_api.get_pods = Mock(side_effect=mock_get_pods)
+        result = tested_object.run_rule()
+        assert result.status == Status.PASSED
+
+    def test_nonexistent_namespace_logs_warning(self, tested_object, caplog):
+        """Test that a skipped namespace logs a warning."""
+        import logging
+
+        def mock_get_pods(namespace, field_selector=None, timeout=30):
+            if namespace == "openshift-sdn":
+                raise Exception("not found")
+            return []
+
+        tested_object.oc_api.get_pods = Mock(side_effect=mock_get_pods)
+        with caplog.at_level(logging.WARNING, logger="in_cluster_checks.rules.k8s.k8s_validations"):
+            tested_object.run_rule()
+        assert "openshift-sdn" in caplog.text
+
+    def test_pod_with_missing_status_key(self, tested_object):
+        """Test that a pod with missing 'status' key is handled gracefully."""
+        mock_pod = Mock()
+        mock_pod.as_dict.return_value = {
+            "metadata": {"name": "broken-pod", "creationTimestamp": "2020-01-01T00:00:00Z"},
+        }
+
+        def mock_get_pods(namespace, field_selector=None, timeout=30):
+            if namespace == "openshift-etcd":
+                return [mock_pod]
+            return []
+
+        tested_object.oc_api.get_pods = Mock(side_effect=mock_get_pods)
+        result = tested_object.run_rule()
+        assert result.status == Status.FAILED
+        assert "broken-pod" in result.message
 
 
 def create_mock_node(name, ready_status, other_conditions=None):

--- a/tests/rules/k8s/test_k8s_validations.py
+++ b/tests/rules/k8s/test_k8s_validations.py
@@ -5,10 +5,13 @@ Adapted from HealthChecks test patterns for AllPodsReadyAndRunning.
 """
 
 import json
+import logging
 from unittest.mock import Mock
 
 import pytest
+from openshift_client import OpenShiftPythonException
 
+from in_cluster_checks.core.exceptions import UnExpectedSystemOutput
 from in_cluster_checks.rules.k8s.k8s_validations import (
     AllDeploymentsAvailable,
     AllPodsReadyAndRunning,
@@ -343,8 +346,6 @@ class TestInfraPodsReadyAndRunning:
 
     def test_pod_count_safety_limit_logs_warning(self, tested_object, caplog):
         """Test that exceeding MAX_PODS_PER_NAMESPACE logs a warning."""
-        import logging
-
         limit = InfraPodsReadyAndRunning.MAX_PODS_PER_NAMESPACE
         excess_pods = [
             create_mock_infra_pod("openshift-monitoring", f"pod-{i}", "Running", 1, 1)
@@ -357,7 +358,7 @@ class TestInfraPodsReadyAndRunning:
             return []
 
         tested_object.oc_api.get_pods = Mock(side_effect=mock_get_pods)
-        with caplog.at_level(logging.WARNING, logger="in_cluster_checks.rules.k8s.k8s_validations"):
+        with caplog.at_level(logging.WARNING, logger="in_cluster_checks.core.rule"):
             tested_object.run_rule()
         assert "openshift-monitoring" in caplog.text
         assert str(limit + 50) in caplog.text
@@ -382,11 +383,11 @@ class TestInfraPodsReadyAndRunning:
         assert "bad-pod-beyond-limit" not in result.message
 
     def test_nonexistent_namespace_skipped(self, tested_object):
-        """Test that a namespace that raises an exception is skipped without crashing the rule."""
+        """Test that a namespace that raises OpenShiftPythonException is skipped without crashing."""
 
         def mock_get_pods(namespace, field_selector=None, timeout=30):
             if namespace == "openshift-sdn":
-                raise Exception("namespaces \"openshift-sdn\" not found")
+                raise OpenShiftPythonException("namespaces \"openshift-sdn\" not found")
             if namespace == "openshift-etcd":
                 return [create_mock_infra_pod("openshift-etcd", "etcd-master-0", "Running", 3, 3)]
             return []
@@ -397,17 +398,26 @@ class TestInfraPodsReadyAndRunning:
 
     def test_nonexistent_namespace_logs_warning(self, tested_object, caplog):
         """Test that a skipped namespace logs a warning."""
-        import logging
 
         def mock_get_pods(namespace, field_selector=None, timeout=30):
             if namespace == "openshift-sdn":
-                raise Exception("not found")
+                raise OpenShiftPythonException("not found")
             return []
 
         tested_object.oc_api.get_pods = Mock(side_effect=mock_get_pods)
-        with caplog.at_level(logging.WARNING, logger="in_cluster_checks.rules.k8s.k8s_validations"):
+        with caplog.at_level(logging.WARNING, logger="in_cluster_checks.core.rule"):
             tested_object.run_rule()
         assert "openshift-sdn" in caplog.text
+
+    def test_unexpected_exception_propagates(self, tested_object):
+        """Test that non-OpenShift exceptions (e.g. UnExpectedSystemOutput) propagate."""
+
+        def mock_get_pods(namespace, field_selector=None, timeout=30):
+            raise UnExpectedSystemOutput("10.0.0.1", "oc get pods", "connection refused")
+
+        tested_object.oc_api.get_pods = Mock(side_effect=mock_get_pods)
+        with pytest.raises(UnExpectedSystemOutput):
+            tested_object.run_rule()
 
     def test_pod_with_missing_status_key(self, tested_object):
         """Test that a pod with missing 'status' key is handled gracefully."""

--- a/tests/unit/utils/test_oc_api_utils.py
+++ b/tests/unit/utils/test_oc_api_utils.py
@@ -89,3 +89,36 @@ class TestSelectResources:
     def test_validates_mutually_exclusive_params(self, oc_api):
         with pytest.raises(ValueError, match="Cannot specify both"):
             oc_api.select_resources("pod", namespace="default", all_namespaces=True)
+
+    @patch("in_cluster_checks.utils.oc_api_utils.oc")
+    def test_field_selector_passed_as_dict(self, mock_oc, oc_api):
+        mock_selector = Mock()
+        mock_selector.objects.return_value = []
+
+        mock_oc.timeout.return_value.__enter__ = Mock()
+        mock_oc.timeout.return_value.__exit__ = Mock(return_value=False)
+        mock_oc.selector.return_value = mock_selector
+
+        field_selector = {"!status.phase": "Succeeded"}
+        oc_api.select_resources("pod", namespace="openshift-etcd", field_selector=field_selector)
+
+        call_kwargs = mock_oc.selector.call_args
+        assert call_kwargs.kwargs["field_selectors"] == {"!status.phase": "Succeeded"}
+        assert isinstance(call_kwargs.kwargs["field_selectors"], dict)
+
+    @patch("in_cluster_checks.utils.oc_api_utils.oc")
+    def test_get_pods_passes_field_selector_to_select_resources(self, mock_oc, oc_api):
+        mock_selector = Mock()
+        mock_selector.objects.return_value = []
+
+        mock_oc.timeout.return_value.__enter__ = Mock()
+        mock_oc.timeout.return_value.__exit__ = Mock(return_value=False)
+        mock_oc.project.return_value.__enter__ = Mock()
+        mock_oc.project.return_value.__exit__ = Mock(return_value=False)
+        mock_oc.selector.return_value = mock_selector
+
+        field_selector = {"!status.phase": "Succeeded"}
+        oc_api.get_pods(namespace="openshift-etcd", field_selector=field_selector)
+
+        call_kwargs = mock_oc.selector.call_args
+        assert call_kwargs.kwargs["field_selectors"] == {"!status.phase": "Succeeded"}


### PR DESCRIPTION
## Summary

**Jira**: [PDRIVE-811](https://redhat.atlassian.net/browse/PDRIVE-811)

Optimizes the `InfraPodsReadyAndRunning` rule to reduce memory usage and runtime:

- **Field selector support**: Added `field_selector` (dict) parameter to `select_resources()` and `get_pods()` in `OcApiUtils`. The rule uses `status.phase!=Succeeded` to exclude completed pods from the API response, reducing payload size.
- **Memory optimization**: Ready pods are now counted as an integer instead of storing full pod objects in a list.
- **Expanded namespace coverage**: Infrastructure namespace list expanded from 22 to 27 (added `openshift-cluster-version`, `openshift-ingress-operator`, `openshift-service-ca`, `openshift-network-diagnostics`, `openshift-kube-storage-version-migrator`).
- **Safety limit**: Added a 1000 pods-per-namespace safety limit with warning log to prevent unbounded memory growth.
- **Graceful error handling**: Added try/except per namespace to handle non-existent namespaces (e.g., `openshift-sdn` on OCP 4.17+) without crashing the entire rule.

## Files changed

- `src/in_cluster_checks/utils/oc_api_utils.py` — `field_selector` parameter in `select_resources()` and `get_pods()`
- `src/in_cluster_checks/rules/k8s/k8s_validations.py` — Rule optimizations
- `tests/rules/k8s/test_k8s_validations.py` — 8 new tests (18 total for InfraPodsReadyAndRunning)
- `tests/unit/utils/test_oc_api_utils.py` — 2 new tests for field selector dict verification

## Test plan

- [x] All 108 tests pass
- [x] Pre-commit checks pass (black, flake8, isort, pytest)
- [x] Tested on live OpenShift cluster — rule correctly identifies unhealthy pods
- [x] Verified `field_selectors` passed as dict to `oc.selector()` (not string)
- [x] Confluence documentation updated with expanded namespace list

[PDRIVE-811]: https://redhat.atlassian.net/browse/PDRIVE-811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved infrastructure pod validation by excluding completed pods from API queries.
  * Refined namespace error handling so unreachable namespaces are skipped without causing overall rule failure.
  * Improved reporting for pods with missing or incomplete status information.
* **Improvements**
  * Added support for server-side resource filtering to reduce unnecessary pod processing.
  * Enhanced handling of very large pod sets: results are capped per namespace, with warnings when limits are reached and more accurate ready/non-running reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->