### PR TITLE
fix(PDRIVE-975): treat insights operator as non-critical in cluster o…

### DIFF
--- a/src/in_cluster_checks/rules/k8s/k8s_validations.py
+++ b/src/in_cluster_checks/rules/k8s/k8s_validations.py
@@ -957,80 +957,53 @@ class VerifyClusterOperatorsAvailable(OrchestratorRule):
     links = [
         "https://redhat.atlassian.net/wiki/spaces/PDRIVE/pages/418418357",
     ]
+    NON_CRITICAL_OPERATORS = {"insights"}
 
     def run_rule(self):
         """Check cluster operator conditions: Available, Degraded, Progressing, Upgradeable."""
-        try:
-            _, operators_output, _ = self.oc_api.run_oc_command("get", ["clusteroperators", "-o", "json"], timeout=45)
-        except UnExpectedSystemOutput:
-            return RuleResult.failed("Failed to get cluster operators")
+        operators = self.oc_api.select_resources("clusteroperator", timeout=45)
 
-        try:
-            operators_data = json.loads(operators_output)
-        except json.JSONDecodeError as e:
-            raise UnExpectedSystemOutput(
-                ip=self.get_host_ip(),
-                cmd="oc get clusteroperators -o json",
-                output=operators_output,
-                message=f"Failed to parse JSON: {e}",
-            ) from e
-
-        items = operators_data.get("items", [])
-
-        if not items:
+        if not operators:
             return RuleResult.failed("No cluster operators found in cluster")
 
         unavailable_operators = []
         degraded_operators = []
         progressing_operators = []
         not_upgradeable_operators = []
+        non_critical_degraded = []
 
-        for operator in items:
-            metadata = operator.get("metadata", {})
-            name = metadata.get("name", "unknown")
-            conditions = self._get_conditions_dict(operator)
+        for operator in operators:
+            data = operator.as_dict()
+            name = data.get("metadata", {}).get("name", "unknown")
+            conditions = self._get_conditions_dict(data)
+            is_non_critical = name in self.NON_CRITICAL_OPERATORS
 
-            available_condition = conditions.get("Available")
-            degraded_condition = conditions.get("Degraded")
-            progressing_condition = conditions.get("Progressing")
-            upgradeable_condition = conditions.get("Upgradeable")
+            available = conditions.get("Available")
+            degraded = conditions.get("Degraded")
+            progressing = conditions.get("Progressing")
+            upgradeable = conditions.get("Upgradeable")
 
-            if not available_condition or available_condition.get("status") != "True":
-                reason = "NoAvailableCondition"
-                message = "No Available condition found"
-                if available_condition:
-                    reason = available_condition.get("reason", "Unknown")
-                    message = available_condition.get("message", "")
-                unavailable_operators.append(f"{name} - Reason: {reason}, Message: {message}")
+            if not available or available.get("status") != "True":
+                if not is_non_critical:
+                    unavailable_operators.append(self._format_entry(name, available))
 
-            if degraded_condition and degraded_condition.get("status") == "True":
-                reason = degraded_condition.get("reason", "Unknown")
-                message = degraded_condition.get("message", "")
-                degraded_operators.append(f"{name} - Reason: {reason}, Message: {message}")
+            if degraded and degraded.get("status") == "True":
+                target = non_critical_degraded if is_non_critical else degraded_operators
+                target.append(self._format_entry(name, degraded))
 
-            if progressing_condition and progressing_condition.get("status") == "True":
-                reason = progressing_condition.get("reason", "Unknown")
-                message = progressing_condition.get("message", "")
-                progressing_operators.append(f"{name} - Reason: {reason}, Message: {message}")
+            if not is_non_critical and progressing and progressing.get("status") == "True":
+                progressing_operators.append(self._format_entry(name, progressing))
 
-            if upgradeable_condition and upgradeable_condition.get("status") == "False":
-                reason = upgradeable_condition.get("reason", "Unknown")
-                message = upgradeable_condition.get("message", "")
-                not_upgradeable_operators.append(f"{name} - Reason: {reason}, Message: {message}")
+            if not is_non_critical and upgradeable and upgradeable.get("status") == "False":
+                not_upgradeable_operators.append(self._format_entry(name, upgradeable))
 
         error_messages = []
         warning_messages = []
 
-        if unavailable_operators:
-            error_messages.append(
-                "Following cluster operators are not available:\n  " + "\n  ".join(unavailable_operators)
+        if non_critical_degraded:
+            warning_messages.append(
+                "Following non-critical cluster operators are degraded:\n  " + "\n  ".join(non_critical_degraded)
             )
-
-        if degraded_operators:
-            error_messages.append("Following cluster operators are degraded:\n  " + "\n  ".join(degraded_operators))
-
-        if error_messages:
-            return RuleResult.failed("\n\n".join(error_messages))
 
         if progressing_operators:
             warning_messages.append(
@@ -1042,17 +1015,31 @@ class VerifyClusterOperatorsAvailable(OrchestratorRule):
                 "Following cluster operators are not upgradeable:\n  " + "\n  ".join(not_upgradeable_operators)
             )
 
+        if unavailable_operators:
+            error_messages.append(
+                "Following cluster operators are not available:\n  " + "\n  ".join(unavailable_operators)
+            )
+
+        if degraded_operators:
+            error_messages.append("Following cluster operators are degraded:\n  " + "\n  ".join(degraded_operators))
+
+        if error_messages:
+            return RuleResult.failed("\n\n".join(error_messages + warning_messages))
+
         if warning_messages:
             return RuleResult.warning("\n\n".join(warning_messages))
 
         return RuleResult.passed()
 
     @staticmethod
-    def _get_conditions_dict(operator):
-        """Build a dict of condition type to condition object for an operator."""
-        status = operator.get("status", {})
-        conditions = status.get("conditions", [])
-        return {condition.get("type"): condition for condition in conditions}
+    def _format_entry(name: str, condition: dict | None) -> str:
+        if not condition:
+            return f"{name} - Reason: NoAvailableCondition, Message: No Available condition found"
+        return f"{name} - Reason: {condition.get('reason', 'Unknown')}, Message: {condition.get('message', '')}"
+
+    @staticmethod
+    def _get_conditions_dict(data: dict) -> dict:
+        return {c.get("type"): c for c in data.get("status", {}).get("conditions", [])}
 
 
 class VerifyWebConsoleDisabled(OrchestratorRule):

--- a/tests/rules/k8s/test_k8s_validations.py
+++ b/tests/rules/k8s/test_k8s_validations.py
@@ -1841,6 +1841,16 @@ def _cluster_operators_response(*operators):
     return {"items": list(operators)}
 
 
+def _mock_operators(*operators):
+    """Build a list of mock oc.APIObject instances from operator dicts."""
+    mocks = []
+    for op in operators:
+        m = Mock()
+        m.as_dict.return_value = op
+        mocks.append(m)
+    return mocks
+
+
 class TestVerifyClusterOperatorsAvailable(RuleTestBase):
     """Test VerifyClusterOperatorsAvailable rule."""
 
@@ -1849,27 +1859,38 @@ class TestVerifyClusterOperatorsAvailable(RuleTestBase):
     scenario_passed = [
         RuleScenarioParams(
             "all cluster operators are available and not degraded",
-            oc_cmd_output_dict={
-                ("get", ("clusteroperators", "-o", "json")): CmdOutput(
-                    json.dumps(
-                        _cluster_operators_response(
-                            _make_cluster_operator("authentication"),
-                            _make_cluster_operator("console"),
-                            _make_cluster_operator("etcd"),
-                            _make_cluster_operator("kube-apiserver"),
-                        )
+            tested_object_mock_dict={
+                "oc_api.select_resources": Mock(
+                    return_value=_mock_operators(
+                        _make_cluster_operator("authentication"),
+                        _make_cluster_operator("console"),
+                        _make_cluster_operator("etcd"),
+                        _make_cluster_operator("kube-apiserver"),
                     )
                 ),
             },
         ),
         RuleScenarioParams(
             "single cluster operator is available",
-            oc_cmd_output_dict={
-                ("get", ("clusteroperators", "-o", "json")): CmdOutput(
-                    json.dumps(
-                        _cluster_operators_response(
-                            _make_cluster_operator("etcd"),
-                        )
+            tested_object_mock_dict={
+                "oc_api.select_resources": Mock(
+                    return_value=_mock_operators(_make_cluster_operator("etcd"))
+                ),
+            },
+        ),
+        RuleScenarioParams(
+            "insights operator unavailable (disabled) is skipped",
+            tested_object_mock_dict={
+                "oc_api.select_resources": Mock(
+                    return_value=_mock_operators(
+                        _make_cluster_operator("authentication"),
+                        _make_cluster_operator(
+                            "insights",
+                            available="False",
+                            available_reason="Disabled",
+                            available_message="Insights operator is disabled",
+                        ),
+                        _make_cluster_operator("etcd"),
                     )
                 ),
             },
@@ -1879,19 +1900,17 @@ class TestVerifyClusterOperatorsAvailable(RuleTestBase):
     scenario_failed = [
         RuleScenarioParams(
             "some cluster operators are not available",
-            oc_cmd_output_dict={
-                ("get", ("clusteroperators", "-o", "json")): CmdOutput(
-                    json.dumps(
-                        _cluster_operators_response(
-                            _make_cluster_operator("authentication"),
-                            _make_cluster_operator(
-                                "etcd",
-                                available="False",
-                                available_reason="EtcdMembersDown",
-                                available_message="1 member is not healthy",
-                            ),
-                            _make_cluster_operator("console"),
-                        )
+            tested_object_mock_dict={
+                "oc_api.select_resources": Mock(
+                    return_value=_mock_operators(
+                        _make_cluster_operator("authentication"),
+                        _make_cluster_operator(
+                            "etcd",
+                            available="False",
+                            available_reason="EtcdMembersDown",
+                            available_message="1 member is not healthy",
+                        ),
+                        _make_cluster_operator("console"),
                     )
                 ),
             },
@@ -1900,18 +1919,16 @@ class TestVerifyClusterOperatorsAvailable(RuleTestBase):
         ),
         RuleScenarioParams(
             "cluster operator is degraded",
-            oc_cmd_output_dict={
-                ("get", ("clusteroperators", "-o", "json")): CmdOutput(
-                    json.dumps(
-                        _cluster_operators_response(
-                            _make_cluster_operator("authentication"),
-                            _make_cluster_operator(
-                                "kube-apiserver",
-                                degraded="True",
-                                degraded_reason="NodeInstallerDegraded",
-                                degraded_message="nodes are not ready",
-                            ),
-                        )
+            tested_object_mock_dict={
+                "oc_api.select_resources": Mock(
+                    return_value=_mock_operators(
+                        _make_cluster_operator("authentication"),
+                        _make_cluster_operator(
+                            "kube-apiserver",
+                            degraded="True",
+                            degraded_reason="NodeInstallerDegraded",
+                            degraded_message="nodes are not ready",
+                        ),
                     )
                 ),
             },
@@ -1920,21 +1937,19 @@ class TestVerifyClusterOperatorsAvailable(RuleTestBase):
         ),
         RuleScenarioParams(
             "cluster operator both unavailable and degraded",
-            oc_cmd_output_dict={
-                ("get", ("clusteroperators", "-o", "json")): CmdOutput(
-                    json.dumps(
-                        _cluster_operators_response(
-                            _make_cluster_operator(
-                                "etcd",
-                                available="False",
-                                available_reason="EtcdMembersDown",
-                                available_message="members are unhealthy",
-                                degraded="True",
-                                degraded_reason="UnhealthyMembers",
-                                degraded_message="etcd cluster is degraded",
-                            ),
-                            _make_cluster_operator("authentication"),
-                        )
+            tested_object_mock_dict={
+                "oc_api.select_resources": Mock(
+                    return_value=_mock_operators(
+                        _make_cluster_operator(
+                            "etcd",
+                            available="False",
+                            available_reason="EtcdMembersDown",
+                            available_message="members are unhealthy",
+                            degraded="True",
+                            degraded_reason="UnhealthyMembers",
+                            degraded_message="etcd cluster is degraded",
+                        ),
+                        _make_cluster_operator("authentication"),
                     )
                 ),
             },
@@ -1945,20 +1960,12 @@ class TestVerifyClusterOperatorsAvailable(RuleTestBase):
         ),
         RuleScenarioParams(
             "operator has no Available condition",
-            oc_cmd_output_dict={
-                ("get", ("clusteroperators", "-o", "json")): CmdOutput(
-                    json.dumps(
+            tested_object_mock_dict={
+                "oc_api.select_resources": Mock(
+                    return_value=_mock_operators(
                         {
-                            "items": [
-                                {
-                                    "metadata": {"name": "broken-operator"},
-                                    "status": {
-                                        "conditions": [
-                                            {"type": "Progressing", "status": "False"},
-                                        ],
-                                    },
-                                }
-                            ]
+                            "metadata": {"name": "broken-operator"},
+                            "status": {"conditions": [{"type": "Progressing", "status": "False"}]},
                         }
                     )
                 ),
@@ -1967,9 +1974,34 @@ class TestVerifyClusterOperatorsAvailable(RuleTestBase):
             "  broken-operator - Reason: NoAvailableCondition, Message: No Available condition found",
         ),
         RuleScenarioParams(
+            "insights degraded alongside critical operator includes warning in failure",
+            tested_object_mock_dict={
+                "oc_api.select_resources": Mock(
+                    return_value=_mock_operators(
+                        _make_cluster_operator(
+                            "etcd",
+                            degraded="True",
+                            degraded_reason="UnhealthyMembers",
+                            degraded_message="etcd cluster is degraded",
+                        ),
+                        _make_cluster_operator(
+                            "insights",
+                            degraded="True",
+                            degraded_reason="UploadFailed",
+                            degraded_message="unable to reach console.redhat.com",
+                        ),
+                    )
+                ),
+            },
+            failed_msg="Following cluster operators are degraded:\n"
+            "  etcd - Reason: UnhealthyMembers, Message: etcd cluster is degraded\n\n"
+            "Following non-critical cluster operators are degraded:\n"
+            "  insights - Reason: UploadFailed, Message: unable to reach console.redhat.com",
+        ),
+        RuleScenarioParams(
             "no cluster operators found in cluster",
-            oc_cmd_output_dict={
-                ("get", ("clusteroperators", "-o", "json")): CmdOutput(json.dumps({"items": []})),
+            tested_object_mock_dict={
+                "oc_api.select_resources": Mock(return_value=[]),
             },
             failed_msg="No cluster operators found in cluster",
         ),
@@ -1978,18 +2010,16 @@ class TestVerifyClusterOperatorsAvailable(RuleTestBase):
     scenario_warning = [
         RuleScenarioParams(
             "cluster operator is progressing",
-            oc_cmd_output_dict={
-                ("get", ("clusteroperators", "-o", "json")): CmdOutput(
-                    json.dumps(
-                        _cluster_operators_response(
-                            _make_cluster_operator("authentication"),
-                            _make_cluster_operator(
-                                "kube-apiserver",
-                                progressing="True",
-                                progressing_reason="UpdatingKubeAPIServer",
-                                progressing_message="updating to 4.16.62",
-                            ),
-                        )
+            tested_object_mock_dict={
+                "oc_api.select_resources": Mock(
+                    return_value=_mock_operators(
+                        _make_cluster_operator("authentication"),
+                        _make_cluster_operator(
+                            "kube-apiserver",
+                            progressing="True",
+                            progressing_reason="UpdatingKubeAPIServer",
+                            progressing_message="updating to 4.16.62",
+                        ),
                     )
                 ),
             },
@@ -1998,18 +2028,16 @@ class TestVerifyClusterOperatorsAvailable(RuleTestBase):
         ),
         RuleScenarioParams(
             "cluster operator is not upgradeable",
-            oc_cmd_output_dict={
-                ("get", ("clusteroperators", "-o", "json")): CmdOutput(
-                    json.dumps(
-                        _cluster_operators_response(
-                            _make_cluster_operator("authentication"),
-                            _make_cluster_operator(
-                                "machine-config",
-                                upgradeable="False",
-                                upgradeable_reason="PoolNotUpToDate",
-                                upgradeable_message="worker pool is not up to date",
-                            ),
-                        )
+            tested_object_mock_dict={
+                "oc_api.select_resources": Mock(
+                    return_value=_mock_operators(
+                        _make_cluster_operator("authentication"),
+                        _make_cluster_operator(
+                            "machine-config",
+                            upgradeable="False",
+                            upgradeable_reason="PoolNotUpToDate",
+                            upgradeable_message="worker pool is not up to date",
+                        ),
                     )
                 ),
             },
@@ -2017,21 +2045,38 @@ class TestVerifyClusterOperatorsAvailable(RuleTestBase):
             "  machine-config - Reason: PoolNotUpToDate, Message: worker pool is not up to date",
         ),
         RuleScenarioParams(
+            "insights operator degraded produces warning not failure",
+            tested_object_mock_dict={
+                "oc_api.select_resources": Mock(
+                    return_value=_mock_operators(
+                        _make_cluster_operator("authentication"),
+                        _make_cluster_operator(
+                            "insights",
+                            degraded="True",
+                            degraded_reason="UploadFailed",
+                            degraded_message="unable to reach console.redhat.com",
+                        ),
+                        _make_cluster_operator("etcd"),
+                    )
+                ),
+            },
+            failed_msg="Following non-critical cluster operators are degraded:\n"
+            "  insights - Reason: UploadFailed, Message: unable to reach console.redhat.com",
+        ),
+        RuleScenarioParams(
             "cluster operator is both progressing and not upgradeable",
-            oc_cmd_output_dict={
-                ("get", ("clusteroperators", "-o", "json")): CmdOutput(
-                    json.dumps(
-                        _cluster_operators_response(
-                            _make_cluster_operator(
-                                "kube-apiserver",
-                                progressing="True",
-                                progressing_reason="Updating",
-                                progressing_message="rolling out",
-                                upgradeable="False",
-                                upgradeable_reason="Pending",
-                                upgradeable_message="waiting for rollout",
-                            ),
-                        )
+            tested_object_mock_dict={
+                "oc_api.select_resources": Mock(
+                    return_value=_mock_operators(
+                        _make_cluster_operator(
+                            "kube-apiserver",
+                            progressing="True",
+                            progressing_reason="Updating",
+                            progressing_message="rolling out",
+                            upgradeable="False",
+                            upgradeable_reason="Pending",
+                            upgradeable_message="waiting for rollout",
+                        ),
                     )
                 ),
             },


### PR DESCRIPTION
…perator check

The insights operator degrades in disconnected/restricted-network environments because it cannot reach console.redhat.com. This is expected behavior for telco-base SNO clusters and should not cause a rule failure.

- Skip unavailable/progressing/not-upgradeable checks for non-critical operators
- Warn (not fail) when a non-critical operator is degraded
- Include non-critical warnings in the failure message when critical operators also fail
- Simplify rule with select_resources, _format_entry helper, and cleaner loop
- Switch tests to use select_resources mock instead of raw oc command output

Assisted-by: Claude Code (Claude Sonnet 4.6) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cluster operator availability checks by excluding the non-critical Insights operator from critical failure conditions.
  * Insights operator degradation is now reported as a warning.
  * Failure messages now include relevant accumulated warnings.
  * Improved consistency and clarity of cluster operator condition reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->