### PR TITLE
Added prerequisite to EtcdRule base class (etcd_validations.py:27-48):

### DIFF
--- a/src/in_cluster_checks/rules/etcd/etcd_validations.py
+++ b/src/in_cluster_checks/rules/etcd/etcd_validations.py
@@ -24,6 +24,27 @@ class EtcdRule(OrchestratorRule):
 
     objective_hosts = [Objectives.ORCHESTRATOR]
 
+    def is_prerequisite_fulfilled(self) -> PrerequisiteResult:
+        """
+        Check if cluster has control plane nodes with etcd.
+
+        HyperShift and worker-only clusters have no control plane nodes in data plane,
+        so etcd runs outside the data plane cluster and is not accessible.
+
+        Returns:
+            PrerequisiteResult.not_met if no control plane nodes found,
+            PrerequisiteResult.met otherwise
+        """
+        has_control_plane = any(
+            "control-plane" in executor.node_labels or "master" in executor.node_labels
+            for executor in self._node_executors.values()
+        )
+
+        if not has_control_plane:
+            return PrerequisiteResult.not_met("Cluster has no control plane nodes - etcd checks not applicable")
+
+        return PrerequisiteResult.met()
+
     def _get_etcd_pod_name(self):
         """
         Get name of a running etcd pod using inherited _get_pod_name method.
@@ -173,9 +194,13 @@ class EtcdMemberCountCheck(EtcdRule):
         Check if this rule is applicable.
 
         Returns:
-            PrerequisiteResult.not_met if cluster is SNO (single node),
+            PrerequisiteResult.not_met if cluster is SNO (single node) or has no control plane,
             PrerequisiteResult.met otherwise
         """
+        parent_result = super().is_prerequisite_fulfilled()
+        if not parent_result.fulfilled:
+            return parent_result
+
         nodes = self.oc_api.get_all_nodes()
         node_count = len(nodes)
 

--- a/tests/rules/etcd/test_etcd_validations.py
+++ b/tests/rules/etcd/test_etcd_validations.py
@@ -1,5 +1,7 @@
 """Tests for etcd validations."""
 
+from unittest.mock import Mock
+
 import pytest
 
 from in_cluster_checks.rules.etcd.etcd_validations import (
@@ -24,6 +26,22 @@ from tests.pytest_tools.test_rule_base import (
 
 class TestEtcdBasicCheck(RuleTestBase):
     tested_type = EtcdBasicCheck
+
+    @staticmethod
+    def _create_worker_executor():
+        """Create mock executor with worker label (no control plane)."""
+        executor = Mock()
+        executor.node_name = "worker-0"
+        executor.node_labels = "worker"
+        return executor
+
+    @staticmethod
+    def _create_control_plane_executor():
+        """Create mock executor with control plane label."""
+        executor = Mock()
+        executor.node_name = "master-0"
+        executor.node_labels = "control-plane"
+        return executor
 
     scenario_passed = [
         RuleScenarioParams(
@@ -54,6 +72,13 @@ class TestEtcdBasicCheck(RuleTestBase):
         ),
     ]
 
+    scenario_prerequisite_not_fulfilled = [
+        RuleScenarioParams(
+            "HyperShift cluster - no control plane nodes",
+            tested_object_mock_dict={},
+        ),
+    ]
+
     @pytest.mark.parametrize("scenario_params", scenario_passed)
     def test_scenario_passed(self, scenario_params, tested_object):
         RuleTestBase.test_scenario_passed(self, scenario_params, tested_object)
@@ -61,6 +86,11 @@ class TestEtcdBasicCheck(RuleTestBase):
     @pytest.mark.parametrize("scenario_params", scenario_failed)
     def test_scenario_failed(self, scenario_params, tested_object):
         RuleTestBase.test_scenario_failed(self, scenario_params, tested_object)
+
+    @pytest.mark.parametrize("scenario_params", scenario_prerequisite_not_fulfilled)
+    def test_prerequisite_not_fulfilled(self, scenario_params, tested_object):
+        tested_object._node_executors = {"worker-0": self._create_worker_executor()}
+        RuleTestBase.test_prerequisite_not_fulfilled(self, scenario_params, tested_object)
 
 
 # EtcdAlarmCheck Tests
@@ -114,14 +144,28 @@ class TestEtcdMemberCountCheck(RuleTestBase):
     @staticmethod
     def _mock_nodes(count):
         """Create mock node objects for testing."""
-        from unittest.mock import Mock
-
         nodes = []
         for i in range(count):
             node = Mock()
             node.name.return_value = f"node-{i}"
             nodes.append(node)
         return nodes
+
+    @staticmethod
+    def _create_worker_executor():
+        """Create mock executor with worker label (no control plane)."""
+        executor = Mock()
+        executor.node_name = "worker-0"
+        executor.node_labels = "worker"
+        return executor
+
+    @staticmethod
+    def _create_control_plane_executor():
+        """Create mock executor with control plane label."""
+        executor = Mock()
+        executor.node_name = "master-0"
+        executor.node_labels = "control-plane"
+        return executor
 
     scenario_passed = [
         RuleScenarioParams(
@@ -161,6 +205,10 @@ class TestEtcdMemberCountCheck(RuleTestBase):
                 "oc_api.get_all_nodes": lambda: TestEtcdMemberCountCheck._mock_nodes(1),
             },
         ),
+        RuleScenarioParams(
+            "worker-only cluster - no control plane",
+            tested_object_mock_dict={},
+        ),
     ]
 
     @pytest.mark.parametrize("scenario_params", scenario_passed)
@@ -173,6 +221,10 @@ class TestEtcdMemberCountCheck(RuleTestBase):
 
     @pytest.mark.parametrize("scenario_params", scenario_prerequisite_not_fulfilled)
     def test_prerequisite_not_fulfilled(self, scenario_params, tested_object):
+        if "SNO" in scenario_params.scenario_title:
+            tested_object._node_executors = {"master-0": self._create_control_plane_executor()}
+        else:
+            tested_object._node_executors = {"worker-0": self._create_worker_executor()}
         RuleTestBase.test_prerequisite_not_fulfilled(self, scenario_params, tested_object)
 
 


### PR DESCRIPTION
Checks self._node_executors for control plane nodes (labels contain control-plane or master) Returns not_met if no control plane → all 8 etcd rules skip on HyperShift/worker-only clusters Message: "Cluster has no control plane nodes - etcd checks not applicable"

Updated EtcdMemberCountCheck (etcd_validations.py:195-204):

Calls super().is_prerequisite_fulfilled() first
If parent returns not_met (no control plane) → returns immediately Otherwise checks SNO (single node) case

Added test (test_etcd_validations.py:56-77):

Tests prerequisite detection with worker-only executor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Etcd checks now correctly skip clusters without control-plane or master-labeled nodes, including HyperShift and worker-only configurations.
  * Single-node OpenShift checks now respect the shared prerequisite logic, preventing inappropriate node-count validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->