### PR TITLE
fix(PDRIVE-858): skip recently-terminating namespaces in ValidateNamespaceStatus

### DIFF
--- a/src/in_cluster_checks/rules/k8s/k8s_validations.py
+++ b/src/in_cluster_checks/rules/k8s/k8s_validations.py
@@ -492,6 +492,8 @@ class ValidateNamespaceStatus(OrchestratorRule):
     unique_name = "verify_namespaces_are_in_active_status"
     title = "Validate namespace in Active status"
 
+    TERMINATING_THRESHOLD_SECONDS = 180  # 3 minutes
+
     def run_rule(self):
         """Check if all namespaces are in Active status."""
         namespace_objects = self.oc_api.get_all_namespaces(timeout=45)
@@ -508,6 +510,8 @@ class ValidateNamespaceStatus(OrchestratorRule):
             phase = status_dict.get("phase", "Unknown")
 
             if phase != "Active":
+                if phase == "Terminating" and self._is_recently_terminating(ns_data):
+                    continue
                 inactive_namespaces.append(f"{ns_name} - {phase}")
 
         if inactive_namespaces:
@@ -516,6 +520,18 @@ class ValidateNamespaceStatus(OrchestratorRule):
             return RuleResult.warning(message)
 
         return RuleResult.passed()
+
+    def _is_recently_terminating(self, ns_data: dict) -> bool:
+        """Check if a namespace started terminating within the threshold."""
+        deletion_ts = ns_data.get("metadata", {}).get("deletionTimestamp")
+        if not deletion_ts:
+            return False
+        try:
+            deleted_at = datetime.fromisoformat(deletion_ts.replace("Z", "+00:00"))
+            age_seconds = (datetime.now(timezone.utc) - deleted_at).total_seconds()
+            return age_seconds < self.TERMINATING_THRESHOLD_SECONDS
+        except (ValueError, AttributeError):
+            return False
 
 
 class ValidateAllDaemonsetsScheduled(OrchestratorRule):

--- a/tests/rules/k8s/test_k8s_validations.py
+++ b/tests/rules/k8s/test_k8s_validations.py
@@ -738,6 +738,21 @@ class TestValidateNamespaceStatus:
         assert result.status == Status.WARNING
         assert "mystery-ns" in result.message
 
+    def test_terminating_with_malformed_deletion_timestamp_flagged(self, tested_object):
+        """Test that a Terminating namespace with malformed deletionTimestamp is flagged."""
+        tested_object.oc_api.get_all_namespaces = Mock(
+            return_value=[
+                create_mock_namespace("default", "Active"),
+                create_mock_namespace(
+                    "bad-ts-ns", "Terminating", deletion_timestamp="not-a-date"
+                ),
+            ]
+        )
+
+        result = tested_object.run_rule()
+        assert result.status == Status.WARNING
+        assert "bad-ts-ns" in result.message
+
     def test_mix_of_recent_and_old_terminating(self, tested_object):
         """Test mix: recent terminating skipped, old terminating flagged."""
         recent_ts = (

--- a/tests/rules/k8s/test_k8s_validations.py
+++ b/tests/rules/k8s/test_k8s_validations.py
@@ -6,6 +6,7 @@ Adapted from HealthChecks test patterns for AllPodsReadyAndRunning.
 
 import json
 import logging
+from datetime import datetime, timezone, timedelta
 from unittest.mock import Mock
 
 import pytest
@@ -586,11 +587,14 @@ class TestNodesCpuAndMemoryStatus:
         assert "No node metrics available" in result.message
 
 
-def create_mock_namespace(name, phase):
+def create_mock_namespace(name, phase, deletion_timestamp=None):
     """Create a mock namespace object."""
     mock_ns = Mock()
+    metadata = {"name": name}
+    if deletion_timestamp:
+        metadata["deletionTimestamp"] = deletion_timestamp
     mock_ns.as_dict.return_value = {
-        "metadata": {"name": name},
+        "metadata": metadata,
         "status": {"phase": phase},
     }
     return mock_ns
@@ -683,6 +687,82 @@ class TestValidateNamespaceStatus:
         result = tested_object.run_rule()
         assert result.status == Status.FAILED
         assert "No namespaces found" in result.message
+
+    def test_recently_terminating_namespace_skipped(self, tested_object):
+        """Test that a namespace terminating within threshold is skipped."""
+        recent_ts = (
+            datetime.now(timezone.utc) - timedelta(seconds=60)
+        ).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        tested_object.oc_api.get_all_namespaces = Mock(
+            return_value=[
+                create_mock_namespace("default", "Active"),
+                create_mock_namespace(
+                    "deleting-ns", "Terminating", deletion_timestamp=recent_ts
+                ),
+            ]
+        )
+
+        result = tested_object.run_rule()
+        assert result.status == Status.PASSED
+
+    def test_old_terminating_namespace_flagged(self, tested_object):
+        """Test that a namespace terminating beyond threshold is flagged."""
+        old_ts = (
+            datetime.now(timezone.utc) - timedelta(seconds=600)
+        ).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        tested_object.oc_api.get_all_namespaces = Mock(
+            return_value=[
+                create_mock_namespace("default", "Active"),
+                create_mock_namespace(
+                    "stuck-ns", "Terminating", deletion_timestamp=old_ts
+                ),
+            ]
+        )
+
+        result = tested_object.run_rule()
+        assert result.status == Status.WARNING
+        assert "stuck-ns" in result.message
+
+    def test_terminating_without_deletion_timestamp_flagged(self, tested_object):
+        """Test that a Terminating namespace without deletionTimestamp is flagged."""
+        tested_object.oc_api.get_all_namespaces = Mock(
+            return_value=[
+                create_mock_namespace("default", "Active"),
+                create_mock_namespace("mystery-ns", "Terminating"),
+            ]
+        )
+
+        result = tested_object.run_rule()
+        assert result.status == Status.WARNING
+        assert "mystery-ns" in result.message
+
+    def test_mix_of_recent_and_old_terminating(self, tested_object):
+        """Test mix: recent terminating skipped, old terminating flagged."""
+        recent_ts = (
+            datetime.now(timezone.utc) - timedelta(seconds=30)
+        ).strftime("%Y-%m-%dT%H:%M:%SZ")
+        old_ts = (
+            datetime.now(timezone.utc) - timedelta(seconds=600)
+        ).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        tested_object.oc_api.get_all_namespaces = Mock(
+            return_value=[
+                create_mock_namespace("default", "Active"),
+                create_mock_namespace(
+                    "recent-ns", "Terminating", deletion_timestamp=recent_ts
+                ),
+                create_mock_namespace(
+                    "stuck-ns", "Terminating", deletion_timestamp=old_ts
+                ),
+            ]
+        )
+
+        result = tested_object.run_rule()
+        assert result.status == Status.WARNING
+        assert "stuck-ns" in result.message
+        assert "recent-ns" not in result.message
 
 
 class TestValidateAllDaemonsetsScheduled:


### PR DESCRIPTION
## Summary

- Fixes false positive where `ValidateNamespaceStatus` flagged namespaces in transient `Terminating` state (e.g., during normal deletion, must-gather cleanup, operator restarts)
- Adds a 3-minute threshold: namespaces terminating for less than 180 seconds are skipped; those exceeding the threshold are still flagged as warnings

**Jira**: https://redhat.atlassian.net/browse/PDRIVE-858

## Test plan

- [x] Unit tests for recently-terminating namespace being skipped
- [x] Unit tests for old terminating namespace being flagged
- [x] Unit tests for terminating namespace without `deletionTimestamp` being flagged
- [x] Unit tests for mix of recent and old terminating namespaces
- [x] `pytest` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Recently terminating Kubernetes namespaces are now given up to three minutes to complete deletion before warnings are raised.
  - Older terminating namespaces continue to trigger warnings.
  - Terminating namespaces without a valid deletion timestamp are still flagged.
  - Invalid deletion timestamps are treated as non-recent and flagged.
- **Tests**
  - Added coverage for recent, delayed, missing, invalid, and mixed namespace termination states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->