### PR TITLE
feat(PDRIVE-687): add mypy-based pre-commit hook for type checking

### DIFF
--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -195,6 +195,10 @@ def has_resource(self) -> bool:
 
 **Check `src/in_cluster_checks/utils` for suitable functions before executing shell commands or implementing new logic.**
 
+## Mypy Type Errors
+
+**Fix mypy errors by correcting type annotations — never suppress them with `# noqa`, `# type: ignore`, or by modifying the filter script (`check_mypy.py`).**
+
 ## Debug Logging
 
 See [@.claude/rules/debug-rule.md](debug-rule.md) for debug logging guidelines.

--- a/.claude/skills/new-rule/SKILL.md
+++ b/.claude/skills/new-rule/SKILL.md
@@ -107,7 +107,7 @@ class MyOrchestratorRule(OrchestratorRule):
 ```python
 # Use existing oc_api methods when available
 pods = self.oc_api.get_pods(namespace="openshift-etcd")
-network = self.oc_api.select_resources("network.operator/cluster", single=True)
+network = self.oc_api.select_single_resource("network.operator/cluster")
 
 # Run commands inside pods
 cmd = SafeCmdString("etcdctl version")

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,6 +58,14 @@ repos:
         types: [python]
         files: ^src/in_cluster_checks/
 
+      - id: mypy-type-check
+        name: check types with mypy
+        entry: python tests/linters/check_mypy.py
+        language: system
+        types: [python]
+        files: ^src/in_cluster_checks/
+        pass_filenames: false
+
       - id: pytest-coverage
         name: pytest with coverage
         entry: python -m pytest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -298,7 +298,7 @@ This validates variables to prevent shell injection.
 ```python
 # Use existing oc_api methods when available
 pods = self.oc_api.get_pods(namespace="openshift-etcd")
-network = self.oc_api.select_resources("network.operator/cluster", single=True)
+network = self.oc_api.select_single_resource("network.operator/cluster")
 
 # Use run_oc_command for other oc commands
 rc, out, err = self.oc_api.run_oc_command("get", ["nodes", "-o", "json"])

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,19 @@
+[mypy]
+python_version = 3.12
+check_untyped_defs = True
+show_error_codes = True
+
+# Only report SafeCmdString type errors
+disable_error_code = var-annotated,no-untyped-def,import-untyped,no-any-return,override
+
+# Ignore third-party modules without stubs
+ignore_missing_imports = True
+
+# Files to check
+files = src/in_cluster_checks/
+
+[mypy-openshift_client.*]
+ignore_missing_imports = True
+
+[mypy-dateutil.*]
+ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dev = [
     "black>=24.1.1",
     "flake8>=7.0.0",
     "isort>=5.13.2",
+    "mypy>=1.7.0",
 ]
 
 [project.scripts]

--- a/src/in_cluster_checks/core/data_collector_runner.py
+++ b/src/in_cluster_checks/core/data_collector_runner.py
@@ -13,6 +13,7 @@ from typing import Any, Dict
 
 from in_cluster_checks.core.exceptions import UnExpectedSystemOutput
 from in_cluster_checks.core.executor import OrchestratorExecutor
+from in_cluster_checks.core.operations import DataCollector
 from in_cluster_checks.core.parallel_runner import ParallelRunner
 from in_cluster_checks.utils.dict_utils import convert_dict_to_sorted_json_str
 from in_cluster_checks.utils.enums import ORCHESTRATOR_HOST_NAME, Objectives
@@ -37,7 +38,7 @@ class DataCollectorRunner:
 
     @classmethod
     def execute_data_collector(
-        cls, rule_instance, collector_class: type, use_parallel: bool = True, **kwargs
+        cls, rule_instance, collector_class: type[DataCollector], use_parallel: bool = True, **kwargs
     ) -> Dict[str, Any]:
         """
         Execute a DataCollector on all hosts and return aggregated results.
@@ -193,7 +194,12 @@ class DataCollectorRunner:
 
     @classmethod
     def run_collectors(
-        cls, collector_instances: list, use_parallel: bool, collector_class: type, rule_instance, **kwargs
+        cls,
+        collector_instances: list,
+        use_parallel: bool,
+        collector_class: type[DataCollector],
+        rule_instance,
+        **kwargs,
     ) -> Dict[str, Dict]:
         """
         Run collectors with caching for many-to-one relationships.
@@ -391,7 +397,7 @@ class DataCollectorRunner:
 
     @staticmethod
     def handle_collector_failures(
-        rule_instance, collector_class: type, host_exceptions: Dict[str, str], hosts_dict: Dict[str, Any]
+        rule_instance, collector_class: type[DataCollector], host_exceptions: Dict[str, str], hosts_dict: Dict[str, Any]
     ):
         """
         Handle collector failures and track success.
@@ -428,7 +434,7 @@ class DataCollectorRunner:
         Returns:
             True if all hosts failed, False otherwise
         """
-        return host_exceptions_dict and set(host_exceptions_dict.keys()) == set(hosts_dict.keys())
+        return bool(host_exceptions_dict) and set(host_exceptions_dict.keys()) == set(hosts_dict.keys())
 
     @staticmethod
     def format_collector_exceptions(collector_name: str, host_exceptions_dict: Dict[str, str]) -> list:

--- a/src/in_cluster_checks/core/domain.py
+++ b/src/in_cluster_checks/core/domain.py
@@ -43,7 +43,7 @@ class RuleDomain(abc.ABC):
         raise NotImplementedError(f"domain_name() must be implemented in {self.__class__.__name__}")
 
     @abc.abstractmethod
-    def get_rule_classes(self) -> List[type]:
+    def get_rule_classes(self) -> List[type[Rule]]:
         """
         Get list of rule classes to run in this domain.
 
@@ -59,7 +59,7 @@ class RuleDomain(abc.ABC):
         """
         raise NotImplementedError(f"get_rule_classes() must be implemented in {self.__class__.__name__}")
 
-    def _filter_rules_for_light_run(self, rule_classes: List[type]) -> List[type]:
+    def _filter_rules_for_light_run(self, rule_classes: List[type[Rule]]) -> List[type[Rule]]:
         """
         Filter rules based on light_run mode.
 
@@ -111,7 +111,9 @@ class RuleDomain(abc.ABC):
         """Clean up after domain execution — e.g. free cached command outputs."""
         pass
 
-    def _create_rule_groups(self, rule_classes: List[type], host_executors_dict: Dict[str, Any]) -> List[List[Rule]]:
+    def _create_rule_groups(
+        self, rule_classes: List[type[Rule]], host_executors_dict: Dict[str, Any]
+    ) -> List[List[Rule]]:
         """
         Create grouped rule instances following HC's pattern.
 
@@ -139,7 +141,7 @@ class RuleDomain(abc.ABC):
 
         return rule_groups
 
-    def _create_instances_for_rule(self, rule_class: type, host_executors_dict: Dict[str, Any]) -> List[Rule]:
+    def _create_instances_for_rule(self, rule_class: type[Rule], host_executors_dict: Dict[str, Any]) -> List[Rule]:
         """
         Create rule instances for a single rule class.
 
@@ -163,7 +165,7 @@ class RuleDomain(abc.ABC):
         # Create instances for matching nodes (handles both ONE_* and multi-type)
         return self._create_per_node_instances(rule_class, host_executors_dict)
 
-    def _create_orchestrator_instance(self, rule_class: type, host_executors_dict: Dict[str, Any]) -> List[Rule]:
+    def _create_orchestrator_instance(self, rule_class: type[Rule], host_executors_dict: Dict[str, Any]) -> List[Rule]:
         """
         Create single orchestrator instance.
 
@@ -186,7 +188,7 @@ class RuleDomain(abc.ABC):
             self.logger.error(f"Failed to instantiate {rule_class.__name__} as orchestrator: {e}")
             return []
 
-    def _create_per_node_instances(self, rule_class: type, host_executors_dict: Dict[str, Any]) -> List[Rule]:
+    def _create_per_node_instances(self, rule_class: type[Rule], host_executors_dict: Dict[str, Any]) -> List[Rule]:
         """
         Create rule instances for each matching node.
 
@@ -210,7 +212,7 @@ class RuleDomain(abc.ABC):
 
         return instances
 
-    def _should_create_for_executor(self, rule_class: type, executor: Any) -> bool:
+    def _should_create_for_executor(self, rule_class: type[Rule], executor: Any) -> bool:
         """
         Check if rule should be created for the given executor.
 
@@ -231,7 +233,7 @@ class RuleDomain(abc.ABC):
 
         return True
 
-    def _matches_debug_filter(self, rule_class: type) -> bool:
+    def _matches_debug_filter(self, rule_class: type[Rule]) -> bool:
         """
         Check if rule matches debug filter (by unique_name or title).
 

--- a/src/in_cluster_checks/core/exceptions.py
+++ b/src/in_cluster_checks/core/exceptions.py
@@ -44,7 +44,8 @@ class UnExpectedSystemOutput(ExecutionException):
 
         # Sanitize command before including in exception message
         safe_cmd = SecretFilter.sanitize(self.cmd)
-        super().__init__(f"{message} on {ip}: {safe_cmd}\nOutput: {output[:500]}")  # Limit output length
+        safe_output = SecretFilter.sanitize(output[:500])
+        super().__init__(f"{message} on {ip}: {safe_cmd}\nOutput: {safe_output}")
 
     def __str__(self):
         """Return formatted exception string (HC-style)."""

--- a/src/in_cluster_checks/core/executor_factory.py
+++ b/src/in_cluster_checks/core/executor_factory.py
@@ -91,7 +91,7 @@ class NodeExecutorFactory:
 
         return self._host_executors_dict
 
-    def _get_internal_ip(self, node_dict: dict) -> str:
+    def _get_internal_ip(self, node_dict: dict) -> str | None:
         """
         Extract internal IP from node data.
 

--- a/src/in_cluster_checks/core/operations.py
+++ b/src/in_cluster_checks/core/operations.py
@@ -35,6 +35,8 @@ class Operator:
     # e.g., [Objectives.ALL_NODES], [Objectives.ICE_CONTAINER], etc.
     objective_hosts = []
 
+    unique_name: str | None = None
+
     # Thread-safe debug output lock (prevents interleaved output in parallel execution)
     _debug_lock = threading.RLock()
 
@@ -76,7 +78,11 @@ class Operator:
             print(f"\n[DEBUG] [{self.get_host_name()}] {message}", flush=True)
 
     def run_cmd(
-        self, cmd: SafeCmdString, timeout: int = 120, hosts_cached_pool: dict = None, add_bash_timeout: bool = False
+        self,
+        cmd: SafeCmdString,
+        timeout: int = 120,
+        hosts_cached_pool: dict | None = None,
+        add_bash_timeout: bool = False,
     ) -> tuple:
         """
         Run command on host/container and log it.
@@ -141,7 +147,7 @@ class Operator:
         return res
 
     def get_output_from_run_cmd(
-        self, cmd: SafeCmdString, timeout: int = 30, message: str = None, hosts_cached_pool: dict = None
+        self, cmd: SafeCmdString, timeout: int = 30, message: str | None = None, hosts_cached_pool: dict | None = None
     ) -> str:
         """
         Run command, log it, and return stdout if successful.
@@ -315,13 +321,9 @@ class Operator:
                 f"Add as class variable: unique_name = 'your_unique_name'"
             )
 
-    def get_unique_name(self) -> str:
+    def get_unique_name(self) -> str | None:
         """Get unique operation name (accessible as class or instance attribute)."""
         return self.unique_name
-
-    def get_severity(self) -> str:
-        """Get severity level (HC-style interface)."""
-        return self._severity if self._severity else "NA"
 
     def get_implication_tags(self) -> list:
         """Get implication tags (HC-style interface)."""
@@ -505,7 +507,9 @@ class OrchestratorDataCollector(DataCollector):
             objective_hosts = [Objectives.ORCHESTRATOR]
 
             def collect_data(self):
-                network_obj = self.oc_api.select_resources("network.operator/cluster", single=True)
+                network_obj = self.oc_api.select_single_resource("network.operator/cluster")
+                if not network_obj:
+                    return None
                 return network_obj.model.spec.defaultNetwork.type
     """
 
@@ -531,7 +535,11 @@ class OrchestratorDataCollector(DataCollector):
         pass
 
     def run_cmd(
-        self, cmd: SafeCmdString, timeout: int = 120, hosts_cached_pool: dict = None, add_bash_timeout: bool = False
+        self,
+        cmd: SafeCmdString,
+        timeout: int = 120,
+        hosts_cached_pool: dict | None = None,
+        add_bash_timeout: bool = False,
     ) -> tuple:
         """
         Not available for OrchestratorDataCollector - use oc_api methods instead.

--- a/src/in_cluster_checks/core/printer.py
+++ b/src/in_cluster_checks/core/printer.py
@@ -311,12 +311,12 @@ class StructedPrinter:
             logger.info("")  # Empty line after host validations
 
     @staticmethod
-    def print_to_json(results: Dict[str, Any], output_file: str) -> None:
+    def print_to_json(results: List[Dict[str, Any]], output_file: str) -> None:
         """
         Write rule results to JSON file with restricted permissions (owner-only).
 
         Args:
-            results: Dictionary with rule results in Insights format
+            results: List of report dicts from format_results()
             output_file: Path to output JSON file
         """
         file_descriptor = os.open(output_file, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
@@ -359,7 +359,7 @@ class StructedPrinter:
                     if run_time is not None:
                         tc_attrs["time"] = str(run_time)
 
-                    testcase = ET.SubElement(testsuite, "testcase", **tc_attrs)
+                    testcase = ET.SubElement(testsuite, "testcase", tc_attrs)
                     status = host_result.get("status")
                     message = _strip_xml_illegal_chars(host_result.get("message", ""))
 
@@ -380,7 +380,7 @@ class StructedPrinter:
         tree.write(output_file, encoding="unicode", xml_declaration=True)
 
     @staticmethod
-    def format_results(flow_results: list, rule_component_map: Dict[str, str]) -> Dict[str, Any]:
+    def format_results(flow_results: list, rule_component_map: Dict[str, str]) -> List[Dict[str, Any]]:
         """
         Format multiple flow results into Insights-compatible structure.
 
@@ -393,21 +393,17 @@ class StructedPrinter:
             rule_component_map: Map of {rule_name: full_component_path}
 
         Returns:
-            Formatted results dictionary:
+            List of report dicts, each containing:
             {
-                "in_cluster_rules": [
-                    {
-                        "rule_id": "domain|rule",
-                        "component": "...",
-                        "key": "rule",
-                        "status": "aggregated_status",  # Worst status across all hosts
-                        "description": "...",
-                        "domain": "...",
-                        "details": [  # Array of host results
-                            {"node_ip": "...", "node_name": "...", "status": "...", ...},
-                            {"node_ip": "...", "node_name": "...", "status": "...", ...}
-                        ]
-                    }
+                "rule_id": "domain|rule",
+                "component": "...",
+                "key": "rule",
+                "status": "aggregated_status",  # Worst status across all hosts
+                "description": "...",
+                "domain": "...",
+                "details": [  # Array of host results
+                    {"node_ip": "...", "node_name": "...", "status": "...", ...},
+                    {"node_ip": "...", "node_name": "...", "status": "...", ...}
                 ]
             }
         """

--- a/src/in_cluster_checks/core/rule.py
+++ b/src/in_cluster_checks/core/rule.py
@@ -78,7 +78,7 @@ class Rule(Operator):
         return self.objective_hosts
 
     @classmethod
-    def get_unique_name_classmethod(cls) -> str:
+    def get_unique_name_classmethod(cls) -> str | None:
         """
         Get unique operation name without instantiation.
 

--- a/src/in_cluster_checks/rules/hw_fw_details/hw_fw_base.py
+++ b/src/in_cluster_checks/rules/hw_fw_details/hw_fw_base.py
@@ -182,7 +182,7 @@ class HwFwRule(OrchestratorRule):
 
         # Process each node group
         for group_label, executors in node_groups.items():
-            group_result = OrderedDict()
+            group_result: OrderedDict[str, Any] = OrderedDict()
             group_result["node_count"] = len(executors)
             group_result["nodes"] = [e.node_name for e in executors]
             group_result[category_key] = OrderedDict()
@@ -223,9 +223,10 @@ class HwFwRule(OrchestratorRule):
                     collector_result["value"] = self._get_list_of_id_host_name_data(group_data)
 
                 # Create nested structure: topic -> name -> result (HC Blueprint format)
-                if topic not in group_result[category_key]:
-                    group_result[category_key][topic] = OrderedDict()
-                group_result[category_key][topic][name] = collector_result
+                category_data: OrderedDict = group_result[category_key]
+                if topic not in category_data:
+                    category_data[topic] = OrderedDict()
+                category_data[topic][name] = collector_result
 
             result_data[group_label] = group_result
 

--- a/src/in_cluster_checks/rules/k8s/k8s_validations.py
+++ b/src/in_cluster_checks/rules/k8s/k8s_validations.py
@@ -275,7 +275,12 @@ class InfraPodsReadyAndRunning(OrchestratorRule):
             age_seconds = (datetime.now(timezone.utc) - parsed_time).total_seconds()
             return age_seconds > threshold_seconds
         except (ValueError, AttributeError) as err:
-            raise UnExpectedSystemOutput(f"Failed to parse pod timestamp: {timestamp_str}") from err
+            raise UnExpectedSystemOutput(
+                ip="cluster-api",
+                cmd="oc get pods -A -o json",
+                output=str(timestamp_str),
+                message=f"Failed to parse pod timestamp: {timestamp_str}",
+            ) from err
 
 
 class NodesAreReady(OrchestratorRule):
@@ -1318,7 +1323,7 @@ class VerifyFARControllerReplicas(OrchestratorRule):
     def run_rule(self):
         """Check FAR controller manager has correct number of replicas."""
         # Step 1: Check if this is a Single Node OpenShift cluster
-        infrastructure = self.oc_api.select_resources("infrastructure/cluster", single=True, timeout=30)
+        infrastructure = self.oc_api.select_single_resource("infrastructure/cluster", timeout=30)
         if infrastructure:
             infra_dict = infrastructure.as_dict()
             topology = infra_dict.get("status", {}).get("controlPlaneTopology", "")

--- a/src/in_cluster_checks/rules/k8s/subscription_operator_validations.py
+++ b/src/in_cluster_checks/rules/k8s/subscription_operator_validations.py
@@ -4,6 +4,8 @@ Subscription operator validations for OpenShift clusters.
 Validates health and status of subscription operators.
 """
 
+from typing import Any
+
 from in_cluster_checks.core.rule import OrchestratorRule
 from in_cluster_checks.core.rule_result import PrerequisiteResult, RuleResult
 from in_cluster_checks.utils.enums import Objectives
@@ -39,7 +41,7 @@ class SubscriptionOperatorRule(OrchestratorRule):
             f"{self.operator_display_name} operator is not installed on this cluster"
         )
 
-    def _check_pod_security_context(self, pod_name: str, security_context: dict[str, object] | None) -> list[str]:
+    def _check_pod_security_context(self, pod_name: str, security_context: dict[str, Any] | None) -> list[str]:
         """Validate pod-level security context has runAsNonRoot set to true.
 
         Args:
@@ -61,7 +63,7 @@ class SubscriptionOperatorRule(OrchestratorRule):
             )
         return errors
 
-    def _check_containers_non_root(self, pod_name: str, all_containers: list[dict[str, object]]) -> list[str]:
+    def _check_containers_non_root(self, pod_name: str, all_containers: list[dict[str, Any]]) -> list[str]:
         """Validate no container runs as root (runAsUser != 0, runAsNonRoot not false).
 
         Args:

--- a/src/in_cluster_checks/rules/network/dns_validations.py
+++ b/src/in_cluster_checks/rules/network/dns_validations.py
@@ -1,5 +1,3 @@
-from typing import ClassVar
-
 from in_cluster_checks.core.exceptions import UnExpectedSystemOutput
 from in_cluster_checks.core.operations import OrchestratorDataCollector
 from in_cluster_checks.core.rule import Rule, RuleResult
@@ -17,7 +15,7 @@ class DnsOperatorConfigCollector(OrchestratorDataCollector):
     upstream resolver addresses.
     """
 
-    objective_hosts: ClassVar[list] = [Objectives.ORCHESTRATOR]
+    objective_hosts = [Objectives.ORCHESTRATOR]
 
     def collect_data(self, **kwargs) -> list[str]:
         """
@@ -45,7 +43,12 @@ class DnsOperatorConfigCollector(OrchestratorDataCollector):
             if "NotFound" in combined_output or "not found" in combined_output.lower():
                 return []
             # Other errors should propagate
-            raise UnExpectedSystemOutput(f"Failed to query DNS operator config: {stderr}")
+            raise UnExpectedSystemOutput(
+                ip=self.get_host_ip(),
+                cmd="oc get dns.operator.openshift.io/cluster -o json",
+                output=f"{dns_config_output}\n{stderr}".strip(),
+                message="Failed to query DNS operator config",
+            )
 
         # Parse DNS config
         dns_config = parse_json(
@@ -80,11 +83,11 @@ class VerifyDnsReachability(Rule):
     4. Reports which DNS servers are reachable/unreachable from this node
     """
 
-    objective_hosts: ClassVar[list] = [Objectives.ALL_NODES]
-    supported_profiles: ClassVar[set] = {"general"}
+    objective_hosts = [Objectives.ALL_NODES]
+    supported_profiles = {"general"}
     unique_name = "verify_dns_reachability"
     title = "Verify DNS server reachability"
-    links: ClassVar[list] = [
+    links = [
         "https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418450933/Verify+DNS+reachability",
     ]
     RESOLV_CONF_PATH = "/etc/resolv.conf"

--- a/src/in_cluster_checks/rules/network/nmstate_validations.py
+++ b/src/in_cluster_checks/rules/network/nmstate_validations.py
@@ -76,10 +76,18 @@ class VerifyAllNNCPsAvailable(OrchestratorRule):
         for nncp in nncps:
             # Validate required metadata field
             if not hasattr(nncp, "model") or not hasattr(nncp.model, "metadata"):
-                raise UnExpectedSystemOutput(f"NNCP object missing required 'model.metadata' structure: {nncp}")
+                raise UnExpectedSystemOutput(
+                    ip=self.get_host_ip(),
+                    cmd="oc get nodenetworkconfigurationpolicies -A",
+                    output=str(nncp),
+                    message=f"NNCP object missing required 'model.metadata' structure: {nncp}",
+                )
             if not hasattr(nncp.model.metadata, "name"):
                 raise UnExpectedSystemOutput(
-                    f"NNCP object missing required 'model.metadata.name' field: {nncp.model.metadata}"
+                    ip=self.get_host_ip(),
+                    cmd="oc get nodenetworkconfigurationpolicies -A",
+                    output=str(nncp.model.metadata),
+                    message=f"NNCP object missing required 'model.metadata.name' field: {nncp.model.metadata}",
                 )
 
             nncp_name = nncp.model.metadata.name
@@ -107,9 +115,19 @@ class VerifyAllNNCPsAvailable(OrchestratorRule):
         condition_map = {}
         for cond in conditions:
             if not hasattr(cond, "type"):
-                raise UnExpectedSystemOutput(f"NNCP {nncp_name} condition missing required 'type' field: {cond}")
+                raise UnExpectedSystemOutput(
+                    ip=self.get_host_ip(),
+                    cmd="oc get nodenetworkconfigurationpolicies -A",
+                    output=str(cond),
+                    message=f"NNCP {nncp_name} condition missing required 'type' field: {cond}",
+                )
             if not hasattr(cond, "status"):
-                raise UnExpectedSystemOutput(f"NNCP {nncp_name} condition missing required 'status' field: {cond}")
+                raise UnExpectedSystemOutput(
+                    ip=self.get_host_ip(),
+                    cmd="oc get nodenetworkconfigurationpolicies -A",
+                    output=str(cond),
+                    message=f"NNCP {nncp_name} condition missing required 'status' field: {cond}",
+                )
             condition_map[cond.type] = cond
 
         # Check Available condition

--- a/src/in_cluster_checks/rules/network/node_connectivity_validations.py
+++ b/src/in_cluster_checks/rules/network/node_connectivity_validations.py
@@ -163,7 +163,7 @@ class BondDnsCollector(OvsOperatorBase, DataCollector):
 
         return all_bonds_dns
 
-    def collect_data(self, **kwargs) -> dict:
+    def collect_data(self, **kwargs) -> dict | None:
         """
         Collect DNS server data from all bond interfaces.
 

--- a/src/in_cluster_checks/rules/network/ovnk8s_validations.py
+++ b/src/in_cluster_checks/rules/network/ovnk8s_validations.py
@@ -32,7 +32,7 @@ class OVNKubernetesBase(OrchestratorRule):
             PrerequisiteResult indicating if OVN-Kubernetes is the network type
         """
         try:
-            network_obj = self.oc_api.select_resources(resource_type="network.operator/cluster", single=True)
+            network_obj = self.oc_api.select_single_resource(resource_type="network.operator/cluster")
             if not network_obj:
                 return PrerequisiteResult.not_met("Cannot determine network type: network.operator/cluster not found")
 
@@ -225,10 +225,7 @@ class MTUOverlayInterfaces(OVNKubernetesBase):
         return RuleResult.passed()
 
     def _get_expected_mtu(self) -> Optional[int]:
-        network_obj = self.oc_api.select_resources(
-            resource_type="network.operator/cluster",
-            single=True,
-        )
+        network_obj = self.oc_api.select_single_resource(resource_type="network.operator/cluster")
 
         if not network_obj:
             return None

--- a/src/in_cluster_checks/rules/network/ovs_base.py
+++ b/src/in_cluster_checks/rules/network/ovs_base.py
@@ -282,7 +282,7 @@ class IsOVNKubernetesCollector(OrchestratorDataCollector):
             True if OVN-Kubernetes, False otherwise
         """
         try:
-            network_obj = self.oc_api.select_resources(resource_type="network.operator/cluster", single=True)
+            network_obj = self.oc_api.select_single_resource(resource_type="network.operator/cluster")
             if not network_obj:
                 return False
 
@@ -340,7 +340,7 @@ class NncpOvsBondVlanCollector(OvsOperatorBase, OrchestratorDataCollector):
             return set()
 
         nncps = parse_json(
-            output=out, cmd="oc get nodenetworkconfigurationpolicies.nmstate.io -A -o json", ip=self.get_host_ip
+            output=out, cmd="oc get nodenetworkconfigurationpolicies.nmstate.io -A -o json", ip=self.get_host_ip()
         ).get("items", [])
         ovs_bond_vlans = set()
 
@@ -397,7 +397,7 @@ class OvnSecondaryNetworkBridgesCollector(OrchestratorDataCollector):
             return set()
 
         nncps = parse_json(
-            output=out, cmd="oc get nodenetworkconfigurationpolicies.nmstate.io -A -o json", ip=self.get_host_ip
+            output=out, cmd="oc get nodenetworkconfigurationpolicies.nmstate.io -A -o json", ip=self.get_host_ip()
         ).get("items", [])
         secondary_bridges = set()
         for nncp in nncps:

--- a/src/in_cluster_checks/rules/resources_utilization/resources_utilization.py
+++ b/src/in_cluster_checks/rules/resources_utilization/resources_utilization.py
@@ -1,13 +1,21 @@
 """Orchestrator rule for cluster resources utilization reporting."""
 
 import re
-from typing import Any, Dict, List
+from typing import Any, Dict, List, TypedDict
 
 from in_cluster_checks.core.exceptions import UnExpectedSystemOutput
 from in_cluster_checks.core.operations import OrchestratorDataCollector
 from in_cluster_checks.core.rule import OrchestratorRule, RuleResult
 from in_cluster_checks.utils.enums import Objectives
 from in_cluster_checks.utils.parsing_utils import format_cpu, format_memory
+
+
+class ParsedResourceLine(TypedDict):
+    resource_name: str
+    requests_value: str
+    requests_pct: str | None
+    limits_value: str
+    limits_pct: str | None
 
 
 class NodeResourcesCollector(OrchestratorDataCollector):
@@ -99,7 +107,7 @@ class NodeResourcesCollector(OrchestratorDataCollector):
 
         return sorted(node_labels.split(","))
 
-    def _parse_allocated_resources(self, describe_output: str) -> Dict[str, Dict[str, str]]:
+    def _parse_allocated_resources(self, describe_output: str) -> Dict[str, Dict[str, str | None]]:
         """Parse 'Allocated resources' section from oc describe node output.
 
         Args:
@@ -149,7 +157,7 @@ class NodeResourcesCollector(OrchestratorDataCollector):
 
         return allocated
 
-    def _parse_resource_line(self, line: str) -> Dict[str, str] | None:
+    def _parse_resource_line(self, line: str) -> ParsedResourceLine | None:
         """Parse a single resource line from the allocated resources table.
 
         Args:

--- a/src/in_cluster_checks/rules/storage/storage_validations.py
+++ b/src/in_cluster_checks/rules/storage/storage_validations.py
@@ -95,9 +95,7 @@ class CephRule(OrchestratorRule):
 
         try:
             # Check if openshift-storage namespace exists (Rook-Ceph namespace)
-            namespace_obj = self.oc_api.select_resources(
-                resource_type="namespace/openshift-storage", timeout=10, single=True
-            )
+            namespace_obj = self.oc_api.select_single_resource(resource_type="namespace/openshift-storage", timeout=10)
             if not namespace_obj:
                 return PrerequisiteResult.not_met(
                     "OpenShift Storage namespace not found. Ceph is not deployed in this cluster."
@@ -618,7 +616,7 @@ class OsdJournalError(CephRule):
 
     def _get_osd_pods(self) -> list:
         """Get all OSD pods from the cluster."""
-        return self._get_pods(namespace=self.NAMESPACE, labels={"app": "rook-ceph-osd"})
+        return self.oc_api.get_pods(namespace=self.NAMESPACE, labels={"app": "rook-ceph-osd"})
 
     def _check_pod_health(self, pod) -> dict | None:
         """

--- a/src/in_cluster_checks/runner.py
+++ b/src/in_cluster_checks/runner.py
@@ -14,6 +14,7 @@ from typing import Dict, Optional
 from in_cluster_checks import global_config
 from in_cluster_checks.core.data_collector_runner import DataCollectorRunner
 from in_cluster_checks.core.domain import RuleDomain
+from in_cluster_checks.core.executor import NodeExecutor
 from in_cluster_checks.core.executor_factory import NodeExecutorFactory
 from in_cluster_checks.core.printer import StructedPrinter
 from in_cluster_checks.utils.enums import Status
@@ -61,8 +62,8 @@ class InClusterCheckRunner:
 
         self.logger = logging.getLogger(__name__)
         self.domain_package = domain_package
-        self.factory = None
-        self.node_executors = None
+        self.factory: NodeExecutorFactory | None = None
+        self.node_executors: Dict[str, NodeExecutor] | None = None
 
         # Set global config so other components can access it
         global_config.set_config(

--- a/src/in_cluster_checks/utils/oc_api_utils.py
+++ b/src/in_cluster_checks/utils/oc_api_utils.py
@@ -16,7 +16,7 @@ Usage:
 
     class MyCollector(OrchestratorDataCollector):
         def collect_data(self):
-            network_obj = self.oc_api.select_resources("network.operator/cluster", single=True)
+            network_obj = self.oc_api.select_single_resource("network.operator/cluster")
             ...
 """
 
@@ -347,48 +347,22 @@ class OcApiUtils:
             # If parsing fails, return the original timestamp
             return creation_timestamp
 
-    def select_resources(
+    def _log_and_build_selector_kwargs(
         self,
         resource_type: str,
         namespace: str | None = None,
         labels: Dict[str, str] | None = None,
-        field_selector: dict | None = None,
+        field_selector: Dict[str, str] | None = None,
         all_namespaces: bool = False,
-        timeout: int = 30,
-        single: bool = False,
-    ) -> list | Any | None:
-        """Execute oc.selector with consistent error handling and timeout management.
-
-        This is a generic wrapper around oc.selector() that provides:
-        - Consistent timeout management
-        - Standardized error handling with contextual logging
-        - Support for both .objects() (list) and .object() (single) patterns
-        - Validation of mutually exclusive parameters
-
-        Args:
-            resource_type: Resource type to select (e.g., "node", "pod", "network.operator/cluster")
-            namespace: Specific namespace to search in (mutually exclusive with all_namespaces)
-            labels: Dictionary of label selectors (e.g., {"app": "myapp"})
-            field_selector: Dictionary of field selectors for server-side filtering.
-                           Prefix key with '!' for != logic.
-                           (e.g., {"!status.phase": "Succeeded"} for status.phase!=Succeeded)
-            all_namespaces: Search across all namespaces (mutually exclusive with namespace)
-            timeout: Timeout in seconds (default: 30)
-            single: If True, return single object via .object() instead of list via .objects()
-
-        Returns:
-            - If single=True: Single resource object or None if not found
-            - If single=False: List of resource objects (empty list if none found)
+    ) -> Dict[str, Any]:
+        """Validate params, log the command, and build selector kwargs.
 
         Raises:
             ValueError: If both namespace and all_namespaces are specified
-            OpenShiftPythonException: If command fails (e.g., invalid resource type, timeout)
         """
-        # Validate mutually exclusive parameters
         if namespace and all_namespaces:
             raise ValueError("Cannot specify both 'namespace' and 'all_namespaces' parameters")
 
-        # Build command string for logging
         cmd_parts = ["oc", "get", resource_type]
         if namespace:
             cmd_parts.extend(["-n", namespace])
@@ -405,42 +379,109 @@ class OcApiUtils:
         cmd_str = " ".join(cmd_parts)
         self.operator._add_cmd_to_log(cmd_str)
 
-        # In debug mode, print command BEFORE execution
         self._debug_log(f"Executing command via oc.selector: {cmd_str}")
 
-        with oc.timeout(timeout):
-            # Build selector kwargs
-            selector_kwargs = {}
-            if labels:
-                selector_kwargs["labels"] = labels
-            if field_selector:
-                selector_kwargs["field_selectors"] = field_selector
-            if all_namespaces:
-                selector_kwargs["all_namespaces"] = True
+        selector_kwargs: Dict[str, Any] = {}
+        if labels:
+            selector_kwargs["labels"] = labels
+        if field_selector:
+            selector_kwargs["field_selectors"] = field_selector
+        if all_namespaces:
+            selector_kwargs["all_namespaces"] = True
 
-            # Create selector with appropriate context
+        return selector_kwargs
+
+    def select_resources(
+        self,
+        resource_type: str,
+        namespace: str | None = None,
+        labels: Dict[str, str] | None = None,
+        field_selector: Dict[str, str] | None = None,
+        all_namespaces: bool = False,
+        timeout: int = 30,
+    ) -> list[oc.APIObject]:
+        """Select multiple resources of a given type.
+
+        Args:
+            resource_type: Resource type to select (e.g., "node", "pod")
+            namespace: Specific namespace to search in (mutually exclusive with all_namespaces)
+            labels: Dictionary of label selectors (e.g., {"app": "myapp"})
+            field_selector: Dictionary of field selectors for server-side filtering.
+                           Prefix key with '!' for != logic.
+                           (e.g., {"!status.phase": "Succeeded"} for status.phase!=Succeeded)
+            all_namespaces: Search across all namespaces (mutually exclusive with namespace)
+            timeout: Timeout in seconds (default: 30)
+
+        Returns:
+            List of resource objects (empty list if none found)
+
+        Raises:
+            ValueError: If both namespace and all_namespaces are specified
+            OpenShiftPythonException: If command fails (e.g., invalid resource type, timeout)
+        """
+        selector_kwargs = self._log_and_build_selector_kwargs(
+            resource_type, namespace, labels, field_selector, all_namespaces
+        )
+
+        with oc.timeout(timeout):
             if namespace:
                 with oc.project(namespace):
-                    selector = oc.selector(resource_type, **selector_kwargs)
-                    result = selector.object(ignore_not_found=True) if single else selector.objects()
+                    result = oc.selector(resource_type, **selector_kwargs).objects()
             else:
-                selector = oc.selector(resource_type, **selector_kwargs)
-                result = selector.object(ignore_not_found=True) if single else selector.objects()
+                result = oc.selector(resource_type, **selector_kwargs).objects()
 
-            # In debug mode, print results after execution with limited fields
-            # Extract base resource type (e.g., "pod" from "pod" or "deployment" from "deployment.apps")
             base_type = resource_type.split("/")[-1].split(".")[0]
+            msg = f"Found {len(result)} {base_type}(s) (showing limited fields equivalent to -o wide)"
+            self._debug_log(msg, obj=result, resource_type=base_type)
 
-            if single:
-                result_name = result.name() if result else "None"
-                self._debug_log(
-                    f"Command result: {result_name} (showing limited fields equivalent to -o wide)",
-                    obj=result,
-                    resource_type=base_type,
-                )
+            return result
+
+    def select_single_resource(
+        self,
+        resource_type: str,
+        namespace: str | None = None,
+        labels: Dict[str, str] | None = None,
+        field_selector: Dict[str, str] | None = None,
+        all_namespaces: bool = False,
+        timeout: int = 30,
+    ) -> Any | None:
+        """Select a single resource of a given type.
+
+        Args:
+            resource_type: Resource type to select (e.g., "network.operator/cluster")
+            namespace: Specific namespace to search in (mutually exclusive with all_namespaces)
+            labels: Dictionary of label selectors (e.g., {"app": "myapp"})
+            field_selector: Dictionary of field selectors for server-side filtering.
+                           Prefix key with '!' for != logic.
+                           (e.g., {"!status.phase": "Succeeded"} for status.phase!=Succeeded)
+            all_namespaces: Search across all namespaces (mutually exclusive with namespace)
+            timeout: Timeout in seconds (default: 30)
+
+        Returns:
+            Single resource object or None if not found
+
+        Raises:
+            ValueError: If both namespace and all_namespaces are specified
+            OpenShiftPythonException: If command fails (e.g., invalid resource type, timeout)
+        """
+        selector_kwargs = self._log_and_build_selector_kwargs(
+            resource_type, namespace, labels, field_selector, all_namespaces
+        )
+
+        with oc.timeout(timeout):
+            if namespace:
+                with oc.project(namespace):
+                    result = oc.selector(resource_type, **selector_kwargs).object(ignore_not_found=True)
             else:
-                msg = f"Found {len(result)} {base_type}(s) (showing limited fields equivalent to -o wide)"
-                self._debug_log(msg, obj=result, resource_type=base_type)
+                result = oc.selector(resource_type, **selector_kwargs).object(ignore_not_found=True)
+
+            base_type = resource_type.split("/")[-1].split(".")[0]
+            result_name = result.name() if result else "None"
+            self._debug_log(
+                f"Command result: {result_name} (showing limited fields equivalent to -o wide)",
+                obj=result,
+                resource_type=base_type,
+            )
 
             return result
 
@@ -448,7 +489,7 @@ class OcApiUtils:
         self,
         namespace: str = None,
         labels: dict = None,
-        field_selector: dict = None,
+        field_selector: Dict[str, str] | None = None,
         timeout: int = 30,
     ) -> list:
         """Get pods from namespace with optional label and field selector filtering.
@@ -505,7 +546,7 @@ class OcApiUtils:
             self.logger.info(error_msg)
         return None
 
-    def run_rsh_cmd(self, namespace: str, pod: str, command: SafeCmdString, timeout: int = 120) -> tuple:
+    def run_rsh_cmd(self, namespace: str | None, pod: str | None, command: SafeCmdString, timeout: int = 120) -> tuple:
         """
         Run command in a pod using oc rsh.
 
@@ -519,8 +560,21 @@ class OcApiUtils:
             Tuple of (return_code, stdout, stderr)
 
         Raises:
+            UnExpectedSystemOutput: If namespace or pod is None
             TypeError: If command is not a SafeCmdString instance
         """
+        if not namespace:
+            raise UnExpectedSystemOutput(
+                ip=self.operator.get_host_ip(), cmd=str(command), output="", message="Namespace not provided"
+            )
+        if not pod:
+            raise UnExpectedSystemOutput(
+                ip=self.operator.get_host_ip(),
+                cmd=str(command),
+                output="",
+                message=f"Pod not found in namespace {namespace}",
+            )
+
         # Enforce SafeCmdString usage to prevent shell injection
         if not isinstance(command, SafeCmdString):
             raise TypeError(

--- a/src/in_cluster_checks/utils/parsing_utils.py
+++ b/src/in_cluster_checks/utils/parsing_utils.py
@@ -104,7 +104,7 @@ def get_dict_from_string(text: str, delimiter: str = None) -> Dict[str, Union[st
     Returns:
         Dictionary mapping keys to values (auto-converts values to int when possible)
     """
-    result = {}
+    result: Dict[str, Union[str, int]] = {}
     delimiter = delimiter or " "
 
     for line in text.splitlines():

--- a/tests/linters/check_mypy.py
+++ b/tests/linters/check_mypy.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""
+Mypy pre-commit hook that reports all errors except non-SafeCmdString [assignment] errors.
+
+Used as a pre-commit hook entry point (see .pre-commit-config.yaml).
+Mypy configuration is read from mypy.ini.
+"""
+
+import subprocess
+import sys
+
+
+def main() -> None:
+    """Run mypy and report all errors, filtering [assignment] to SafeCmdString only."""
+    files = sys.argv[1:] if len(sys.argv) > 1 else ["src/in_cluster_checks/"]
+
+    cmd = ["mypy", *files]
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+
+    if result.returncode not in (0, 1):
+        print(result.stderr or result.stdout)
+        sys.exit(result.returncode)
+
+    errors = []
+    has_safecmd_errors = False
+    for line in result.stdout.splitlines():
+        if "error:" not in line:
+            continue
+        if "[assignment]" in line and "SafeCmdString" not in line:
+            continue
+        errors.append(line)
+        if "SafeCmdString" in line:
+            has_safecmd_errors = True
+
+    if not errors:
+        sys.exit(0)
+
+    for error in errors:
+        print(error)
+
+    if has_safecmd_errors:
+        print()
+        print("Methods requiring SafeCmdString:")
+        print("  - run_cmd(cmd, ...)")
+        print("  - get_output_from_run_cmd(cmd, ...)")
+        print("  - execute_cmd(cmd, ...)")
+        print("  - run_cmd_return_is_successful(cmd, ...)")
+        print("  - run_and_get_the_nth_field(cmd, ...)")
+        print("  - run_rsh_cmd(namespace, pod, command, ...)")
+        print()
+        print("Use: SafeCmdString('cmd {var}').format(var=value)")
+
+    print()
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/rules/k8s/test_k8s_validations.py
+++ b/tests/rules/k8s/test_k8s_validations.py
@@ -2369,7 +2369,7 @@ class TestVerifyFARControllerReplicas(RuleTestBase):
         RuleScenarioParams(
             "FAR deployment has 2 replicas and all are ready",
             tested_object_mock_dict={
-                "oc_api.select_resources": Mock(return_value=create_mock_infrastructure_for_far("HighlyAvailable")),
+                "oc_api.select_single_resource": Mock(return_value=create_mock_infrastructure_for_far("HighlyAvailable")),
                 "oc_api.get_all_deployments": Mock(
                     return_value=[
                         create_mock_deployment(
@@ -2389,7 +2389,7 @@ class TestVerifyFARControllerReplicas(RuleTestBase):
         RuleScenarioParams(
         "FAR deployment disappears before rule execution",
         tested_object_mock_dict={
-                "oc_api.select_resources": Mock(
+                "oc_api.select_single_resource": Mock(
                 return_value=create_mock_infrastructure_for_far("HighlyAvailable")
                 ),
                 "oc_api.get_all_deployments": Mock(return_value=[]),
@@ -2402,7 +2402,7 @@ class TestVerifyFARControllerReplicas(RuleTestBase):
         RuleScenarioParams(
             "FAR deployment has wrong spec replicas",
             tested_object_mock_dict={
-                "oc_api.select_resources": Mock(return_value=create_mock_infrastructure_for_far("HighlyAvailable")),
+                "oc_api.select_single_resource": Mock(return_value=create_mock_infrastructure_for_far("HighlyAvailable")),
                 "oc_api.get_all_deployments": Mock(
                     return_value=[
                         create_mock_deployment(
@@ -2419,7 +2419,7 @@ class TestVerifyFARControllerReplicas(RuleTestBase):
         RuleScenarioParams(
             "FAR deployment has correct spec but not all replicas ready",
             tested_object_mock_dict={
-                "oc_api.select_resources": Mock(return_value=create_mock_infrastructure_for_far("HighlyAvailable")),
+                "oc_api.select_single_resource": Mock(return_value=create_mock_infrastructure_for_far("HighlyAvailable")),
                 "oc_api.get_all_deployments": Mock(
                     return_value=[
                         create_mock_deployment(
@@ -2457,7 +2457,7 @@ class TestVerifyFARControllerReplicas(RuleTestBase):
 
     def test_sno_cluster_skipped(self, tested_object):
         """Test that rule is skipped on SNO (Single Node OpenShift) cluster."""
-        tested_object.oc_api.select_resources = Mock(return_value=create_mock_infrastructure_for_far("SingleReplica"))
+        tested_object.oc_api.select_single_resource = Mock(return_value=create_mock_infrastructure_for_far("SingleReplica"))
         tested_object.oc_api.get_all_deployments = Mock(
             return_value=[
                 create_mock_deployment(

--- a/tests/rules/network/test_ovnk8s_validations.py
+++ b/tests/rules/network/test_ovnk8s_validations.py
@@ -46,7 +46,7 @@ class OVNKubernetesTestBase(RuleTestBase):
         RuleScenarioParams(
             "prerequisite_fulfilled",
             tested_object_mock_dict={
-                "oc_api.select_resources": Mock(return_value=_create_mock_network_ovnkube())
+                "oc_api.select_single_resource": Mock(return_value=_create_mock_network_ovnkube())
             },
         )
     ]

--- a/tests/rules/network/test_ovs_validations.py
+++ b/tests/rules/network/test_ovs_validations.py
@@ -168,17 +168,15 @@ class TestIsOVNKubernetesCollector(DataCollectorTestBase):
             "OVN-Kubernetes cluster",
             {},
             scenario_res=True,
+            tested_object_mock_dict={"oc_api.select_single_resource": Mock(return_value=network_mock_ovn)},
         ),
         DataCollectorScenarioParams(
             "non-OVN cluster",
             {},
             scenario_res=False,
+            tested_object_mock_dict={"oc_api.select_single_resource": Mock(return_value=network_mock_other)},
         ),
     ]
-
-    # Set tested_object_mock_dict for each scenario
-    scenarios[0].tested_object_mock_dict = {"oc_api.select_resources": Mock(return_value=network_mock_ovn)}
-    scenarios[1].tested_object_mock_dict = {"oc_api.select_resources": Mock(return_value=network_mock_other)}
 
     @pytest.mark.parametrize("scenario_params", scenarios)
     def test_collect_data(self, scenario_params, tested_object):

--- a/tests/rules/storage/test_storage_validations.py
+++ b/tests/rules/storage/test_storage_validations.py
@@ -76,7 +76,7 @@ class TestCephOsdTreeWorks(RuleTestBase):
             tested_object_mock_dict={
                 # Both tools and operator pods return None
                 "oc_api.get_pod_name": Mock(return_value=None),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
             },
         )
     ]
@@ -86,7 +86,7 @@ class TestCephOsdTreeWorks(RuleTestBase):
             "operator pod available",
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-operator-abc123"),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
             },
         )
     ]
@@ -102,7 +102,7 @@ class TestCephOsdTreeWorks(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-12345"),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
             },
         ),
         RuleScenarioParams(
@@ -116,7 +116,7 @@ class TestCephOsdTreeWorks(RuleTestBase):
             tested_object_mock_dict={
                 # First call returns None (no tools pod), second call returns operator pod
                 "oc_api.get_pod_name": Mock(side_effect=[None, "rook-ceph-operator-abc123"]),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
             },
         )
     ]
@@ -131,7 +131,7 @@ class TestCephOsdTreeWorks(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-12345"),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
             },
             failed_msg="ceph osd tree is not working.\nError: connection refused",
         ),
@@ -144,7 +144,7 @@ class TestCephOsdTreeWorks(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(side_effect=[None, "rook-ceph-operator-abc123"]),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
             },
             failed_msg="ceph osd tree is not working.\nError: failed to connect",
         )
@@ -216,7 +216,7 @@ class TestIsCephHealthOk(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-12345"),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
             },
         ),
         RuleScenarioParams(
@@ -230,7 +230,7 @@ class TestIsCephHealthOk(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-12345"),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
             },
         ),
         RuleScenarioParams(
@@ -244,7 +244,7 @@ class TestIsCephHealthOk(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(side_effect=[None, "rook-ceph-operator-abc123"]),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
             },
         ),
     ]
@@ -261,7 +261,7 @@ class TestIsCephHealthOk(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-12345"),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
             },
             failed_msg=(
                 "Ceph health is not ok.\n"
@@ -288,7 +288,7 @@ class TestIsCephHealthOk(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-12345"),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
             },
             failed_msg=(
                 "Ceph health is not ok.\n"
@@ -313,7 +313,7 @@ class TestIsCephHealthOk(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-12345"),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
             },
             failed_msg="Failed to get ceph health status.\nError: connection timeout",
         ),
@@ -328,7 +328,7 @@ class TestIsCephHealthOk(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(side_effect=[None, "rook-ceph-operator-abc123"]),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
             },
             failed_msg="Failed to get ceph health status.\nError: cluster unreachable",
         ),
@@ -382,7 +382,7 @@ class TestIsCephOSDsNearFull(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-12345"),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
             },
         )
     ]
@@ -397,7 +397,7 @@ class TestIsCephOSDsNearFull(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-12345"),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
             },
             failed_msg=(
                 "There are OSDs disk usage near or already over the limit.\n"
@@ -421,7 +421,7 @@ class TestIsCephOSDsNearFull(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-12345"),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
             },
             failed_msg=(
                 "There are OSDs disk usage near or already over the limit.\n"
@@ -442,7 +442,7 @@ class TestIsCephOSDsNearFull(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-12345"),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
             },
             failed_msg="Failed to get ceph osd df status.\nError: command not found",
         ),
@@ -493,7 +493,7 @@ class TestIsOSDsUp(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-12345"),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
             },
         )
     ]
@@ -508,7 +508,7 @@ class TestIsOSDsUp(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-12345"),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
             },
             failed_msg="The following OSDs are in down state: [osd.1, osd.2]",
         ),
@@ -521,7 +521,7 @@ class TestIsOSDsUp(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-12345"),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
             },
             failed_msg="Failed to get ceph osd tree status.\nError: ceph cluster not available",
         ),
@@ -572,7 +572,7 @@ class TestIsOSDsWeightOK(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-12345"),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
             },
         )
     ]
@@ -587,7 +587,7 @@ class TestIsOSDsWeightOK(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-12345"),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
             },
             failed_msg=(
                 "The following OSDs weight not in acceptable range:\n\n"
@@ -603,7 +603,7 @@ class TestIsOSDsWeightOK(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-12345"),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
             },
             failed_msg=(
                 "The following OSDs weight not in acceptable range:\n\n"
@@ -622,7 +622,7 @@ class TestIsOSDsWeightOK(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-12345"),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
             },
             failed_msg="Failed to get ceph osd df status.\nError: timeout",
         ),
@@ -656,7 +656,7 @@ class TestOrphanCsiVolumes(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-xyz"),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
             },
         ),
         RuleScenarioParams(
@@ -673,7 +673,7 @@ class TestOrphanCsiVolumes(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-xyz"),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
             },
         ),
         RuleScenarioParams(
@@ -685,7 +685,7 @@ class TestOrphanCsiVolumes(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-xyz"),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
             },
         ),
         RuleScenarioParams(
@@ -702,7 +702,7 @@ class TestOrphanCsiVolumes(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-xyz"),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
             },
         ),
     ]
@@ -722,7 +722,7 @@ class TestOrphanCsiVolumes(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-xyz"),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
             },
         ),
     ]
@@ -752,7 +752,7 @@ class TestOrphanCsiVolumes(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-xyz"),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
             },
         ),
         RuleScenarioParams(
@@ -777,7 +777,7 @@ class TestOrphanCsiVolumes(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-xyz"),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
             },
         ),
         RuleScenarioParams(
@@ -804,7 +804,7 @@ class TestOrphanCsiVolumes(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-xyz"),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
             },
         ),
     ]
@@ -834,7 +834,7 @@ class TestOrphanCsiVolumes(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-xyz"),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
             },
         ),
         RuleScenarioParams(
@@ -861,7 +861,7 @@ class TestOrphanCsiVolumes(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-xyz"),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
             },
         ),
     ]
@@ -891,7 +891,7 @@ class TestOrphanCsiVolumes(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-xyz"),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
             },
         ),
         RuleScenarioParams(
@@ -920,7 +920,7 @@ class TestOrphanCsiVolumes(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-xyz"),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
             },
         ),
         RuleScenarioParams(
@@ -945,7 +945,7 @@ class TestOrphanCsiVolumes(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-xyz"),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
             },
         ),
         RuleScenarioParams(
@@ -972,7 +972,7 @@ class TestOrphanCsiVolumes(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-xyz"),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
             },
             failed_msg="Failed to list CSI subvolumes from Ceph.\nError: Error: unable to connect to ceph cluster",
         ),
@@ -1008,7 +1008,7 @@ class TestOsdJournalError(RuleTestBase):
             "all OSD pods healthy",
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-12345"),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
                 "_get_osd_pods": Mock(
                     return_value=[
                         create_pod_mock("rook-ceph-osd-0", phase="Running", ready=True, restarts=0),
@@ -1024,7 +1024,7 @@ class TestOsdJournalError(RuleTestBase):
             "OSD pod not running",
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-12345"),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
                 "_get_osd_pods": Mock(
                     return_value=[
                         create_pod_mock("rook-ceph-osd-0", phase="Pending", ready=False, restarts=0),
@@ -1044,7 +1044,7 @@ class TestOsdJournalError(RuleTestBase):
             "OSD pod with recent restarts",
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-12345"),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
                 "_get_osd_pods": Mock(
                     return_value=[
                         create_pod_mock(
@@ -1070,7 +1070,7 @@ class TestOsdJournalError(RuleTestBase):
             "OSD pod in CrashLoopBackOff",
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-12345"),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
                 "_get_osd_pods": Mock(
                     return_value=[
                         create_pod_mock("rook-ceph-osd-0", phase="Running", ready=False, waiting_reason="CrashLoopBackOff"),
@@ -1114,7 +1114,7 @@ class TestCheckPoolSize(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-12345"),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
             },
         )
     ]
@@ -1130,7 +1130,7 @@ class TestCheckPoolSize(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-12345"),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
             },
             failed_msg="ceph replication factor is less than 2 in following pools:\nname2",
         ),
@@ -1144,7 +1144,7 @@ class TestCheckPoolSize(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-12345"),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
             },
             failed_msg="ceph replication factor is less than 2 in following pools:\npool1\npool2",
         ),
@@ -1160,7 +1160,7 @@ class TestCheckPoolSize(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-12345"),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
             },
             failed_msg="Failed to get ceph pool details.\nError: connection refused",
         ),
@@ -1194,7 +1194,7 @@ class TestCephSlowOps(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-12345"),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
             },
         ),
     ]
@@ -1213,7 +1213,7 @@ class TestCephSlowOps(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-12345"),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
             },
             failed_msg=(
                 "There are slow ops observed on this cluster. "
@@ -1231,7 +1231,7 @@ class TestCephSlowOps(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-12345"),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
             },
             failed_msg=(
                 "There are slow ops observed on this cluster. "
@@ -1251,7 +1251,7 @@ class TestCephSlowOps(RuleTestBase):
             },
             tested_object_mock_dict={
                 "oc_api.get_pod_name": Mock(return_value="rook-ceph-tools-12345"),
-                "oc_api.select_resources": Mock(return_value=Mock()),
+                "oc_api.select_single_resource": Mock(return_value=Mock()),
             },
             failed_msg="Failed to get ceph health detail.\nError: connection refused",
         ),

--- a/tests/unit/utils/test_oc_api_utils.py
+++ b/tests/unit/utils/test_oc_api_utils.py
@@ -67,7 +67,7 @@ class TestSelectResources:
         mock_oc.timeout.return_value.__exit__ = Mock(return_value=False)
         mock_oc.selector.return_value = mock_selector
 
-        result = oc_api.select_resources("network.operator/cluster", single=True)
+        result = oc_api.select_single_resource("network.operator/cluster")
 
         assert result == mock_obj
         mock_selector.object.assert_called_once_with(ignore_not_found=True)
@@ -81,7 +81,7 @@ class TestSelectResources:
         mock_oc.timeout.return_value.__exit__ = Mock(return_value=False)
         mock_oc.selector.return_value = mock_selector
 
-        result = oc_api.select_resources("namespace/nonexistent", single=True)
+        result = oc_api.select_single_resource("namespace/nonexistent")
 
         assert result is None
         mock_selector.object.assert_called_once_with(ignore_not_found=True)


### PR DESCRIPTION
Add a pre-commit hook that runs mypy to catch type errors at commit time. Reports all mypy errors, with [assignment] errors filtered to SafeCmdString violations only.

- Add mypy.ini configuration for type checking
- Add check_mypy.py wrapper with SafeCmdString-specific filtering
- Add safecmdstring-mypy-check hook to .pre-commit-config.yaml
- Add mypy to dev dependencies

Assisted-by: Claude Code (Claude Opus 4.6) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing or invalid cluster resources and command output.
  * Ensured status checks consistently return clear boolean results.
  * Improved error details for network, DNS, Kubernetes, and storage validations.
  * Sanitized command output included in error messages.

* **Improvements**
  * Resource lookups now provide clearer results for single and multiple resources.
  * Output formatting and resource parsing are more predictable.

* **Quality**
  * Added automated type checking to identify potential issues earlier.
  * Updated validation guidance and examples for current resource lookup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->