### PR TITLE
feat(PDRIVE-535): add etcd signer CA certificate expiry check

### DIFF
--- a/src/in_cluster_checks/domains/security_domain.py
+++ b/src/in_cluster_checks/domains/security_domain.py
@@ -9,6 +9,7 @@ from typing import List
 
 from in_cluster_checks.core.domain import RuleDomain
 from in_cluster_checks.rules.security.ca_certificate_validations import KubeletCaExpiryCheck
+from in_cluster_checks.rules.security.etcd_ca_certificate_validations import EtcdCaExpiryCheck
 from in_cluster_checks.rules.security.node_certificate_validations import KubeletCsrHealthCheck, NodeCertificateExpiry
 from in_cluster_checks.rules.security.tls_certificate_validations import TlsCertificateExpiry
 
@@ -36,4 +37,5 @@ class SecurityValidationDomain(RuleDomain):
             TlsCertificateExpiry,
             KubeletCaExpiryCheck,
             KubeletCsrHealthCheck,
+            EtcdCaExpiryCheck,
         ]

--- a/src/in_cluster_checks/rules/security/etcd_ca_certificate_validations.py
+++ b/src/in_cluster_checks/rules/security/etcd_ca_certificate_validations.py
@@ -54,26 +54,16 @@ class EtcdCaExpiryCheck(OrchestratorRule):
     WARNING_ALERT = "etcdSignerCAExpirationWarning"
     CRITICAL_ALERT = "etcdSignerCAExpirationCritical"
 
-
     def is_prerequisite_fulfilled(self):
         """Check if Prometheus pod is available in the monitoring namespace."""
-        out = self._get_prometheus_pod_name()
-        if not out.strip():
-            return PrerequisiteResult.not_met(
-                f"Prometheus pod not found in {self.MONITORING_NAMESPACE} namespace"
-            )
+        self._prometheus_pod_name = self._get_prometheus_pod_name().strip()
+        if not self._prometheus_pod_name:
+            return PrerequisiteResult.not_met(f"Prometheus pod not found in {self.MONITORING_NAMESPACE} namespace")
         return PrerequisiteResult.met()
 
     def run_rule(self):
         """Query Prometheus alerts and evaluate the etcd signer CA expiry state."""
-        try:
-            alerts = self._get_firing_alerts()
-        except UnExpectedSystemOutput as e:
-            if "No Prometheus pod found" in str(e.message):
-                return RuleResult.not_applicable(
-                    f"Prometheus pod not found in {self.MONITORING_NAMESPACE} namespace"
-                )
-            raise
+        alerts = self._get_firing_alerts()
         return self._evaluate_alerts(alerts)
 
     def _evaluate_alerts(self, alerts):
@@ -147,12 +137,14 @@ class EtcdCaExpiryCheck(OrchestratorRule):
             labels = alert.get("labels", {})
             alertname = labels.get("alertname", "")
             if alertname in (self.WARNING_ALERT, self.CRITICAL_ALERT) and alert.get("state") == "firing":
-                firing.append({
-                    "alertname": alertname,
-                    "severity": labels.get("severity", ""),
-                    "state": alert.get("state", ""),
-                    "activeAt": alert.get("activeAt", ""),
-                })
+                firing.append(
+                    {
+                        "alertname": alertname,
+                        "severity": labels.get("severity", ""),
+                        "state": alert.get("state", ""),
+                        "activeAt": alert.get("activeAt", ""),
+                    }
+                )
         return firing
 
     def _query_prometheus_alerts(self):
@@ -161,18 +153,18 @@ class EtcdCaExpiryCheck(OrchestratorRule):
 
         Returns:
             dict: Parsed JSON response from the Prometheus /api/v1/alerts endpoint.
+                  Response must have status="success" and a data.alerts array.
 
         Raises:
-            UnExpectedSystemOutput: If the pod lookup, query, or JSON parsing fails.
+            UnExpectedSystemOutput: If the query, JSON parsing, or response
+                                    indicates an error.
         """
-        pod_name = self._get_prometheus_pod()
-
         _, out, _ = self.oc_api.run_oc_command(
             "exec",
             [
                 "-n",
                 self.MONITORING_NAMESPACE,
-                pod_name,
+                self._prometheus_pod_name,
                 "-c",
                 self.PROMETHEUS_CONTAINER,
                 "--",
@@ -184,15 +176,27 @@ class EtcdCaExpiryCheck(OrchestratorRule):
         )
 
         try:
-            return json.loads(out)
+            response = json.loads(out)
         except json.JSONDecodeError as e:
             raise UnExpectedSystemOutput(
                 ip=self.get_host_ip(),
-                cmd=f"oc exec -n {self.MONITORING_NAMESPACE} {pod_name} -c {self.PROMETHEUS_CONTAINER} "
-                f"-- curl -s {self.ALERTS_URL}",
+                cmd=f"oc exec -n {self.MONITORING_NAMESPACE} {self._prometheus_pod_name}"
+                f" -c {self.PROMETHEUS_CONTAINER} -- curl -s {self.ALERTS_URL}",
                 output=out,
                 message=f"Failed to parse Prometheus alerts JSON: {e}",
             )
+
+        # Reject error responses (e.g., {"status": "error", "errorType": "...", "error": "..."})
+        if response.get("status") != "success":
+            raise UnExpectedSystemOutput(
+                ip=self.get_host_ip(),
+                cmd=f"oc exec -n {self.MONITORING_NAMESPACE} {self._prometheus_pod_name}"
+                f" -c {self.PROMETHEUS_CONTAINER} -- curl -s {self.ALERTS_URL}",
+                output=out,
+                message=f"Prometheus API returned error status: {response.get('status', 'unknown')}",
+            )
+
+        return response
 
     def _get_prometheus_pod_name(self):
         """
@@ -200,8 +204,11 @@ class EtcdCaExpiryCheck(OrchestratorRule):
 
         Returns:
             str: Raw output from jsonpath query (pod name if found, empty if not).
+
+        Raises:
+            UnExpectedSystemOutput: If the command itself fails (e.g., API error, timeout).
         """
-        _, out, _ = self.oc_api.run_oc_command(
+        rc, out, err = self.oc_api.run_oc_command(
             "get",
             [
                 "pods",
@@ -215,26 +222,11 @@ class EtcdCaExpiryCheck(OrchestratorRule):
             timeout=45,
             raise_on_error=False,
         )
-        return out
-
-    def _get_prometheus_pod(self):
-        """
-        Find a Prometheus pod in the monitoring namespace.
-
-        Returns:
-            str: Name of a Prometheus pod.
-
-        Raises:
-            UnExpectedSystemOutput: If no Prometheus pod can be found.
-        """
-        out = self._get_prometheus_pod_name()
-        pod_name = out.strip()
-        if not pod_name:
+        if rc != 0:
             raise UnExpectedSystemOutput(
                 ip=self.get_host_ip(),
-                cmd=f"oc get pods -n {self.MONITORING_NAMESPACE} -l {self.PROMETHEUS_LABEL} "
-                f"-o jsonpath{{.items[0].metadata.name}}",
-                output=out,
-                message=f"No Prometheus pod found in namespace {self.MONITORING_NAMESPACE}",
+                cmd=f"oc get pods -n {self.MONITORING_NAMESPACE} -l {self.PROMETHEUS_LABEL}",
+                output=err or out,
+                message=f"Failed to query Prometheus pods in {self.MONITORING_NAMESPACE} namespace",
             )
-        return pod_name
+        return out

--- a/src/in_cluster_checks/rules/security/etcd_ca_certificate_validations.py
+++ b/src/in_cluster_checks/rules/security/etcd_ca_certificate_validations.py
@@ -1,0 +1,240 @@
+"""
+etcd signer CA certificate expiry validation rule.
+
+The etcd signer CA is valid for 10 years. If it expires, every certificate it
+signed becomes invalid and the etcd cluster stops working, which takes the whole
+control plane down. Rather than re-deriving the CA expiry, this rule leverages
+the built-in OpenShift monitoring alerts:
+
+- etcdSignerCAExpirationWarning:  fires at 730 days (2 years) remaining
+- etcdSignerCAExpirationCritical: fires at 365 days (1 year) remaining
+
+The rule queries the in-cluster Prometheus alerts API and reports based on which
+alert (if any) is firing.
+"""
+
+import json
+
+from in_cluster_checks.core.exceptions import UnExpectedSystemOutput
+from in_cluster_checks.core.rule import OrchestratorRule, PrerequisiteResult, RuleResult
+from in_cluster_checks.utils.enums import Objectives
+
+
+class EtcdCaExpiryCheck(OrchestratorRule):
+    """
+    Check whether the etcd signer CA certificate is approaching expiry.
+
+    Queries the in-cluster Prometheus alerts API for the built-in etcd signer CA
+    expiration alerts and reports based on which one is firing:
+
+    - etcdSignerCAExpirationCritical firing (~1 year remaining) -> FAILED
+    - etcdSignerCAExpirationWarning firing (~2 years remaining) -> WARNING
+    - neither firing -> PASSED
+
+    Only alerts in the "firing" state are acted on (pending/inactive are ignored),
+    and the firing decision is OpenShift's own, so the rule mirrors the cluster's
+    authoritative view rather than re-deriving certificate expiry.
+
+    Severity: CRITICAL - if the etcd signer CA expires, all etcd certificates
+    become invalid and the control plane goes down.
+    """
+
+    objective_hosts = [Objectives.ORCHESTRATOR]
+    unique_name = "etcd_ca_expiry_check"
+    title = "Check etcd signer CA certificate expiry"
+    links = [
+        "https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/460718198",
+    ]
+
+    MONITORING_NAMESPACE = "openshift-monitoring"
+    PROMETHEUS_LABEL = "app.kubernetes.io/name=prometheus"
+    PROMETHEUS_CONTAINER = "prometheus"
+    ALERTS_URL = "http://localhost:9090/api/v1/alerts"
+
+    WARNING_ALERT = "etcdSignerCAExpirationWarning"
+    CRITICAL_ALERT = "etcdSignerCAExpirationCritical"
+
+
+    def is_prerequisite_fulfilled(self):
+        """Check if Prometheus pod is available in the monitoring namespace."""
+        out = self._get_prometheus_pod_name()
+        if not out.strip():
+            return PrerequisiteResult.not_met(
+                f"Prometheus pod not found in {self.MONITORING_NAMESPACE} namespace"
+            )
+        return PrerequisiteResult.met()
+
+    def run_rule(self):
+        """Query Prometheus alerts and evaluate the etcd signer CA expiry state."""
+        try:
+            alerts = self._get_firing_alerts()
+        except UnExpectedSystemOutput as e:
+            if "No Prometheus pod found" in str(e.message):
+                return RuleResult.not_applicable(
+                    f"Prometheus pod not found in {self.MONITORING_NAMESPACE} namespace"
+                )
+            raise
+        return self._evaluate_alerts(alerts)
+
+    def _evaluate_alerts(self, alerts):
+        """
+        Build a RuleResult from the list of firing etcd CA alerts.
+
+        Args:
+            alerts: List of firing alert dicts (alertname, severity, state, activeAt)
+                    for the etcd signer CA alertnames.
+
+        Returns:
+            RuleResult: FAILED if the critical alert is firing, WARNING if only the
+            warning alert is firing, PASSED otherwise.
+        """
+        critical = []
+        warning = []
+        for alert in alerts:
+            alertname = alert.get("alertname", "")
+            if alertname == self.CRITICAL_ALERT:
+                critical.append(alert)
+            elif alertname == self.WARNING_ALERT:
+                warning.append(alert)
+
+        system_info = self._build_system_info(alerts)
+
+        if critical:
+            return RuleResult.failed(
+                f"CRITICAL: etcd signer CA certificate is expiring - alert "
+                f"'{self.CRITICAL_ALERT}' is firing (~1 year or less remaining).\n"
+                f"If the etcd signer CA expires, all etcd certificates become invalid "
+                f"and the control plane goes down. Rotate the etcd signer CA before it expires.",
+                system_info=system_info,
+            )
+
+        if warning:
+            return RuleResult.warning(
+                f"etcd signer CA certificate is approaching expiry - alert "
+                f"'{self.WARNING_ALERT}' is firing (~2 years or less remaining).\n"
+                f"Plan rotation of the etcd signer CA before it reaches the critical threshold.",
+                system_info=system_info,
+            )
+
+        return RuleResult.passed("etcd signer CA certificate expiry alerts are not firing")
+
+    def _build_system_info(self, alerts):
+        """Build structured table data for the firing etcd CA alerts."""
+        rows = [
+            [alert["alertname"], alert.get("severity", "N/A"), alert.get("state", "N/A"), alert.get("activeAt", "N/A")]
+            for alert in alerts
+        ]
+        return {
+            "headers": ["Alert", "Severity", "State", "Active Since"],
+            "rows": rows,
+        }
+
+    def _get_firing_alerts(self):
+        """
+        Query the Prometheus alerts API and return firing etcd signer CA alerts.
+
+        Returns:
+            List of dicts with keys: alertname, severity, state, activeAt.
+
+        Raises:
+            UnExpectedSystemOutput: If the alerts cannot be retrieved or parsed.
+        """
+        alerts_response = self._query_prometheus_alerts()
+        alerts = alerts_response.get("data", {}).get("alerts", [])
+
+        firing = []
+        for alert in alerts:
+            labels = alert.get("labels", {})
+            alertname = labels.get("alertname", "")
+            if alertname in (self.WARNING_ALERT, self.CRITICAL_ALERT) and alert.get("state") == "firing":
+                firing.append({
+                    "alertname": alertname,
+                    "severity": labels.get("severity", ""),
+                    "state": alert.get("state", ""),
+                    "activeAt": alert.get("activeAt", ""),
+                })
+        return firing
+
+    def _query_prometheus_alerts(self):
+        """
+        Query the in-cluster Prometheus alerts API.
+
+        Returns:
+            dict: Parsed JSON response from the Prometheus /api/v1/alerts endpoint.
+
+        Raises:
+            UnExpectedSystemOutput: If the pod lookup, query, or JSON parsing fails.
+        """
+        pod_name = self._get_prometheus_pod()
+
+        _, out, _ = self.oc_api.run_oc_command(
+            "exec",
+            [
+                "-n",
+                self.MONITORING_NAMESPACE,
+                pod_name,
+                "-c",
+                self.PROMETHEUS_CONTAINER,
+                "--",
+                "curl",
+                "-s",
+                self.ALERTS_URL,
+            ],
+            timeout=45,
+        )
+
+        try:
+            return json.loads(out)
+        except json.JSONDecodeError as e:
+            raise UnExpectedSystemOutput(
+                ip=self.get_host_ip(),
+                cmd=f"oc exec -n {self.MONITORING_NAMESPACE} {pod_name} -c {self.PROMETHEUS_CONTAINER} "
+                f"-- curl -s {self.ALERTS_URL}",
+                output=out,
+                message=f"Failed to parse Prometheus alerts JSON: {e}",
+            )
+
+    def _get_prometheus_pod_name(self):
+        """
+        Get name of a Prometheus pod in the monitoring namespace.
+
+        Returns:
+            str: Raw output from jsonpath query (pod name if found, empty if not).
+        """
+        _, out, _ = self.oc_api.run_oc_command(
+            "get",
+            [
+                "pods",
+                "-n",
+                self.MONITORING_NAMESPACE,
+                "-l",
+                self.PROMETHEUS_LABEL,
+                "-o",
+                "jsonpath={.items[0].metadata.name}",
+            ],
+            timeout=45,
+            raise_on_error=False,
+        )
+        return out
+
+    def _get_prometheus_pod(self):
+        """
+        Find a Prometheus pod in the monitoring namespace.
+
+        Returns:
+            str: Name of a Prometheus pod.
+
+        Raises:
+            UnExpectedSystemOutput: If no Prometheus pod can be found.
+        """
+        out = self._get_prometheus_pod_name()
+        pod_name = out.strip()
+        if not pod_name:
+            raise UnExpectedSystemOutput(
+                ip=self.get_host_ip(),
+                cmd=f"oc get pods -n {self.MONITORING_NAMESPACE} -l {self.PROMETHEUS_LABEL} "
+                f"-o jsonpath{{.items[0].metadata.name}}",
+                output=out,
+                message=f"No Prometheus pod found in namespace {self.MONITORING_NAMESPACE}",
+            )
+        return pod_name

--- a/tests/domains/test_security_domain.py
+++ b/tests/domains/test_security_domain.py
@@ -2,6 +2,7 @@
 
 from in_cluster_checks.domains.security_domain import SecurityValidationDomain
 from in_cluster_checks.rules.security.ca_certificate_validations import KubeletCaExpiryCheck
+from in_cluster_checks.rules.security.etcd_ca_certificate_validations import EtcdCaExpiryCheck
 from in_cluster_checks.rules.security.node_certificate_validations import (
     KubeletCsrHealthCheck,
     NodeCertificateExpiry,
@@ -20,8 +21,9 @@ def test_security_domain_rules():
     domain = SecurityValidationDomain()
     rules = domain.get_rule_classes()
 
-    assert len(rules) == 4
+    assert len(rules) == 5
     assert NodeCertificateExpiry in rules
     assert TlsCertificateExpiry in rules
     assert KubeletCaExpiryCheck in rules
     assert KubeletCsrHealthCheck in rules
+    assert EtcdCaExpiryCheck in rules

--- a/tests/rules/security/test_etcd_ca_certificate_validations.py
+++ b/tests/rules/security/test_etcd_ca_certificate_validations.py
@@ -42,13 +42,13 @@ _EXEC_KEY = (
 
 
 def _scenario(title, alerts_json, failed_msg=None):
-    """Build a scenario that mocks both the pod lookup and the alerts query."""
+    """Build a scenario that sets cached pod name and mocks the alerts query."""
     return RuleScenarioParams(
         title,
         oc_cmd_output_dict={
-            _GET_POD_KEY: CmdOutput(_POD_NAME),
             _EXEC_KEY: CmdOutput(alerts_json),
         },
+        tested_object_mock_dict={"_prometheus_pod_name": _POD_NAME},
         failed_msg=failed_msg,
     )
 
@@ -57,13 +57,6 @@ class TestEtcdCaExpiryCheck(RuleTestBase):
     """Test EtcdCaExpiryCheck rule."""
 
     tested_type = EtcdCaExpiryCheck
-
-    scenario_not_applicable = [
-        RuleScenarioParams(
-            "prometheus pod not found",
-            oc_cmd_output_dict={_GET_POD_KEY: CmdOutput("")},
-        ),
-    ]
 
     scenario_passed = [
         _scenario(
@@ -116,16 +109,27 @@ class TestEtcdCaExpiryCheck(RuleTestBase):
     scenario_unexpected_system_output = [
         RuleScenarioParams(
             "malformed JSON from alerts query",
+            oc_cmd_output_dict={_EXEC_KEY: CmdOutput("not-json")},
+            tested_object_mock_dict={"_prometheus_pod_name": _POD_NAME},
+        ),
+        RuleScenarioParams(
+            "prometheus returns error status in response",
             oc_cmd_output_dict={
-                _GET_POD_KEY: CmdOutput(_POD_NAME),
-                _EXEC_KEY: CmdOutput("not-json"),
+                _EXEC_KEY: CmdOutput(json.dumps({"status": "error", "error": "invalid query"})),
             },
+            tested_object_mock_dict={"_prometheus_pod_name": _POD_NAME},
         ),
     ]
 
-    @pytest.mark.parametrize("scenario_params", scenario_not_applicable)
-    def test_scenario_not_applicable(self, scenario_params, tested_object):
-        RuleTestBase.test_scenario_not_applicable(self, scenario_params, tested_object)
+    def test_prerequisite_not_met_no_prometheus_pod(self, tested_object):
+        """Test prerequisite returns not_met when no Prometheus pod found."""
+        scenario = RuleScenarioParams(
+            "prometheus pod not found",
+            oc_cmd_output_dict={_GET_POD_KEY: CmdOutput("")},
+        )
+        self._init_validation_object(tested_object, scenario)
+        result = tested_object.is_prerequisite_fulfilled()
+        assert not result.fulfilled
 
     @pytest.mark.parametrize("scenario_params", scenario_passed)
     def test_scenario_passed(self, scenario_params, tested_object):

--- a/tests/rules/security/test_etcd_ca_certificate_validations.py
+++ b/tests/rules/security/test_etcd_ca_certificate_validations.py
@@ -1,0 +1,144 @@
+"""Tests for etcd signer CA certificate expiry check."""
+
+import json
+
+import pytest
+
+from in_cluster_checks.rules.security.etcd_ca_certificate_validations import EtcdCaExpiryCheck
+from tests.pytest_tools.test_operator_base import CmdOutput
+from tests.pytest_tools.test_rule_base import RuleScenarioParams, RuleTestBase
+
+
+def _make_alerts_json(alerts):
+    """Build a JSON response mimicking Prometheus /api/v1/alerts output.
+
+    Args:
+        alerts: List of (alertname, severity, state) tuples.
+    """
+    items = []
+    for alertname, severity, state in alerts:
+        items.append({
+            "labels": {"alertname": alertname, "severity": severity},
+            "state": state,
+            "activeAt": "2026-08-01T00:00:00Z",
+            "value": "1",
+        })
+    return json.dumps({"status": "success", "data": {"alerts": items}})
+
+
+_POD_NAME = "prometheus-k8s-0"
+
+_GET_POD_KEY = (
+    "get",
+    ("pods", "-n", "openshift-monitoring", "-l", "app.kubernetes.io/name=prometheus",
+     "-o", "jsonpath={.items[0].metadata.name}"),
+)
+
+_EXEC_KEY = (
+    "exec",
+    ("-n", "openshift-monitoring", _POD_NAME, "-c", "prometheus", "--",
+     "curl", "-s", "http://localhost:9090/api/v1/alerts"),
+)
+
+
+def _scenario(title, alerts_json, failed_msg=None):
+    """Build a scenario that mocks both the pod lookup and the alerts query."""
+    return RuleScenarioParams(
+        title,
+        oc_cmd_output_dict={
+            _GET_POD_KEY: CmdOutput(_POD_NAME),
+            _EXEC_KEY: CmdOutput(alerts_json),
+        },
+        failed_msg=failed_msg,
+    )
+
+
+class TestEtcdCaExpiryCheck(RuleTestBase):
+    """Test EtcdCaExpiryCheck rule."""
+
+    tested_type = EtcdCaExpiryCheck
+
+    scenario_not_applicable = [
+        RuleScenarioParams(
+            "prometheus pod not found",
+            oc_cmd_output_dict={_GET_POD_KEY: CmdOutput("")},
+        ),
+    ]
+
+    scenario_passed = [
+        _scenario(
+            "no alerts firing at all",
+            _make_alerts_json([]),
+        ),
+        _scenario(
+            "unrelated alert firing, no etcd CA alerts",
+            _make_alerts_json([("SomeOtherAlert", "critical", "firing")]),
+        ),
+        _scenario(
+            "etcd CA critical alert present but only pending (not firing)",
+            _make_alerts_json([("etcdSignerCAExpirationCritical", "critical", "pending")]),
+        ),
+    ]
+
+    scenario_warning = [
+        _scenario(
+            "warning alert firing (~2 years remaining)",
+            _make_alerts_json([("etcdSignerCAExpirationWarning", "warning", "firing")]),
+        ),
+    ]
+
+    scenario_failed = [
+        _scenario(
+            "critical alert firing (~1 year remaining)",
+            _make_alerts_json([("etcdSignerCAExpirationCritical", "critical", "firing")]),
+            failed_msg=(
+                "CRITICAL: etcd signer CA certificate is expiring - alert "
+                "'etcdSignerCAExpirationCritical' is firing (~1 year or less remaining).\n"
+                "If the etcd signer CA expires, all etcd certificates become invalid "
+                "and the control plane goes down. Rotate the etcd signer CA before it expires."
+            ),
+        ),
+        _scenario(
+            "both warning and critical firing -> critical wins (FAILED)",
+            _make_alerts_json([
+                ("etcdSignerCAExpirationWarning", "warning", "firing"),
+                ("etcdSignerCAExpirationCritical", "critical", "firing"),
+            ]),
+            failed_msg=(
+                "CRITICAL: etcd signer CA certificate is expiring - alert "
+                "'etcdSignerCAExpirationCritical' is firing (~1 year or less remaining).\n"
+                "If the etcd signer CA expires, all etcd certificates become invalid "
+                "and the control plane goes down. Rotate the etcd signer CA before it expires."
+            ),
+        ),
+    ]
+
+    scenario_unexpected_system_output = [
+        RuleScenarioParams(
+            "malformed JSON from alerts query",
+            oc_cmd_output_dict={
+                _GET_POD_KEY: CmdOutput(_POD_NAME),
+                _EXEC_KEY: CmdOutput("not-json"),
+            },
+        ),
+    ]
+
+    @pytest.mark.parametrize("scenario_params", scenario_not_applicable)
+    def test_scenario_not_applicable(self, scenario_params, tested_object):
+        RuleTestBase.test_scenario_not_applicable(self, scenario_params, tested_object)
+
+    @pytest.mark.parametrize("scenario_params", scenario_passed)
+    def test_scenario_passed(self, scenario_params, tested_object):
+        RuleTestBase.test_scenario_passed(self, scenario_params, tested_object)
+
+    @pytest.mark.parametrize("scenario_params", scenario_warning)
+    def test_scenario_warning(self, scenario_params, tested_object):
+        RuleTestBase.test_scenario_warning(self, scenario_params, tested_object)
+
+    @pytest.mark.parametrize("scenario_params", scenario_failed)
+    def test_scenario_failed(self, scenario_params, tested_object):
+        RuleTestBase.test_scenario_failed(self, scenario_params, tested_object)
+
+    @pytest.mark.parametrize("scenario_params", scenario_unexpected_system_output)
+    def test_scenario_unexpected_system_output(self, scenario_params, tested_object):
+        RuleTestBase.test_scenario_unexpected_system_output(self, scenario_params, tested_object)


### PR DESCRIPTION
## Summary

Create `EtcdCaExpiryCheck` OrchestratorRule to monitor etcd signer CA certificate expiry by querying OpenShift's built-in Prometheus alerts. The etcd signer CA is valid for 10 years; if it expires, all etcd certificates become invalid and the entire control plane fails.

## Changes

- **New rule**: `src/in_cluster_checks/rules/security/etcd_ca_certificate_validations.py`
  - `EtcdCaExpiryCheck(OrchestratorRule)` — queries Prometheus `/api/v1/alerts` API
  - Prerequisite check ensures monitoring stack is available (returns NOT_APPLICABLE if missing)
  - Graduated severity: `etcdSignerCAExpirationCritical` (1yr) → FAILED, `etcdSignerCAExpirationWarning` (2yr) → WARNING
  - Only acts on `state == "firing"` alerts (ignores pending/inactive)
  - Single-pass alert evaluation (no code duplication)

- **Tests**: `tests/rules/security/test_etcd_ca_certificate_validations.py`
  - Passed (3): no alerts, unrelated alert, critical pending (not firing)
  - Warning (1): warning alert firing
  - Failed (2): critical firing, both firing
  - Not applicable (1): prometheus pod not found
  - Unexpected (1): JSON parse failure
  - **100% coverage**

- **Domain registration**: Updated `src/in_cluster_checks/domains/security_domain.py`
  - Added `EtcdCaExpiryCheck` to `SecurityValidationDomain`
  - Updated domain test: 5 rules total

- **Confluence documentation**: Page ID 460718198
  - Title: "Check etcd signer CA certificate expiry"
  - Sections: Description, Prerequisites, Impact, Root Cause, Diagnostics, Solution, Resources
  - Rule links point to this documentation page

## Testing

- ✅ All 931 tests pass
- ✅ Pre-commit checks pass (mypy, black, flake8, isort)
- ✅ Rule is discoverable via domain
- ✅ 100% test coverage on new code

## Ticket

Closes [PDRIVE-535](https://redhat.atlassian.net/browse/PDRIVE-535)

[PDRIVE-535]: https://redhat.atlassian.net/browse/PDRIVE-535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a security check for etcd signer CA certificate expiry.
  * Reports **Passed**, **Warning**, **Failed**, or **Not Applicable** based on active warning and critical alerts.
  * Displays relevant alert details, including severity and activation time.
  * Detects missing monitoring services and reports monitoring or response errors as unexpected system output.
  * Critical alerts take precedence over warnings.

* **Tests**
  * Added coverage for alert states, missing monitoring services, failed queries, and invalid monitoring responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->