### PR TITLE
feat(PDRIVE-902): promote command output caching to Operator level

### DIFF
--- a/src/in_cluster_checks/core/operations.py
+++ b/src/in_cluster_checks/core/operations.py
@@ -75,18 +75,26 @@ class Operator:
         if global_config.debug_rule_flag:
             print(f"\n[DEBUG] [{self.get_host_name()}] {message}", flush=True)
 
-    def run_cmd(self, cmd: SafeCmdString, timeout: int = 120, add_bash_timeout: bool = False) -> tuple:
+    def run_cmd(
+        self, cmd: SafeCmdString, timeout: int = 120, hosts_cached_pool: dict = None, add_bash_timeout: bool = False
+    ) -> tuple:
         """
         Run command on host/container and log it.
 
         Args:
             cmd: SafeCmdString object with command to execute
             timeout: Timeout in seconds (default: 120)
+            hosts_cached_pool: Optional dict for caching command outputs per host.
+                When provided, results are cached by (hostname, cmd) and reused on subsequent calls.
+                The caller owns the dict and is responsible for clearing it.
             add_bash_timeout: If True, wraps command with bash timeout command for guaranteed termination
 
         Returns:
             Tuple of (return_code, stdout, stderr)
         """
+        if hosts_cached_pool is not None:
+            return self._run_cmd_use_cached(cmd, hosts_cached_pool, timeout, add_bash_timeout)
+
         self._add_cmd_to_log(cmd)
 
         # Execute command (parallelized, no lock)
@@ -103,13 +111,38 @@ class Operator:
                     self._debug_log(f"STDERR:\n{err}")
                 print("=" * 60, flush=True)
 
-        # Note: In normal mode, we don't log failed commands since many failures are expected
-        # (e.g., prerequisite checks testing if commands exist). The JSON output contains
-        # exception details when validations fail.
-
         return return_code, out, err
 
-    def get_output_from_run_cmd(self, cmd: SafeCmdString, timeout: int = 30, message: str = None) -> str:
+    def _run_cmd_use_cached(
+        self, cmd: SafeCmdString, cached_pool: dict, timeout: int = 120, add_bash_timeout: bool = False
+    ) -> tuple:
+        """
+        Run command with caching to avoid duplicate executions across collectors.
+
+        Args:
+            cmd: Command to execute
+            cached_pool: Dictionary for storing cached results, keyed by hostname -> cmd_string
+            timeout: Command timeout in seconds
+            add_bash_timeout: If True, wraps command with bash timeout
+
+        Returns:
+            Tuple of (return_code, stdout, stderr)
+        """
+        hostname = self.get_host_name()
+        cmd_str = str(cmd)
+
+        if cached_pool.get(hostname, {}).get(cmd_str):
+            return cached_pool[hostname][cmd_str]
+
+        cached_pool[hostname] = cached_pool.get(hostname, {})
+        res = self.run_cmd(cmd, timeout, hosts_cached_pool=None, add_bash_timeout=add_bash_timeout)
+        cached_pool[hostname][cmd_str] = res
+
+        return res
+
+    def get_output_from_run_cmd(
+        self, cmd: SafeCmdString, timeout: int = 30, message: str = None, hosts_cached_pool: dict = None
+    ) -> str:
         """
         Run command, log it, and return stdout if successful.
 
@@ -117,6 +150,7 @@ class Operator:
             cmd: SafeCmdString object with command to execute
             timeout: Timeout in seconds (default: 30)
             message: Optional custom error message
+            hosts_cached_pool: Optional dict for caching command outputs per host.
 
         Returns:
             stdout from command (stripped)
@@ -124,7 +158,7 @@ class Operator:
         Raises:
             UnExpectedSystemOutput: If command fails (non-zero exit code)
         """
-        rc, out, err = self.run_cmd(cmd, timeout)
+        rc, out, err = self.run_cmd(cmd, timeout, hosts_cached_pool=hosts_cached_pool)
 
         if rc != 0:
             error_message = message if message else "Unexpected output (exit code: {})".format(rc)
@@ -496,7 +530,9 @@ class OrchestratorDataCollector(DataCollector):
         """Override to skip ORCHESTRATOR validation - this class is designed for it."""
         pass
 
-    def run_cmd(self, cmd: SafeCmdString, timeout: int = 120) -> tuple:
+    def run_cmd(
+        self, cmd: SafeCmdString, timeout: int = 120, hosts_cached_pool: dict = None, add_bash_timeout: bool = False
+    ) -> tuple:
         """
         Not available for OrchestratorDataCollector - use oc_api methods instead.
 
@@ -506,6 +542,8 @@ class OrchestratorDataCollector(DataCollector):
         Args:
             cmd: Command (not used)
             timeout: Timeout (not used)
+            hosts_cached_pool: Not used
+            add_bash_timeout: Not used
 
         Raises:
             NotImplementedError: Always raised with guidance

--- a/src/in_cluster_checks/rules/hw_fw_details/collectors/bios_collectors.py
+++ b/src/in_cluster_checks/rules/hw_fw_details/collectors/bios_collectors.py
@@ -51,7 +51,9 @@ class BIOSVersion(BIOS):
             Example: {"1": "2.8.0"}
         """
         cmd = SafeCmdString("sudo dmidecode -s bios-version")
-        bios_version = self._run_cached_command(cmd, timeout=30).strip()
+        bios_version = self.get_output_from_run_cmd(
+            cmd, timeout=30, hosts_cached_pool=HwFwDataCollector.cached_data_pool
+        ).strip()
 
         return {bios_id: bios_version for bios_id in self.get_component_ids()}
 
@@ -78,7 +80,9 @@ class BIOSFirmware(BIOS):
             Example: {"1": "1.68"}
         """
         cmd = SafeCmdString("sudo dmidecode --type bios | grep 'Firmware Revision'")
-        out = self._run_cached_command(cmd, timeout=30).strip()
+        out = self.get_output_from_run_cmd(
+            cmd, timeout=30, hosts_cached_pool=HwFwDataCollector.cached_data_pool
+        ).strip()
 
         # Parse firmware from output (format: "Firmware Revision: 1.68")
         if ":" in out:
@@ -112,7 +116,9 @@ class BIOSRevision(BIOS):
             Example: {"1": "2.50"}
         """
         cmd = SafeCmdString("sudo dmidecode --type bios | grep -i 'BIOS Revision'")
-        out = self._run_cached_command(cmd, timeout=30).strip()
+        out = self.get_output_from_run_cmd(
+            cmd, timeout=30, hosts_cached_pool=HwFwDataCollector.cached_data_pool
+        ).strip()
 
         # Parse revision from output (format: "BIOS Revision: 2.50")
         if ":" in out:
@@ -146,6 +152,8 @@ class BIOSReleaseDate(BIOS):
             Example: {"1": "12/15/2023"}
         """
         cmd = SafeCmdString("sudo dmidecode -s bios-release-date")
-        bios_release_date = self._run_cached_command(cmd, timeout=30).strip()
+        bios_release_date = self.get_output_from_run_cmd(
+            cmd, timeout=30, hosts_cached_pool=HwFwDataCollector.cached_data_pool
+        ).strip()
 
         return {bios_id: bios_release_date for bios_id in self.get_component_ids()}

--- a/src/in_cluster_checks/rules/hw_fw_details/collectors/cpu_collectors.py
+++ b/src/in_cluster_checks/rules/hw_fw_details/collectors/cpu_collectors.py
@@ -35,7 +35,11 @@ class ProcessorType(HwFwDataCollector):
             List of processor IDs like ["CPU0", "CPU1"] or ["socket_0", "socket_1"]
         """
         # Try to get socket designations from dmidecode
-        dmidecode_output = self._run_cached_command(SafeCmdString("sudo dmidecode -t processor"), timeout=30)
+        dmidecode_output = self.get_output_from_run_cmd(
+            SafeCmdString("sudo dmidecode -t processor"),
+            timeout=30,
+            hosts_cached_pool=HwFwDataCollector.cached_data_pool,
+        )
 
         # Parse Socket Designation fields
         socket_designations = re.findall(r"Socket Designation:\s+(.+)", dmidecode_output)
@@ -43,7 +47,9 @@ class ProcessorType(HwFwDataCollector):
             return socket_designations
 
         # Fallback: use lscpu to get socket count
-        lscpu_output = self._run_cached_command(SafeCmdString("lscpu"))
+        lscpu_output = self.get_output_from_run_cmd(
+            SafeCmdString("lscpu"), hosts_cached_pool=HwFwDataCollector.cached_data_pool
+        )
         socket_match = re.search(r"Socket\(s\):\s+(\d+)", lscpu_output)
         socket_count = int(socket_match.group(1)) if socket_match else 1
 
@@ -58,7 +64,9 @@ class ProcessorType(HwFwDataCollector):
             Example: {"CPU0": "Intel Xeon Gold 6238", "CPU1": "Intel Xeon Gold 6238"}
         """
         # Get lscpu output (cached)
-        lscpu_output = self._run_cached_command(SafeCmdString("lscpu"))
+        lscpu_output = self.get_output_from_run_cmd(
+            SafeCmdString("lscpu"), hosts_cached_pool=HwFwDataCollector.cached_data_pool
+        )
 
         # Parse model name
         model_match = re.search(r"Model name:\s+(.+)", lscpu_output)
@@ -100,7 +108,11 @@ class ProcessorCurrentFrequency(HwFwDataCollector):
             Dictionary of {processor_id: frequency_in_mhz}
             Example: {"CPU0": 2100, "CPU1": 2100}
         """
-        dmidecode_output = self._run_cached_command(SafeCmdString("sudo dmidecode -t processor"), timeout=30)
+        dmidecode_output = self.get_output_from_run_cmd(
+            SafeCmdString("sudo dmidecode -t processor"),
+            timeout=30,
+            hosts_cached_pool=HwFwDataCollector.cached_data_pool,
+        )
 
         # Parse processor information as JSON-like blocks
         processors_info = self._parse_dmidecode_processor_blocks(dmidecode_output)
@@ -199,7 +211,9 @@ class NumberOfThreadsPerCore(HwFwDataCollector):
             Dictionary of {processor_id: threads_per_core}
             Example: {"CPU0": 2, "CPU1": 2}
         """
-        lscpu_output = self._run_cached_command(SafeCmdString("lscpu"))
+        lscpu_output = self.get_output_from_run_cmd(
+            SafeCmdString("lscpu"), hosts_cached_pool=HwFwDataCollector.cached_data_pool
+        )
 
         # Parse threads per core
         threads_match = re.search(r"Thread\(s\) per core:\s+(\d+)", lscpu_output)
@@ -235,7 +249,9 @@ class NumberOfPhysicalCoresPerProcessor(HwFwDataCollector):
             Dictionary of {processor_id: physical_cores_per_socket}
             Example: {"CPU0": 22, "CPU1": 22}
         """
-        lscpu_output = self._run_cached_command(SafeCmdString("lscpu"))
+        lscpu_output = self.get_output_from_run_cmd(
+            SafeCmdString("lscpu"), hosts_cached_pool=HwFwDataCollector.cached_data_pool
+        )
 
         # Parse cores per socket
         cores_match = re.search(r"Core\(s\) per socket:\s+(\d+)", lscpu_output)
@@ -280,7 +296,9 @@ class CpuIsolated(HwFwDataCollector):
             Example: {"1": ""} if no isolation configured
         """
         # Read kernel command line
-        cmdline_output = self._run_cached_command(SafeCmdString("cat /proc/cmdline"))
+        cmdline_output = self.get_output_from_run_cmd(
+            SafeCmdString("cat /proc/cmdline"), hosts_cached_pool=HwFwDataCollector.cached_data_pool
+        )
 
         # Check if isolcpus parameter exists
         if " isolcpus=" not in cmdline_output:

--- a/src/in_cluster_checks/rules/hw_fw_details/collectors/disk_collectors.py
+++ b/src/in_cluster_checks/rules/hw_fw_details/collectors/disk_collectors.py
@@ -33,7 +33,7 @@ class DiskDataCollector(HwFwDataCollector):
             Only includes real physical disks (no virtual/loop devices)
         """
         cmd = SafeCmdString("sudo lsblk -d -o name,model")
-        output = self._run_cached_command(cmd, timeout=30)
+        output = self.get_output_from_run_cmd(cmd, timeout=30, hosts_cached_pool=HwFwDataCollector.cached_data_pool)
 
         lines = output.splitlines()
         if len(lines) < 2:  # Need header + at least one disk
@@ -94,7 +94,7 @@ class DiskDataCollector(HwFwDataCollector):
             Dict of {disk_name: field_value}
         """
         cmd = SafeCmdString("sudo lsblk -d -o name,{field_name}").format(field_name=field_name)
-        output = self._run_cached_command(cmd, timeout=30)
+        output = self.get_output_from_run_cmd(cmd, timeout=30, hosts_cached_pool=HwFwDataCollector.cached_data_pool)
 
         lines = output.splitlines()
         if len(lines) < 2:
@@ -194,7 +194,7 @@ class DiskType(DiskDataCollector):
 
         # Use smartctl to check (cached, ignore errors as smartctl returns 64 for old SMART data)
         cmd = SafeCmdString("sudo smartctl -a /dev/{disk_name}").format(disk_name=disk_name)
-        output = self._run_cached_command(cmd, timeout=30, ignore_errors=True)
+        _, output, _ = self.run_cmd(cmd, timeout=30, hosts_cached_pool=HwFwDataCollector.cached_data_pool)
 
         # Check for NVMe indicators in output
         if "Total NVM Capacity:" in output or "NVMe" in output:
@@ -291,7 +291,7 @@ class DiskSize(DiskDataCollector):
         """
         # Get size in bytes
         cmd = SafeCmdString("sudo lsblk -d -o name,size -b")
-        output = self._run_cached_command(cmd, timeout=30)
+        output = self.get_output_from_run_cmd(cmd, timeout=30, hosts_cached_pool=HwFwDataCollector.cached_data_pool)
 
         lines = output.splitlines()
         if len(lines) < 2:
@@ -357,7 +357,7 @@ class OperatingSystemDisk(DiskDataCollector):
             Empty list if no OS disks found
         """
         cmd = SafeCmdString("sudo lsblk -n")
-        output = self._run_cached_command(cmd, timeout=30)
+        output = self.get_output_from_run_cmd(cmd, timeout=30, hosts_cached_pool=HwFwDataCollector.cached_data_pool)
         return self._parse_lsblk_output(output)
 
     def _parse_lsblk_output(self, output: str) -> List[str]:
@@ -413,7 +413,7 @@ class OperatingSystemDisk(DiskDataCollector):
 
         # Collect disk rotation data (0=SSD, 1=HDD)
         cmd = SafeCmdString("sudo lsblk -d -o name,rota")
-        output = self._run_cached_command(cmd, timeout=30)
+        output = self.get_output_from_run_cmd(cmd, timeout=30, hosts_cached_pool=HwFwDataCollector.cached_data_pool)
 
         lines = output.splitlines()
         if len(lines) < 2:
@@ -463,7 +463,7 @@ class OperatingSystemDisk(DiskDataCollector):
         real_disk_names = super().get_component_ids()
 
         cmd = SafeCmdString("sudo lsblk -d -o name,size -b")
-        output = self._run_cached_command(cmd, timeout=30)
+        output = self.get_output_from_run_cmd(cmd, timeout=30, hosts_cached_pool=HwFwDataCollector.cached_data_pool)
 
         lines = output.splitlines()
         if len(lines) < 2:

--- a/src/in_cluster_checks/rules/hw_fw_details/collectors/memory_collectors.py
+++ b/src/in_cluster_checks/rules/hw_fw_details/collectors/memory_collectors.py
@@ -44,7 +44,9 @@ class Memory(HwFwDataCollector):
         Returns:
             List of memory device dicts (only populated slots)
         """
-        dmidecode_output = self._run_cached_command(SafeCmdString("sudo dmidecode -t memory"), timeout=30)
+        dmidecode_output = self.get_output_from_run_cmd(
+            SafeCmdString("sudo dmidecode -t memory"), timeout=30, hosts_cached_pool=HwFwDataCollector.cached_data_pool
+        )
         dmidecode_json = self._parse_dmidecode_memory_blocks(dmidecode_output)
 
         res = []

--- a/src/in_cluster_checks/rules/hw_fw_details/collectors/nic_collectors.py
+++ b/src/in_cluster_checks/rules/hw_fw_details/collectors/nic_collectors.py
@@ -43,7 +43,7 @@ class NICDataCollector(HwFwDataCollector):
             Example: {"01:00": ["01:00.0", "01:00.1"]}
         """
         cmd = SafeCmdString("sudo lspci | grep -i 'ethernet\\|infiniband' | grep -vi 'virtual'")
-        output = self._run_cached_command(cmd, timeout=30)
+        output = self.get_output_from_run_cmd(cmd, timeout=30, hosts_cached_pool=HwFwDataCollector.cached_data_pool)
 
         nic_ports_ids = {}
         for line in output.splitlines():
@@ -96,7 +96,7 @@ class NICDataCollector(HwFwDataCollector):
         # Get all physical interfaces by listing directories with device symlink
         # Use ls -d to list directories, not their contents
         cmd = SafeCmdString("ls -d /sys/class/net/*/device 2>/dev/null | cut -d'/' -f5")
-        output = self._run_cached_command(cmd, timeout=30)
+        output = self.get_output_from_run_cmd(cmd, timeout=30, hosts_cached_pool=HwFwDataCollector.cached_data_pool)
 
         # Check each physical interface
         for iface in output.strip().split():
@@ -105,7 +105,9 @@ class NICDataCollector(HwFwDataCollector):
 
             # Get PCI address via readlink
             pci_cmd = SafeCmdString("readlink /sys/class/net/{iface}/device 2>/dev/null").format(iface=iface)
-            pci_output = self._run_cached_command(pci_cmd, timeout=30).strip()
+            pci_output = self.get_output_from_run_cmd(
+                pci_cmd, timeout=30, hosts_cached_pool=HwFwDataCollector.cached_data_pool
+            ).strip()
 
             # readlink returns something like "../../../0000:12:00.0"
             # Extract just the PCI ID part
@@ -147,7 +149,7 @@ class NICDataCollector(HwFwDataCollector):
 
             # Get detailed info for this PCI device
             cmd = SafeCmdString("sudo lspci -vmm -s {first_port}").format(first_port=first_port)
-            output = self._run_cached_command(cmd, timeout=30)
+            output = self.get_output_from_run_cmd(cmd, timeout=30, hosts_cached_pool=HwFwDataCollector.cached_data_pool)
 
             # Parse lspci -vmm output (key-value pairs)
             value = self._parse_lspci_vmm(output, field)
@@ -275,7 +277,7 @@ class NICSpeed(NICDataCollector):
         Returns speed in Mb/s (e.g., 1000, 10000, 25000)
         """
         cmd = SafeCmdString("sudo ethtool {port_name}").format(port_name=port_name)
-        output = self._run_cached_command(cmd, timeout=30)
+        output = self.get_output_from_run_cmd(cmd, timeout=30, hosts_cached_pool=HwFwDataCollector.cached_data_pool)
 
         # Look for "Supported link modes:" section
         # Extract text between "Supported link modes:" and next section
@@ -411,7 +413,7 @@ class NICVersion(NICDataCollector):
             # Use first port (all ports on same NIC have same values)
             first_port = port_names[0]
             cmd = SafeCmdString("sudo ethtool -i {first_port}").format(first_port=first_port)
-            output = self._run_cached_command(cmd, timeout=30)
+            output = self.get_output_from_run_cmd(cmd, timeout=30, hosts_cached_pool=HwFwDataCollector.cached_data_pool)
 
             # Parse ethtool -i output for the field
             field_value = self._parse_ethtool_field(output, field)
@@ -463,7 +465,7 @@ class NICFirmware(NICDataCollector):
 
             first_port = port_names[0]
             cmd = SafeCmdString("sudo ethtool -i {first_port}").format(first_port=first_port)
-            output = self._run_cached_command(cmd, timeout=30)
+            output = self.get_output_from_run_cmd(cmd, timeout=30, hosts_cached_pool=HwFwDataCollector.cached_data_pool)
 
             # Parse for firmware-version field
             firmware = self._parse_ethtool_field(output, "firmware-version")
@@ -515,7 +517,7 @@ class NICDriver(NICDataCollector):
 
             first_port = port_names[0]
             cmd = SafeCmdString("sudo ethtool -i {first_port}").format(first_port=first_port)
-            output = self._run_cached_command(cmd, timeout=30)
+            output = self.get_output_from_run_cmd(cmd, timeout=30, hosts_cached_pool=HwFwDataCollector.cached_data_pool)
 
             # Parse for driver field
             driver = self._parse_ethtool_field(output, "driver")

--- a/src/in_cluster_checks/rules/hw_fw_details/collectors/numa_collectors.py
+++ b/src/in_cluster_checks/rules/hw_fw_details/collectors/numa_collectors.py
@@ -31,7 +31,7 @@ class NUMADataCollector(HwFwDataCollector):
             List of NUMA node IDs (e.g., ["node 0", "node 1"])
         """
         cmd = SafeCmdString("lscpu | grep 'NUMA node(s):'")
-        output = self._run_cached_command(cmd, timeout=30)
+        output = self.get_output_from_run_cmd(cmd, timeout=30, hosts_cached_pool=HwFwDataCollector.cached_data_pool)
 
         # Parse number of NUMA nodes
         match = re.search(r"NUMA node\(s\):\s+(\d+)", output)
@@ -81,7 +81,9 @@ class NumaSizeMemory(NUMADataCollector):
             cmd = SafeCmdString("cat /sys/devices/system/node/node{node_num}/meminfo").format(node_num=node_num)
 
             try:
-                output = self._run_cached_command(cmd, timeout=30)
+                output = self.get_output_from_run_cmd(
+                    cmd, timeout=30, hosts_cached_pool=HwFwDataCollector.cached_data_pool
+                )
 
                 # Parse MemTotal line
                 # Format: "Node X MemTotal:       32948232 kB"
@@ -125,7 +127,7 @@ class NumaCpus(NUMADataCollector):
             Example: {"node 0": "0-15,32-47", "node 1": "16-31,48-63"}
         """
         cmd = SafeCmdString("lscpu")
-        output = self._run_cached_command(cmd, timeout=30)
+        output = self.get_output_from_run_cmd(cmd, timeout=30, hosts_cached_pool=HwFwDataCollector.cached_data_pool)
 
         result = {}
 
@@ -185,7 +187,7 @@ class NumaNICs(NUMADataCollector):
         # Get list of all network interfaces with physical devices (those with np in name)
         cmd = SafeCmdString("ls /sys/class/net/ | grep np")
         try:
-            output = self._run_cached_command(cmd, timeout=30)
+            output = self.get_output_from_run_cmd(cmd, timeout=30, hosts_cached_pool=HwFwDataCollector.cached_data_pool)
             all_port_names = [line.strip() for line in output.splitlines() if line.strip()]
         except Exception:
             # If command fails, return empty result
@@ -198,7 +200,9 @@ class NumaNICs(NUMADataCollector):
             try:
                 # Read NUMA node number
                 cmd = SafeCmdString("cat {numa_node_path}").format(numa_node_path=numa_node_path)
-                output = self._run_cached_command(cmd, timeout=30)
+                output = self.get_output_from_run_cmd(
+                    cmd, timeout=30, hosts_cached_pool=HwFwDataCollector.cached_data_pool
+                )
 
                 # Parse NUMA node number (use abs() to handle -1 for non-NUMA systems)
                 numa_node_num = abs(int(output.strip()))

--- a/src/in_cluster_checks/rules/hw_fw_details/collectors/os_collectors.py
+++ b/src/in_cluster_checks/rules/hw_fw_details/collectors/os_collectors.py
@@ -51,7 +51,9 @@ class OperatingSystemVersion(OSInfo):
             Example: {"1": "Red Hat Enterprise Linux 9.2"}
         """
         cmd = SafeCmdString("cat /etc/redhat-release")
-        os_version = self._run_cached_command(cmd, timeout=30).strip()
+        os_version = self.get_output_from_run_cmd(
+            cmd, timeout=30, hosts_cached_pool=HwFwDataCollector.cached_data_pool
+        ).strip()
 
         return {os_id: os_version for os_id in self.get_component_ids()}
 
@@ -79,6 +81,8 @@ class KernelVersion(OSInfo):
             Example: {"1": "5.14.0-284.11.1.el9_2.x86_64"}
         """
         cmd = SafeCmdString("uname -r")
-        kernel_version = self._run_cached_command(cmd, timeout=30).strip()
+        kernel_version = self.get_output_from_run_cmd(
+            cmd, timeout=30, hosts_cached_pool=HwFwDataCollector.cached_data_pool
+        ).strip()
 
         return {kernel_id: kernel_version for kernel_id in self.get_component_ids()}

--- a/src/in_cluster_checks/rules/hw_fw_details/hw_fw_base.py
+++ b/src/in_cluster_checks/rules/hw_fw_details/hw_fw_base.py
@@ -15,7 +15,6 @@ from in_cluster_checks.core.operations import DataCollector
 from in_cluster_checks.core.rule import OrchestratorRule
 from in_cluster_checks.core.rule_result import RuleResult
 from in_cluster_checks.utils.enums import Objectives
-from in_cluster_checks.utils.safe_cmd_string import SafeCmdString
 
 
 class HwFwDataCollector(DataCollector):
@@ -27,13 +26,11 @@ class HwFwDataCollector(DataCollector):
 
     Key features:
     - Component-based data organization
-    - Command output caching to avoid duplicate executions
+    - Command output caching via Operator-level hosts_cached_pool
     - Standardized output format: {component_id: {property: value}}
     """
 
-    # Class-level cache shared across all collector instances
-    # Structure: {(node_name, command): output}
-    cached_command_outputs = {}
+    cached_data_pool = {}
     raise_collection_errors = False
 
     def __init__(self, host_executor=None):
@@ -115,72 +112,10 @@ class HwFwDataCollector(DataCollector):
         """
         raise NotImplementedError(f"collect_data() must be implemented in {self.__class__.__name__}")
 
-    def _run_cached_command(self, cmd: SafeCmdString, timeout: int = 30, ignore_errors: bool = False) -> str:
-        """
-        Run command with caching to avoid duplicate executions.
-
-        If the same command was already run on this node, return cached output.
-        Thread-safe for parallel execution.
-
-        Args:
-            cmd: Command to execute
-            timeout: Command timeout in seconds
-            ignore_errors: If True, return stdout even if command fails (non-zero exit)
-
-        Returns:
-            Command stdout
-
-        Raises:
-            Exception: If command fails and ignore_errors is False
-        """
-        node_name = self.get_host_name()
-        cache_key = (node_name, str(cmd))
-
-        # Check cache first (thread-safe)
-        with self.threadLock:
-            if cache_key in self.cached_command_outputs:
-                self.add_to_rule_log(f"Using cached output for command: {cmd}")
-                return self.cached_command_outputs[cache_key]
-
-        # Command not cached - execute it
-        if ignore_errors:
-            # Use run_cmd to get raw output even on error
-            _, output, _ = self.run_cmd(cmd, timeout)
-        else:
-            # Use get_output_from_run_cmd which raises on error
-            output = self.get_output_from_run_cmd(cmd, timeout)
-
-        # Store in cache (thread-safe)
-        with self.threadLock:
-            self.cached_command_outputs[cache_key] = output
-
-        return output
-
     @classmethod
     def clear_cache(cls):
-        """
-        Clear the command output cache.
-
-        Should be called between domain executions to free memory.
-        Thread-safe.
-        """
-        with cls.threadLock:
-            cls.cached_command_outputs.clear()
-
-    def get_cache_stats(self) -> Dict[str, int]:
-        """
-        Get cache statistics for monitoring.
-
-        Returns:
-            Dictionary with cache metrics:
-            - total_entries: Total number of cached commands
-            - node_count: Number of unique nodes in cache
-        """
-        with self.threadLock:
-            total_entries = len(self.cached_command_outputs)
-            unique_nodes = len(set(node for node, _ in self.cached_command_outputs.keys()))
-
-        return {"total_entries": total_entries, "node_count": unique_nodes}
+        """Clear the cached data pool. Called by the domain after verify() completes."""
+        cls.cached_data_pool.clear()
 
 
 class HwFwRule(OrchestratorRule):

--- a/tests/core/test_operations.py
+++ b/tests/core/test_operations.py
@@ -253,3 +253,102 @@ class TestOperator:
 
         with pytest.raises(IndexError, match="Field 5 not found"):
             Operator._get_the_nth_field("one two three", 5)
+
+
+class TestOperatorCachedPool:
+    """Test hosts_cached_pool caching in Operator."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        """Set up test fixtures."""
+        global_config.debug_rule_flag = False
+        self.mock_executor = Mock()
+        self.mock_executor.ip = "192.168.1.10"
+        self.mock_executor.host_name = "test-node"
+        self.mock_executor.roles = []
+        self.mock_executor.execute_cmd.return_value = (0, "output", "")
+        self.operator = DummyOperator(self.mock_executor)
+
+    def test_run_cmd_without_pool_executes_normally(self):
+        """run_cmd without hosts_cached_pool executes every time."""
+        self.operator.run_cmd(SafeCmdString("echo hello"))
+        self.operator.run_cmd(SafeCmdString("echo hello"))
+
+        assert self.mock_executor.execute_cmd.call_count == 2
+
+    def test_run_cmd_with_pool_caches_result(self):
+        """run_cmd with hosts_cached_pool caches and reuses result."""
+        pool = {}
+        self.operator.run_cmd(SafeCmdString("echo hello"), hosts_cached_pool=pool)
+        self.operator.run_cmd(SafeCmdString("echo hello"), hosts_cached_pool=pool)
+
+        assert self.mock_executor.execute_cmd.call_count == 1
+
+    def test_cached_pool_returns_same_result(self):
+        """Cached result matches the original execution result."""
+        pool = {}
+        ret1 = self.operator.run_cmd(SafeCmdString("echo hello"), hosts_cached_pool=pool)
+        ret2 = self.operator.run_cmd(SafeCmdString("echo hello"), hosts_cached_pool=pool)
+
+        assert ret1 == ret2
+        assert ret1 == (0, "output", "")
+
+    def test_different_commands_not_cached_together(self):
+        """Different commands are cached separately."""
+        self.mock_executor.execute_cmd.side_effect = [
+            (0, "output_a", ""),
+            (0, "output_b", ""),
+        ]
+
+        pool = {}
+        ret_a = self.operator.run_cmd(SafeCmdString("cmd_a"), hosts_cached_pool=pool)
+        ret_b = self.operator.run_cmd(SafeCmdString("cmd_b"), hosts_cached_pool=pool)
+
+        assert self.mock_executor.execute_cmd.call_count == 2
+        assert ret_a[1] == "output_a"
+        assert ret_b[1] == "output_b"
+
+    def test_different_hosts_not_cached_together(self):
+        """Same command on different hosts is cached separately."""
+        mock_executor_2 = Mock()
+        mock_executor_2.ip = "192.168.1.11"
+        mock_executor_2.host_name = "test-node-2"
+        mock_executor_2.roles = []
+        mock_executor_2.execute_cmd.return_value = (0, "output_node2", "")
+
+        operator_2 = DummyOperator(mock_executor_2)
+
+        pool = {}
+        ret1 = self.operator.run_cmd(SafeCmdString("echo hello"), hosts_cached_pool=pool)
+        ret2 = operator_2.run_cmd(SafeCmdString("echo hello"), hosts_cached_pool=pool)
+
+        assert self.mock_executor.execute_cmd.call_count == 1
+        assert mock_executor_2.execute_cmd.call_count == 1
+        assert ret1[1] == "output"
+        assert ret2[1] == "output_node2"
+
+    def test_pool_clear_allows_re_execution(self):
+        """Clearing the pool dict allows commands to be re-executed."""
+        pool = {}
+        self.operator.run_cmd(SafeCmdString("echo hello"), hosts_cached_pool=pool)
+        pool.clear()
+        self.operator.run_cmd(SafeCmdString("echo hello"), hosts_cached_pool=pool)
+
+        assert self.mock_executor.execute_cmd.call_count == 2
+
+    def test_get_output_from_run_cmd_with_pool(self):
+        """get_output_from_run_cmd propagates hosts_cached_pool."""
+        pool = {}
+        out1 = self.operator.get_output_from_run_cmd(SafeCmdString("echo hello"), hosts_cached_pool=pool)
+        out2 = self.operator.get_output_from_run_cmd(SafeCmdString("echo hello"), hosts_cached_pool=pool)
+
+        assert self.mock_executor.execute_cmd.call_count == 1
+        assert out1 == out2 == "output"
+
+    def test_get_output_from_run_cmd_pool_raises_on_failure(self):
+        """get_output_from_run_cmd with pool still raises on non-zero exit."""
+        self.mock_executor.execute_cmd.return_value = (1, "", "error")
+
+        pool = {}
+        with pytest.raises(UnExpectedSystemOutput):
+            self.operator.get_output_from_run_cmd(SafeCmdString("bad cmd"), hosts_cached_pool=pool)

--- a/tests/pytest_tools/test_operator_base.py
+++ b/tests/pytest_tools/test_operator_base.py
@@ -197,13 +197,16 @@ class OperatorTestBase:
             patches.append(patch(full_module, mock_obj))
         return patches
 
-    def _run_cmd_side_effects(self, cmd: str, timeout: int = 120, add_bash_timeout: bool = False):
+    def _run_cmd_side_effects(
+        self, cmd: str, timeout: int = 120, hosts_cached_pool: dict = None, add_bash_timeout: bool = False
+    ):
         """
         Mock side effect for run_cmd().
 
         Args:
             cmd: Command to execute
             timeout: Timeout (ignored in mock)
+            hosts_cached_pool: Ignored in mock (caching not simulated)
             add_bash_timeout: If True, wraps command with timeout before lookup
 
         Returns:
@@ -299,7 +302,9 @@ class OperatorTestBase:
 
         return res.return_code, res.out, res.err
 
-    def _get_output_from_run_cmd_side_effects(self, cmd: str, timeout: int = 30, message: str = None):
+    def _get_output_from_run_cmd_side_effects(
+        self, cmd: str, timeout: int = 30, message: str = None, hosts_cached_pool: dict = None
+    ):
         """
         Mock side effect for get_output_from_run_cmd().
 
@@ -307,6 +312,7 @@ class OperatorTestBase:
             cmd: Command to execute
             timeout: Timeout (ignored in mock)
             message: Optional error message (ignored in mock, for HC compatibility)
+            hosts_cached_pool: Ignored in mock (caching not simulated)
 
         Returns:
             Command stdout

--- a/tests/rules/hw_fw_details/collectors/test_disk_collectors.py
+++ b/tests/rules/hw_fw_details/collectors/test_disk_collectors.py
@@ -288,14 +288,14 @@ class TestOperatingSystemDiskType(DataCollectorTestBase):
         """Initialize and pre-populate cache for nested collectors."""
         super()._init_data_collector_object(collector_object, scenario_params)
 
-        # Pre-populate the class-level cache so nested collectors can use it
+        # Pre-populate the class-level cached_data_pool so nested collectors can use it
         # This is needed because OperatingSystemDiskType creates instances of
         # OperatingSystemDiskName and DiskType internally
-        node_name = "test_node"
+        node_name = collector_object.get_host_name()
         if scenario_params:
+            collector_object.cached_data_pool[node_name] = {}
             for cmd, cmd_output in scenario_params.cmd_input_output_dict.items():
-                cache_key = (node_name, cmd)
-                collector_object.cached_command_outputs[cache_key] = cmd_output.out
+                collector_object.cached_data_pool[node_name][cmd] = (cmd_output.return_code, cmd_output.out, cmd_output.err)
 
     # lsblk outputs
     lsblk_output = """sda                                                             disk
@@ -383,14 +383,14 @@ class TestOperatingSystemDiskSize(DataCollectorTestBase):
         """Initialize and pre-populate cache for nested collectors."""
         super()._init_data_collector_object(collector_object, scenario_params)
 
-        # Pre-populate the class-level cache so nested collectors can use it
+        # Pre-populate the class-level cached_data_pool so nested collectors can use it
         # This is needed because OperatingSystemDiskSize creates instances of
         # OperatingSystemDiskName and DiskSize internally
-        node_name = "test_node"
+        node_name = collector_object.get_host_name()
         if scenario_params:
+            collector_object.cached_data_pool[node_name] = {}
             for cmd, cmd_output in scenario_params.cmd_input_output_dict.items():
-                cache_key = (node_name, cmd)
-                collector_object.cached_command_outputs[cache_key] = cmd_output.out
+                collector_object.cached_data_pool[node_name][cmd] = (cmd_output.return_code, cmd_output.out, cmd_output.err)
 
     # lsblk outputs
     lsblk_output = """sda                                                             disk


### PR DESCRIPTION
## Summary

- Add `hosts_cached_pool` parameter to `Operator.run_cmd()` and `get_output_from_run_cmd()`, restoring the framework-level opt-in caching from the original HealthChecks project
- Refactor `HwFwDataCollector` to use the new Operator-level cache instead of its own `_run_cached_command()` implementation
- All hw_fw_details collectors now call `get_output_from_run_cmd()` with `hosts_cached_pool=HwFwDataCollector.cached_data_pool` directly

## Motivation

Ticket: https://redhat.atlassian.net/browse/PDRIVE-902

The command-level caching was scoped to `HwFwDataCollector` only. Other domains (e.g., network, cluster_overview) that need to collect a command once per node and evaluate the output multiple times had no access to this mechanism. This promotes the proven `hosts_cached_pool` pattern from HealthChecks to the Operator level so any domain can use it.

## Usage

Rules/collectors opt in by declaring a class-level pool and passing it:

```python
class MyDataCollector(DataCollector):
    cached_data_pool = {}

def collect_data(self):
    out = self.get_output_from_run_cmd(
        cmd, hosts_cached_pool=MyDataCollector.cached_data_pool
    )
```

Each domain clears its pool after `verify()` completes (same as `_clean_flow()` in HealthChecks).

## Test plan

- [x] Unit tests for `Operator._run_cmd_use_cached()` (cache hit/miss, different hosts, pool clear, propagation)
- [x] Existing hw_fw_details collector tests updated and passing
- [x] Full test suite: 935 passed, 0 failed
- [x] Pre-commit checks all green
- [x] Verified on big lab (3-node cluster): each command executed exactly once per node, results correct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Added host- and command-level caching for system command results, reducing repeated command execution during hardware and firmware data collection.
  * Preserved command output, error handling, and parsing behavior while reusing cached results.

* **Bug Fixes**
  * Ensured cached results remain separated by host and command.
  * Added cache clearing support so subsequent checks can refresh collected data.

* **Tests**
  * Added coverage for cache reuse, isolation, clearing, result propagation, and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->