### PR TITLE
refactor(PDRIVE-902): add clean_domain hook to RuleDomain

### DIFF
--- a/src/in_cluster_checks/core/domain.py
+++ b/src/in_cluster_checks/core/domain.py
@@ -100,10 +100,16 @@ class RuleDomain(abc.ABC):
 
         ParallelRunner.run_domain_rules_on_all_hosts(rule_groups, printer)
 
+        self.clean_domain()
+
         details = printer.get_msg()
         printer.print_summary(self.domain_name())
 
         return {"domain_name": self.domain_name(), "details": details}
+
+    def clean_domain(self):
+        """Clean up after domain execution — e.g. free cached command outputs."""
+        pass
 
     def _create_rule_groups(self, rule_classes: List[type], host_executors_dict: Dict[str, Any]) -> List[List[Rule]]:
         """

--- a/src/in_cluster_checks/domains/hw_fw_details_domain.py
+++ b/src/in_cluster_checks/domains/hw_fw_details_domain.py
@@ -5,7 +5,7 @@ Orchestrates validators that compare hardware/firmware
 configurations across nodes within the same host groups.
 """
 
-from typing import Any, Dict, List
+from typing import List
 
 from in_cluster_checks.core.domain import RuleDomain
 from in_cluster_checks.rules.hw_fw_details.firmware_rule import FirmwareDetailsRule
@@ -37,22 +37,5 @@ class HwFwDetailsValidationDomain(RuleDomain):
             FirmwareDetailsRule,
         ]
 
-    def verify(self, host_executors_dict: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        Run all hardware/firmware validators.
-
-        Extends base verify() to clear data collector cache after completion.
-
-        Args:
-            host_executors_dict: Dictionary of {node_name: NodeExecutor}
-
-        Returns:
-            Dictionary with domain results
-        """
-        # Run validators (base class handles the execution)
-        result = super().verify(host_executors_dict)
-
-        # Clear cache after domain completes
+    def clean_domain(self):
         HwFwDataCollector.clear_cache()
-
-        return result


### PR DESCRIPTION
## Summary

- Add `clean_domain()` hook to `RuleDomain.verify()`, matching the `_clean_flow()` pattern from HealthChecks
- Simplify `HwFwDetailsValidationDomain` to use the hook instead of overriding `verify()`

## Motivation

Ticket: https://redhat.atlassian.net/browse/PDRIVE-902

Follow-up to #135. In HealthChecks, `_clean_flow()` was a hook on `BaseValidationFlow` that subclasses overrode to clean up after execution (e.g. clear cached command outputs). We didn't have this hook — domains had to override `verify()` instead. This adds the equivalent hook so domains can cleanly opt into cleanup without overriding the full verify flow.

## Test plan

- [x] Full test suite: 940 passed, 0 failed
- [x] Pre-commit checks all green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation cleanup to ensure temporary hardware and firmware data is cleared after checks complete.
  * Preserved consistent result collection and reporting following validation processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->